### PR TITLE
fix(upstream): defer domain upstream DNS resolution 

### DIFF
--- a/docs/docs/plugin-reference/executor.md
+++ b/docs/docs/plugin-reference/executor.md
@@ -236,7 +236,9 @@ sidebar_position: 3
   - `https://` / `doh://` 表示 DoH，`h3://` 表示强制 DoH over HTTP/3。
   - `tcp+pipeline://` 与 `tls+pipeline://` 会直接启用流水线模式。
   - DoH 地址应包含实际请求路径，例如 `/dns-query`。
-- 配置建议：域名型上游建议同时配置 `bootstrap`，避免形成引导解析依赖。
+- 解析行为：启动和配置校验阶段不会解析域名型上游；未配置 `bootstrap` 或 `dial_addr` 时，会在首次建连时使用系统解析。
+- 配置建议：域名型上游建议在 `bootstrap` 和 `dial_addr` 中二选一，避免运行期形成对本机 DNS 的引导解析依赖。
+- 互斥规则：`bootstrap` 和 `dial_addr` 同时配置时，只有 `dial_addr` 生效，`bootstrap` 会被忽略。
 
 #### `upstreams[].tag`
 
@@ -250,6 +252,7 @@ sidebar_position: 3
 - 作用：指定实际连接 IP，同时保留 `addr` 中的主机名用于 SNI、Host 和证书校验。
 - 示例：`dial_addr: "1.1.1.1"`
 - 适用场景：固定拨号地址、绕过本机解析或配合自定义路由出口。
+- 互斥规则：与 `bootstrap` 同时配置时，本字段优先生效。
 
 #### `upstreams[].port`
 
@@ -268,6 +271,8 @@ sidebar_position: 3
   - 仅在 `addr` 使用域名时有意义。
   - 应写为 `IP:port`，不能再写域名。
   - 典型用于 DoT、DoQ、DoH 域名上游的首次解析。
+  - 使用 `bootstrap` 后，上游域名解析由 OxiDNS 查询该引导服务器完成，并按 TTL 缓存。
+  - 与 `dial_addr` 同时配置时，本字段会被忽略。
 
 #### `upstreams[].bootstrap_version`
 

--- a/docs/i18n/en/docusaurus-plugin-content-docs/current/plugin-reference/executor.md
+++ b/docs/i18n/en/docusaurus-plugin-content-docs/current/plugin-reference/executor.md
@@ -221,6 +221,9 @@ Sends DNS queries to upstreams.
 - Notes:
   - No scheme means UDP.
   - DoH addresses should include the full request path.
+  - Startup and config validation do not resolve domain-based upstreams. Without `bootstrap` or `dial_addr`, the hostname is resolved through the OS resolver when the first connection is created.
+  - For domain-based upstreams, choose either `bootstrap` or `dial_addr` to avoid runtime bootstrap dependency on the local DNS setup.
+  - `bootstrap` and `dial_addr` are mutually exclusive at runtime. If both are configured, only `dial_addr` is effective and `bootstrap` is ignored.
 
 #### `upstreams[].tag`
 
@@ -231,6 +234,7 @@ Sends DNS queries to upstreams.
 
 - Type: `ip`; Required: no
 - Purpose: Actual connection IP while preserving the hostname from `addr` for SNI, Host, and certificate validation.
+- Notes: Takes precedence over `bootstrap` when both are configured.
 
 #### `upstreams[].port`
 
@@ -241,6 +245,7 @@ Sends DNS queries to upstreams.
 
 - Type: `string`; Required: no
 - Purpose: Bootstrap resolver for domain-based upstreams.
+- Notes: Use an `IP:port` address. With bootstrap enabled, OxiDNS resolves the upstream hostname through that resolver and caches it according to DNS TTL. Ignored when `dial_addr` is also configured.
 
 #### `upstreams[].bootstrap_version`
 

