### PR TITLE
docs: add roadmap page and sync README with planned directions

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,21 @@ Windows 可在 PowerShell 中执行：
 - [常见场景](https://oxidns.org/scenarios)
 - [架构与设计](https://oxidns.org/architecture-and-design)
 - [性能与基准](https://oxidns.org/benchmarks)
+- [路线图](https://oxidns.org/roadmap)
+
+---
+
+## 路线图
+
+以下是当前规划中的开发方向，按顺序排列。详细说明请参考[文档路线图](https://oxidns.org/roadmap)。
+
+1. **编译定制化**：按功能模块拆分编译，用户 fork 后可自由组合插件，构建精简的定制版本，并通过自定义仓库实现自动更新
+2. **IP 优选**：对 DNS 响应中的多个 A/AAAA 地址并行测速，自动选出延迟最低的 IP 返回给客户端
+3. **MikroTik 深度集成**：新增从 RouterOS 拉取地址列表作为数据源，以及将本地 IP 集主动推送到 RouterOS 的能力
+4. **OpenWrt 支持**：通过 opkg 一键安装、服务自动托管，为 OpenWrt 用户提供原生部署体验
+5. **WebUI 与指标增强**：为各新增插件补充管理界面，扩展 Prometheus 指标覆盖范围
+
+长期来看，计划探索 WebAssembly 插件和动态链接库插件两种扩展机制，支持第三方开发者独立开发和分发插件。
 
 ---
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -210,6 +210,21 @@ For the full installation flow, see [Quick Start](https://oxidns.org/en/quicksta
 - [Common Scenarios](https://oxidns.org/en/scenarios)
 - [Architecture and Design](https://oxidns.org/en/architecture-and-design)
 - [Performance and Benchmarks](https://oxidns.org/en/benchmarks)
+- [Roadmap](https://oxidns.org/en/roadmap)
+
+---
+
+## Roadmap
+
+The following outlines the planned development directions in delivery order. See the [documentation roadmap](https://oxidns.org/en/roadmap) for full details.
+
+1. **Custom builds**: Split compilation by plugin module so users can fork, select only the plugins they need, and auto-update from a custom repository
+2. **IP optimization**: Probe multiple A/AAAA addresses from a DNS response in parallel and return the lowest-latency IP to the client
+3. **MikroTik deep integration**: Add the ability to pull RouterOS address lists as a data source and to actively push local IP sets to RouterOS
+4. **OpenWrt support**: One-command install via opkg with automatic service management — a native deployment experience for OpenWrt users
+5. **WebUI and metrics improvements**: Add management interfaces for new plugins and expand Prometheus metric coverage
+
+Looking further ahead, two plugin extension mechanisms are planned: WebAssembly plugins and dynamic library plugins, enabling third-party developers to build and distribute plugins independently.
 
 ---
 

--- a/config.yaml
+++ b/config.yaml
@@ -1,33 +1,47 @@
+# OxiDNS default configuration file
+#
+# See full documentation at:
+# https://oxidns.cn
+
 log:
   level: info
+
+# Management API (optional)
 api:
   http:
-    listen: :9199
+    listen: ":9199"
+    # auth:
+    #   type: basic
+    #   username: admin
+    #   password: secret
+    # Optional static WebUI directory. API routes are served under /api/*.
     webui:
-      root: ./webui
+      root: "./webui"
+
 plugins:
+  # Forward to upstream DNS servers
   - tag: forward
     type: forward
     args:
       upstreams:
-        - addr: 223.5.5.5
+        - addr: "223.5.5.5"
+
   - tag: main_sequence
     type: sequence
     args:
       - exec: $forward
       - exec: accept
+
+  # UDP server listening on :5335
   - tag: udp_server
     type: udp_server
     args:
       entry: main_sequence
-      listen: :5335
+      listen: ":5335"
+
+  # TCP server listening on :5335
   - tag: tcp_server
     type: tcp_server
     args:
       entry: main_sequence
-      listen: :5335
-  - tag: udp_server_53
-    type: udp_server
-    args:
-      entry: main_sequence
-      listen: :53
+      listen: ":5335"

--- a/docs/docs/roadmap.md
+++ b/docs/docs/roadmap.md
@@ -1,0 +1,79 @@
+---
+title: 路线图
+sidebar_position: 5
+---
+
+# 路线图
+
+以下是 OxiDNS 近期规划中的开发方向，按开发顺序排列。
+
+```mermaid
+flowchart LR
+  A["① 编译定制化"] --> B["② IP 优选"]
+  B --> C["③ MikroTik 深度集成"]
+  C --> D["④ OpenWrt 支持"]
+  D --> E["⑤ WebUI 与指标增强"]
+
+  style A fill:#f0fdfa,stroke:#0f766e,stroke-width:2px,color:#0f4c46
+  style B fill:#f0fdfa,stroke:#0f766e,stroke-width:2px,color:#0f4c46
+  style C fill:#f0fdfa,stroke:#0f766e,stroke-width:2px,color:#0f4c46
+  style D fill:#f0fdfa,stroke:#0f766e,stroke-width:2px,color:#0f4c46
+  style E fill:#f0fdfa,stroke:#0f766e,stroke-width:2px,color:#0f4c46
+```
+
+<div style={{display: 'flex', flexDirection: 'column', gap: '0.75rem', marginTop: '1.75rem'}}>
+
+  <div className="doc-plugin-card" style={{display: 'flex', gap: '1.25rem', alignItems: 'flex-start'}}>
+    <div style={{flexShrink: 0, width: '2.2rem', height: '2.2rem', borderRadius: '50%', background: 'var(--ifm-color-primary)', color: '#fff', display: 'flex', alignItems: 'center', justifyContent: 'center', fontWeight: 800, fontSize: '0.95rem', marginTop: '0.1rem'}}>1</div>
+    <div>
+      <div className="doc-plugin-card__eyebrow">第一阶段</div>
+      <h3 className="doc-plugin-card__title">编译定制化</h3>
+      <p style={{margin: '0.4rem 0 0', lineHeight: 1.7}}>按功能模块拆分编译，用户 fork 仓库后可自由组合所需插件，构建精简的定制版本，并通过自定义仓库地址实现自动更新。</p>
+    </div>
+  </div>
+
+  <div className="doc-plugin-card" style={{display: 'flex', gap: '1.25rem', alignItems: 'flex-start'}}>
+    <div style={{flexShrink: 0, width: '2.2rem', height: '2.2rem', borderRadius: '50%', background: 'var(--ifm-color-primary)', color: '#fff', display: 'flex', alignItems: 'center', justifyContent: 'center', fontWeight: 800, fontSize: '0.95rem', marginTop: '0.1rem'}}>2</div>
+    <div>
+      <div className="doc-plugin-card__eyebrow">第二阶段</div>
+      <h3 className="doc-plugin-card__title">IP 优选</h3>
+      <p style={{margin: '0.4rem 0 0', lineHeight: 1.7}}>对 DNS 响应中的多个 A/AAAA 地址并行测速，自动选出延迟最低的 IP 返回给客户端，提升实际访问速度。</p>
+    </div>
+  </div>
+
+  <div className="doc-plugin-card" style={{display: 'flex', gap: '1.25rem', alignItems: 'flex-start'}}>
+    <div style={{flexShrink: 0, width: '2.2rem', height: '2.2rem', borderRadius: '50%', background: 'var(--ifm-color-primary)', color: '#fff', display: 'flex', alignItems: 'center', justifyContent: 'center', fontWeight: 800, fontSize: '0.95rem', marginTop: '0.1rem'}}>3</div>
+    <div>
+      <div className="doc-plugin-card__eyebrow">第三阶段</div>
+      <h3 className="doc-plugin-card__title">MikroTik 深度集成</h3>
+      <p style={{margin: '0.4rem 0 0', lineHeight: 1.7}}>在现有单向推送基础上，新增从 RouterOS 拉取地址列表作为 OxiDNS 数据源，以及将本地 IP 集主动推送到 RouterOS 的能力，实现 DNS 策略与 RouterOS 的双向数据联动。</p>
+    </div>
+  </div>
+
+  <div className="doc-plugin-card" style={{display: 'flex', gap: '1.25rem', alignItems: 'flex-start'}}>
+    <div style={{flexShrink: 0, width: '2.2rem', height: '2.2rem', borderRadius: '50%', background: 'var(--ifm-color-primary)', color: '#fff', display: 'flex', alignItems: 'center', justifyContent: 'center', fontWeight: 800, fontSize: '0.95rem', marginTop: '0.1rem'}}>4</div>
+    <div>
+      <div className="doc-plugin-card__eyebrow">第四阶段</div>
+      <h3 className="doc-plugin-card__title">OpenWrt 支持</h3>
+      <p style={{margin: '0.4rem 0 0', lineHeight: 1.7}}>为 OpenWrt 用户提供与 Debian 包同等级别的原生安装体验：通过 opkg 一键安装、服务自动托管、随系统更新，无需手动部署二进制文件。</p>
+    </div>
+  </div>
+
+  <div className="doc-plugin-card" style={{display: 'flex', gap: '1.25rem', alignItems: 'flex-start'}}>
+    <div style={{flexShrink: 0, width: '2.2rem', height: '2.2rem', borderRadius: '50%', background: 'var(--ifm-color-primary)', color: '#fff', display: 'flex', alignItems: 'center', justifyContent: 'center', fontWeight: 800, fontSize: '0.95rem', marginTop: '0.1rem'}}>5</div>
+    <div>
+      <div className="doc-plugin-card__eyebrow">第五阶段</div>
+      <h3 className="doc-plugin-card__title">WebUI 与指标增强</h3>
+      <p style={{margin: '0.4rem 0 0', lineHeight: 1.7}}>为各新增插件补充 WebUI 管理界面，扩展 Prometheus 指标覆盖范围，提升可观测性和运维体验。</p>
+    </div>
+  </div>
+
+</div>
+
+<div style={{borderLeft: '4px solid var(--ifm-color-primary)', background: 'rgba(15, 118, 110, 0.06)', borderRadius: '0 12px 12px 0', padding: '0.9rem 1.2rem', marginTop: '2rem'}}>
+  <p style={{margin: 0, lineHeight: 1.75}}><strong>关于插件生态的长期方向</strong></p>
+  <ul style={{margin: '0.5rem 0 0', paddingLeft: '1.25rem', lineHeight: 1.75}}>
+    <li><strong>WebAssembly 插件</strong>：探索通过 WASM 支持第三方插件，允许开发者用任意语言按规范开发和分发插件，无需修改 OxiDNS 主体代码，并天然获得沙箱隔离保障。</li>
+    <li><strong>动态链接库插件</strong>：探索通过动态库（.so / .dylib）加载机制支持原生插件，适合对性能要求极高的场景，开发者可独立编译和分发，OxiDNS 在运行时按需加载。</li>
+  </ul>
+</div>

--- a/docs/i18n/en/docusaurus-plugin-content-docs/current/roadmap.md
+++ b/docs/i18n/en/docusaurus-plugin-content-docs/current/roadmap.md
@@ -1,0 +1,62 @@
+---
+title: Roadmap
+sidebar_position: 5
+---
+
+# Roadmap
+
+The following outlines OxiDNS's planned development directions in delivery order.
+
+```mermaid
+flowchart LR
+  A["① Custom Builds"] --> B["② IP Optimization"]
+  B --> C["③ MikroTik Integration"]
+  C --> D["④ OpenWrt Support"]
+  D --> E["⑤ WebUI & Metrics"]
+
+  style A fill:#f0fdfa,stroke:#0f766e,stroke-width:2px,color:#0f4c46
+  style B fill:#f0fdfa,stroke:#0f766e,stroke-width:2px,color:#0f4c46
+  style C fill:#f0fdfa,stroke:#0f766e,stroke-width:2px,color:#0f4c46
+  style D fill:#f0fdfa,stroke:#0f766e,stroke-width:2px,color:#0f4c46
+  style E fill:#f0fdfa,stroke:#0f766e,stroke-width:2px,color:#0f4c46
+```
+
+---
+
+## Phase 1 · Custom Builds
+
+Split compilation by plugin module so users can fork the repository, select only the plugins they need, produce a lean custom build, and keep it up to date via a configurable upgrade repository.
+
+---
+
+## Phase 2 · IP Optimization
+
+Test multiple A/AAAA addresses from a DNS response in parallel and return the lowest-latency IP to the client, improving real-world access speed.
+
+---
+
+## Phase 3 · MikroTik Deep Integration
+
+On top of the existing one-way push, add the ability to pull RouterOS address lists as an OxiDNS data source and to actively push local IP sets to RouterOS, enabling bidirectional data integration between DNS policy and RouterOS.
+
+---
+
+## Phase 4 · OpenWrt Support
+
+Bring a native install experience to OpenWrt users on par with the existing Debian package: one-command install via opkg, automatic service management, and system-integrated updates — no manual binary deployment required.
+
+---
+
+## Phase 5 · WebUI and Metrics Improvements
+
+Add WebUI management interfaces for each new plugin, expand Prometheus metric coverage, and improve overall observability and operational experience.
+
+---
+
+<div style={{borderLeft: '4px solid var(--ifm-color-primary)', background: 'rgba(15, 118, 110, 0.06)', borderRadius: '0 12px 12px 0', padding: '0.9rem 1.2rem', marginTop: '2rem'}}>
+  <p style={{margin: 0, lineHeight: 1.75}}><strong>Long-term direction: plugin ecosystem</strong></p>
+  <ul style={{margin: '0.5rem 0 0', paddingLeft: '1.25rem', lineHeight: 1.75}}>
+    <li><strong>WebAssembly plugins</strong>: Explore WASM-based third-party plugins so developers can write and distribute plugins in any language without modifying OxiDNS, with sandboxing included by default.</li>
+    <li><strong>Dynamic library plugins</strong>: Explore native plugin loading via shared libraries (.so / .dylib) for scenarios with the highest performance requirements, allowing developers to compile and distribute plugins independently and have OxiDNS load them at runtime.</li>
+  </ul>
+</div>

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -5,6 +5,7 @@ const sidebars = {
     'cli',
     'configuration',
     'releases',
+    'roadmap',
     'webui',
     {
       type: 'category',


### PR DESCRIPTION
- Add Chinese and English roadmap docs outlining five development phases: custom builds, IP optimization, MikroTik integration, OpenWrt IPK packaging, and WebUI/metrics improvements
- Include long-term plugin ecosystem directions (WASM and dynamic library plugins) in both doc pages
- Add roadmap entry to docs/sidebars.js and documentation link sections in README / README_EN
- Clean up default config.yaml: add section comments, quote listen addresses, and remove the example :53 server block