--- a/src/network/upstream/mod.rs
+++ b/src/network/upstream/mod.rs
@@ -135,7 +135,8 @@ pub struct UpstreamConfig {
     ///
     /// Useful when you want to connect to a specific IP but use SNI for TLS.
     /// If provided, this IP is used instead of resolving the hostname from
-    /// `addr`.
+    /// `addr`. Mutually exclusive with `bootstrap` at runtime: when both are
+    /// configured, `dial_addr` takes precedence and `bootstrap` is ignored.
     pub dial_addr: Option<IpAddr>,
 
     /// Override the server port (if not specified in `addr`)
@@ -148,9 +149,13 @@ pub struct UpstreamConfig {
 
     /// Bootstrap DNS server for resolving the upstream hostname
     ///
-    /// Required when `addr` contains a hostname instead of an IP address.
-    /// The bootstrap server must be specified as IP:port (e.g., "8.8.8.8:53").
-    /// This prevents circular dependencies in DNS resolution.
+    /// Recommended when `addr` contains a hostname instead of an IP address.
+    /// Without bootstrap, hostname resolution is deferred to connection time
+    /// and uses the operating system resolver. The bootstrap server should be
+    /// specified as IP:port (e.g., "8.8.8.8:53") to avoid circular
+    /// dependencies in DNS resolution. Mutually exclusive with `dial_addr` at
+    /// runtime: when both are configured, `dial_addr` takes precedence and
+    /// bootstrap resolution is skipped.
     ///
     /// # Example
     /// ```yaml
@@ -387,8 +392,8 @@ pub struct ConnectionInfo {
     /// Original address string from configuration (for logging)
     pub raw_addr: String,
 
-    /// Resolved or configured IP address (`None` if it needs runtime resolution
-    /// via bootstrap)
+    /// Literal or explicitly configured IP address (`None` if hostname
+    /// resolution is deferred to bootstrap or connection time)
     pub remote_ip: Option<IpAddr>,
 
     /// Server port (protocol default or explicitly configured)
@@ -446,7 +451,7 @@ impl ConnectionInfo {
             connection_type, host, port, path
         );
 
-        let remote_ip = resolve_ip_from_host(&host, None, false);
+        let remote_ip = static_remote_ip_from_host(&host, None);
 
         Ok(ConnectionInfo {
             tag: None,
@@ -467,6 +472,10 @@ impl ConnectionInfo {
             bind_to_device: None,
             max_conns: None,
         })
+    }
+
+    pub fn validate_addr(addr: &str) -> Result<()> {
+        detect_connection_type(addr).map(|_| ())
     }
 }
 
@@ -511,8 +520,15 @@ impl TryFrom<UpstreamConfig> for ConnectionInfo {
             connection_type, &host, port, path
         );
 
-        let has_bootstrap = bootstrap.is_some();
-        let remote_ip = resolve_ip_from_host(&host, dial_addr, has_bootstrap);
+        let dial_addr_configured = dial_addr.is_some();
+        let remote_ip = static_remote_ip_from_host(&host, dial_addr);
+
+        if dial_addr_configured && bootstrap.is_some() {
+            warn!(
+                upstream = %addr,
+                "Both dial_addr and bootstrap are configured; dial_addr takes precedence and bootstrap will be ignored"
+            );
+        }
 
         let bootstrap = if let Some(bootstrap_server) = bootstrap
             && remote_ip.is_none()
@@ -568,21 +584,18 @@ impl TryFrom<UpstreamConfig> for ConnectionInfo {
     }
 }
 
-/// Resolve IP address from hostname
+/// Determine the startup-known remote IP address.
 ///
 /// # Arguments
 /// - `host`: The hostname or IP address string
 /// - `dial_addr`: Optional pre-configured IP address to use directly
-/// - `has_bootstrap`: Whether a bootstrap server is configured (skip resolution
-///   if true)
 ///
 /// # Returns
-/// `Some(IpAddr)` if successfully resolved or provided, `None` otherwise
-fn resolve_ip_from_host(
-    host: &str,
-    dial_addr: Option<IpAddr>,
-    has_bootstrap: bool,
-) -> Option<IpAddr> {
+/// `Some(IpAddr)` if an IP address is explicitly configured or present
+/// literally in `host`; `None` for hostnames. Hostname resolution is deferred
+/// to bootstrap or connection creation so startup and config validation do not
+/// depend on the local system resolver.
+fn static_remote_ip_from_host(host: &str, dial_addr: Option<IpAddr>) -> Option<IpAddr> {
     // 1. Use dial_addr if provided
     if let Some(ip) = dial_addr {
         return Some(ip);
@@ -593,19 +606,7 @@ fn resolve_ip_from_host(
         return Some(ip);
     }
 
-    // 3. For domain names: resolve only if no bootstrap configured
-    if !has_bootstrap {
-        match try_lookup_server_name(host) {
-            Ok(ip) => Some(ip),
-            Err(e) => {
-                warn!("Failed to resolve server name '{}': {}", host, e);
-                None
-            }
-        }
-    } else {
-        // Bootstrap will handle resolution later
-        None
-    }
+    None
 }
 
 /// Detect the connection type from the config address
@@ -1387,6 +1388,48 @@ mod tests {
         let info = ConnectionInfo::try_from(cfg).expect("helper scheme should be accepted");
         assert_eq!(info.connection_type, ConnectionType::DoH);
         assert!(info.enable_http3);
+    }
+
+    #[test]
+    fn test_connection_info_defers_domain_resolution() {
+        let info = ConnectionInfo::with_addr("tls://dns.example.invalid:853")
+            .expect("domain upstream should parse without DNS resolution");
+        assert_eq!(info.server_name, "dns.example.invalid");
+        assert!(info.remote_ip.is_none());
+
+        let info = ConnectionInfo::try_from(make_upstream_config(
+            "https://resolver.example.invalid/dns-query",
+        ))
+        .expect("domain upstream config should parse without DNS resolution");
+        assert_eq!(info.server_name, "resolver.example.invalid");
+        assert!(info.remote_ip.is_none());
+    }
+
+    #[test]
+    fn test_connection_info_uses_dial_addr_for_domain() {
+        let mut cfg = make_upstream_config("tls://dns.example.invalid:853");
+        cfg.dial_addr = Some(IpAddr::from_str("203.0.113.53").unwrap());
+
+        let info = ConnectionInfo::try_from(cfg).expect("upstream config should parse");
+        assert_eq!(info.server_name, "dns.example.invalid");
+        assert_eq!(
+            info.remote_ip,
+            Some(IpAddr::from_str("203.0.113.53").unwrap())
+        );
+    }
+
+    #[test]
+    fn test_connection_info_dial_addr_takes_precedence_over_bootstrap() {
+        let mut cfg = make_upstream_config("tls://dns.example.invalid:853");
+        cfg.dial_addr = Some(IpAddr::from_str("203.0.113.53").unwrap());
+        cfg.bootstrap = Some("8.8.8.8:53".to_string());
+
+        let info = ConnectionInfo::try_from(cfg).expect("upstream config should parse");
+        assert_eq!(
+            info.remote_ip,
+            Some(IpAddr::from_str("203.0.113.53").unwrap())
+        );
+        assert!(info.bootstrap.is_none());
     }
 
     #[test]

--- a/src/network/upstream/utils.rs
+++ b/src/network/upstream/utils.rs
@@ -272,8 +272,8 @@ pub fn build_doh_request_uri(connection_info: &ConnectionInfo) -> String {
 /// - `Err(DnsError)` if resolution fails or returns no results
 ///
 /// # Notes
-/// - This is typically used once during initialization for static upstream
-///   servers
+/// - This is used at connection time when no literal IP, `dial_addr`, or
+///   bootstrap-resolved address is available
 /// - For dynamic resolution with TTL support, use Bootstrap instead
 /// - Blocks the current task - consider using bootstrap for async resolution
 /// - Returns the first address from the system resolver (maybe IPv4 or IPv6)

--- a/src/plugin/executor/forward.rs
+++ b/src/plugin/executor/forward.rs
@@ -251,7 +251,7 @@ impl MetricSource for ForwardMetrics {
 
 /// Resolve a stable, collision-free label value for each upstream.
 ///
-/// Uses the upstream tag when configured, otherwise its resolved address. Any
+/// Uses the upstream tag when configured, otherwise its configured address. Any
 /// duplicate identity is disambiguated with a `#<index>` suffix so emitted
 /// time series never share an identical label set.
 fn upstream_metric_names(infos: &[&ConnectionInfo]) -> Vec<String> {
@@ -521,9 +521,7 @@ fn validate_forward_config(cfg: &ForwardConfig) -> Result<()> {
 }
 
 fn validate_upstream_addr(addr: &str) -> std::result::Result<(), String> {
-    ConnectionInfo::with_addr(addr)
-        .map(|_| ())
-        .map_err(|e| e.to_string())
+    ConnectionInfo::validate_addr(addr).map_err(|e| e.to_string())
 }
 
 fn build_upstream(upstream_config: UpstreamConfig) -> Result<Box<dyn Upstream>> {
@@ -873,6 +871,12 @@ upstreams:
             Err(err) => err,
         };
         assert!(err.to_string().contains("is invalid"));
+    }
+
+    #[test]
+    fn validate_accepts_domain_upstream_addr_without_resolution() {
+        validate_upstream_addr("tls://dns.example.invalid:853")
+            .expect("domain upstream validation should only parse address syntax");
     }
 
     #[test]

--- a/webui/lib/plugin-definitions/executor.ts
+++ b/webui/lib/plugin-definitions/executor.ts
@@ -150,7 +150,7 @@ export const executorPluginDefinitions: PluginKindDefinition[] = [
             {
               key: "dial_addr",
               description:
-                "指定实际连接 IP，同时保留 addr 中的主机名用于 SNI、Host 和证书校验。",
+                "指定实际连接 IP，同时保留 addr 中的主机名用于 SNI、Host 和证书校验；与 bootstrap 同时配置时本字段优先生效。",
               label: "拨号 IP",
               type: "text",
               placeholder: "203.0.113.53",
@@ -164,7 +164,8 @@ export const executorPluginDefinitions: PluginKindDefinition[] = [
             },
             {
               key: "bootstrap",
-              description: "为域名型上游提供引导解析服务器。",
+              description:
+                "为域名型上游提供引导解析服务器；未配置时会在首次建连时使用系统解析；与 dial_addr 同时配置时会被忽略。",
               label: "Bootstrap",
               type: "text",
               placeholder: "8.8.8.8:53",


### PR DESCRIPTION
- Avoid resolving domain-based upstreams during forward config validation and ConnectionInfo construction.
- Preserve literal IP and dial_addr paths while deferring hostnames to bootstrap or connection time.
- Document that dial_addr takes precedence over bootstrap when both are configured.

Fixes #95