### PR TITLE
feat(upgrade): rework restart flow, enable Windows upgrade, add GitHub token

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures 0.2.17",
+]
+
+[[package]]
 name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -108,6 +119,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+dependencies = [
+ "derive_arbitrary",
+]
+
+[[package]]
 name = "arc-swap"
 version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -181,6 +201,15 @@ checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "block-buffer"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
@@ -205,6 +234,25 @@ name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+
+[[package]]
+name = "bzip2"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49ecfb22d906f800d4fe833b6282cf4dc1c298f5057ca0b5445e5c209735ca47"
+dependencies = [
+ "bzip2-sys",
+]
+
+[[package]]
+name = "bzip2-sys"
+version = "0.1.13+1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "225bff33b2141874fe80d71e07d6eec4f85c5c216453dd96388240f96e1acc14"
+dependencies = [
+ "cc",
+ "pkg-config",
+]
 
 [[package]]
 name = "cast"
@@ -249,7 +297,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.3.0",
  "rand_core 0.10.1",
 ]
 
@@ -284,6 +332,16 @@ checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
 dependencies = [
  "ciborium-io",
  "half",
+]
+
+[[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common 0.1.7",
+ "inout",
 ]
 
 [[package]]
@@ -367,6 +425,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
+name = "constant_time_eq"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
+
+[[package]]
 name = "core-foundation"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -384,12 +448,36 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "crc"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eb8a2a1cd12ab0d987a5d5e825195d372001a4094a0376319d5a0ad71c1ba0d"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
 
 [[package]]
 name = "crc32fast"
@@ -496,6 +584,16 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "crypto-common"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
@@ -553,6 +651,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "deflate64"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac6b926516df9c60bfa16e107b21086399f8285a44ca9711344b9e553c5146e2"
+
+[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -562,14 +666,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer 0.10.4",
+ "crypto-common 0.1.7",
+ "subtle",
+]
+
+[[package]]
 name = "digest"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
- "block-buffer",
+ "block-buffer 0.12.0",
  "const-oid",
- "crypto-common",
+ "crypto-common 0.2.1",
 ]
 
 [[package]]
@@ -881,6 +1007,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1050,6 +1186,15 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest 0.10.7",
+]
 
 [[package]]
 name = "home"
@@ -1352,6 +1497,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "inventory"
 version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1592,6 +1746,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
+name = "lzma-rs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "297e814c836ae64db86b36cf2a557ba54368d03f6afcd7d947c266692f71115e"
+dependencies = [
+ "byteorder",
+ "crc",
+]
+
+[[package]]
+name = "lzma-sys"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fda04ab3764e6cde78b9974eec4f779acaba7c4e84b36eca3cf77c581b85d27"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+]
+
+[[package]]
 name = "matchers"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1801,6 +1976,7 @@ dependencies = [
  "url",
  "webpki-roots",
  "wincode",
+ "zip",
 ]
 
 [[package]]
@@ -1875,6 +2051,16 @@ name = "pastey"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c5a797f0e07bdf071d15742978fc3128ec6c22891c31a3a931513263904c982a"
+
+[[package]]
+name = "pbkdf2"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
+dependencies = [
+ "digest 0.10.7",
+ "hmac",
+]
 
 [[package]]
 name = "percent-encoding"
@@ -2551,14 +2737,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
+]
+
+[[package]]
 name = "sha2"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -3796,6 +3993,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ae8337f8a065cfc972643663ea4279e04e7256de865aa66fe25cec5fb912d3f"
 
 [[package]]
+name = "xz2"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "388c44dc09d76f1536602ead6d325eb532f5c122f17782bd57fb47baeeb767e2"
+dependencies = [
+ "lzma-sys",
+]
+
+[[package]]
 name = "yoke"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3864,6 +4070,20 @@ name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "zerotrie"
@@ -3899,7 +4119,77 @@ dependencies = [
 ]
 
 [[package]]
+name = "zip"
+version = "2.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fabe6324e908f85a1c52063ce7aa26b68dcb7eb6dbc83a2d148403c9bc3eba50"
+dependencies = [
+ "aes",
+ "arbitrary",
+ "bzip2",
+ "constant_time_eq",
+ "crc32fast",
+ "crossbeam-utils",
+ "deflate64",
+ "displaydoc",
+ "flate2",
+ "getrandom 0.3.4",
+ "hmac",
+ "indexmap",
+ "lzma-rs",
+ "memchr",
+ "pbkdf2",
+ "sha1",
+ "thiserror 2.0.18",
+ "time",
+ "xz2",
+ "zeroize",
+ "zopfli",
+ "zstd",
+]
+
+[[package]]
 name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zopfli"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249"
+dependencies = [
+ "bumpalo",
+ "crc32fast",
+ "log",
+ "simd-adler32",
+]
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,6 +99,9 @@ zoneparser = { package = "oxidns-zoneparser", version = "0.1.0", path = "crates/
 [target.'cfg(target_os = "linux")'.dependencies]
 ripset = { package = "oxidns-ripset", version = "0.1.0", path = "crates/ripset" }
 
+[target.'cfg(windows)'.dependencies]
+zip = "2"
+
 
 [features]
 hotpath = ["hotpath/hotpath"]

--- a/docs/docs/cli.md
+++ b/docs/docs/cli.md
@@ -284,7 +284,8 @@ oxidns upgrade
 oxidns upgrade --force
 oxidns upgrade check
 oxidns upgrade download --target latest
-sudo oxidns upgrade apply --restart service
+sudo oxidns upgrade apply
+sudo oxidns upgrade apply --no-restart
 ```
 
 通用参数：
@@ -309,9 +310,8 @@ sudo oxidns upgrade apply --restart service
   - 默认值：`./webui`
 - `--skip-webui`
   - `apply` 时跳过 WebUI 目录升级，仅替换二进制文件。
-- `--restart <none|service>`
-  - `apply` 成功后的重启策略。
-  - 默认值：`none`
+- `--no-restart`
+  - `apply` 成功后跳过服务重启。默认会通过系统服务管理器（systemd / launchd / Windows SCM）自动重启已安装的服务。
 - `--allow-prerelease`
   - 允许使用 prerelease。
 - `--force`
@@ -322,6 +322,8 @@ sudo oxidns upgrade apply --restart service
   - 可选 SOCKS5 代理。
 - `--insecure-skip-verify`
   - 跳过 TLS 证书校验。
+- `--github-token <TOKEN>`
+  - GitHub 个人访问令牌，用于提高 API 速率限制或访问私有仓库。
 
 行为说明：
 
@@ -329,8 +331,9 @@ sudo oxidns upgrade apply --restart service
 - `download` 下载 archive，并使用 GitHub release asset 的 `digest` 字段校验 SHA256。
 - 不写子命令时默认执行 `apply`。
 - `apply` 默认只有检测到新版本才会更新；`--force` 会强制更新。
-- `apply` 在 Unix 平台会解包 `.tar.gz`、备份当前二进制并替换；Windows 当前只支持 `check` 和 `download`。
+- `apply` 在 Unix 平台会解包 `.tar.gz`、备份当前二进制并替换；Windows 会解包 `.zip`、备份并替换二进制，同样支持 WebUI 目录升级。
 - `apply` 默认在替换二进制后，将 archive 中的 `webui/` 目录备份并安装到 `--webui-dir`；`--skip-webui` 可跳过；archive 不含 `webui/` 时跳过且不影响二进制升级。
+- `apply` 成功后默认通过系统服务管理器重启服务；如果不想自动重启，传 `--no-restart`。
 - `apply` 成功后会询问是否清理缓存目录和备份目录，默认选择 `Y`。
 
 ## 页面范围

--- a/docs/i18n/en/docusaurus-plugin-content-docs/current/cli.md
+++ b/docs/i18n/en/docusaurus-plugin-content-docs/current/cli.md
@@ -284,7 +284,8 @@ oxidns upgrade
 oxidns upgrade --force
 oxidns upgrade check
 oxidns upgrade download --target latest
-sudo oxidns upgrade apply --restart service
+sudo oxidns upgrade apply
+sudo oxidns upgrade apply --no-restart
 ```
 
 Common arguments:
@@ -309,9 +310,8 @@ Common arguments:
   - Default: `./webui`
 - `--skip-webui`
   - For `apply`, skip the WebUI directory upgrade and replace only the binary.
-- `--restart <none|service>`
-  - Restart strategy after a successful `apply`.
-  - Default: `none`
+- `--no-restart`
+  - Skip restarting the service after a successful `apply`. By default the installed service is restarted automatically via the system service manager (systemd / launchd / Windows SCM).
 - `--allow-prerelease`
   - Allows prerelease releases.
 - `--force`
@@ -322,6 +322,8 @@ Common arguments:
   - Optional SOCKS5 proxy.
 - `--insecure-skip-verify`
   - Disables TLS certificate verification.
+- `--github-token <TOKEN>`
+  - GitHub personal access token for API requests, used to raise the rate limit or access private repositories.
 
 Behavior:
 
@@ -329,8 +331,9 @@ Behavior:
 - `download` downloads the archive and verifies SHA256 with the GitHub release asset `digest` field.
 - Omitting the subcommand defaults to `apply`.
 - `apply` updates only when a newer version is available by default. `--force` forces the update.
-- On Unix, `apply` unpacks the `.tar.gz`, backs up the current binary, and replaces it. Windows currently supports only `check` and `download`.
+- On Unix, `apply` unpacks the `.tar.gz`, backs up the current binary, and replaces it. On Windows, `apply` unpacks the `.zip`, backs up and replaces the binary, and also upgrades the WebUI directory.
 - By default, after replacing the binary `apply` backs up and installs the archive's `webui/` directory into `--webui-dir`; `--skip-webui` skips it, and an archive without `webui/` is skipped without affecting the binary upgrade.
+- After a successful `apply`, the service is restarted automatically via the system service manager. Pass `--no-restart` to skip the automatic restart.
 - After a successful `apply`, the CLI asks whether to clean the cache and backup directories. The default answer is `Y`.
 
 ## Page Scope

--- a/justfile
+++ b/justfile
@@ -2,19 +2,19 @@ set positional-arguments
 
 # Run the standard local quality gate without mutating source files.
 check:
-    cargo fmt --all --check
-    cargo clippy --all-targets --all-features -- -D warnings
+    cargo +nightly fmt --all --check
+    cargo +nightly clippy --all-targets --all-features -- -D warnings
     cargo test
 
 # Apply formatting and Clippy autofixes where available.
 fix:
-    cargo fmt --all
-    cargo clippy --all-targets --all-features --fix --allow-dirty --allow-staged -- -D warnings
+    cargo +nightly fmt --all
+    cargo +nightly clippy --all-targets --all-features --fix --allow-dirty --allow-staged -- -D warnings
 
 # Fast iteration path when full tests are unnecessary.
 lint:
-    cargo fmt --all --check
-    cargo clippy --all-targets --all-features -- -D warnings
+    cargo +nightly fmt --all --check
+    cargo +nightly clippy --all-targets --all-features -- -D warnings
 
 # Install the repository-managed Git hooks directory for this clone.
 install-hooks:

--- a/src/api/control.rs
+++ b/src/api/control.rs
@@ -27,6 +27,7 @@ use crate::core::error::Result;
 pub enum ControlCommand {
     Shutdown,
     Reload,
+    Restart,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -174,6 +175,16 @@ impl AppController {
         }
         self.command_tx
             .send(ControlCommand::Shutdown)
+            .map_err(|_| ControlRequestError::CommandChannelClosed)
+    }
+
+    pub fn request_restart(&self) -> std::result::Result<(), ControlRequestError> {
+        {
+            let mut state = self.state.lock().expect("control state poisoned");
+            state.shutdown_requested = true;
+        }
+        self.command_tx
+            .send(ControlCommand::Restart)
             .map_err(|_| ControlRequestError::CommandChannelClosed)
     }
 
@@ -366,6 +377,32 @@ impl ApiHandler for ShutdownHandler {
                 &ActionAcceptedResponse {
                     ok: true,
                     action: "shutdown",
+                    status: "accepted",
+                },
+            ),
+            Err(err) => json_error(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "control_command_failed",
+                err.to_string(),
+            ),
+        }
+    }
+}
+
+#[derive(Debug)]
+struct RestartHandler {
+    controller: Arc<AppController>,
+}
+
+#[async_trait]
+impl ApiHandler for RestartHandler {
+    async fn handle(&self, _request: Request<Bytes>) -> crate::api::ApiResponse {
+        match self.controller.request_restart() {
+            Ok(()) => json_ok(
+                StatusCode::ACCEPTED,
+                &ActionAcceptedResponse {
+                    ok: true,
+                    action: "restart",
                     status: "accepted",
                 },
             ),
@@ -790,6 +827,12 @@ pub fn register_builtin_routes(
     register.register_post(
         "/shutdown",
         Arc::new(ShutdownHandler {
+            controller: controller.clone(),
+        }),
+    )?;
+    register.register_post(
+        "/restart",
+        Arc::new(RestartHandler {
             controller: controller.clone(),
         }),
     )?;

--- a/src/app.rs
+++ b/src/app.rs
@@ -38,6 +38,11 @@ use crate::{config, core};
 pub fn run(start: StartOptions) -> Result<()> {
     AppClock::start();
     prepare_working_dir(start.working_dir.as_ref())?;
+    // Clean up any leftover staging file from an interrupted Windows upgrade.
+    #[cfg(windows)]
+    if let Ok(exe) = std::env::current_exe() {
+        let _ = std::fs::remove_file(exe.with_extension("upgrade-new.exe"));
+    }
     banner::print_startup_banner()?;
     let config = load_config(&start)?;
     init_runtime(start, config)
@@ -120,7 +125,82 @@ fn init_runtime(options: StartOptions, config: Config) -> Result<()> {
     let tokio_runtime = tokio_runtime
         .build()
         .map_err(|err| DnsError::runtime(format!("Failed to initialize Tokio runtime: {err}")))?;
-    tokio_runtime.block_on(run_async_main(options, config))
+    match tokio_runtime.block_on(run_async_main(options, config))? {
+        ShutdownSignal::Restart => exec_restart(),
+        _ => Ok(()),
+    }
+}
+
+/// Replace the current process image with a fresh copy of OxiDNS using the
+/// original command-line arguments.
+///
+/// On Unix, `exec()` keeps the same PID so any process supervisor (systemd,
+/// launchd, Docker, etc.) continues tracking the process without interruption.
+/// On non-Unix platforms a new process is spawned and the current one exits.
+pub(crate) fn exec_restart() -> Result<()> {
+    let exe = std::env::current_exe()
+        .map_err(|e| DnsError::runtime(format!("restart: cannot get current executable: {e}")))?;
+    // std::env::args() reads the OS-level process arguments and is safe to
+    // call at any point during the process lifetime.
+    let args: Vec<std::ffi::OsString> = std::env::args_os().skip(1).collect();
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::CommandExt;
+        let err = std::process::Command::new(&exe).args(&args).exec();
+        Err(DnsError::runtime(format!("exec restart failed: {err}")))
+    }
+
+    #[cfg(windows)]
+    {
+        if windows_running_as_service() {
+            // Under Windows SCM: do not spawn a duplicate — SCM will restart the
+            // service on our behalf. Exit with a non-zero code to trigger the
+            // OnFailure restart policy configured at install time.
+            std::process::exit(1);
+        } else {
+            // Foreground mode: spawn the replacement process then exit cleanly.
+            std::process::Command::new(&exe)
+                .args(&args)
+                .spawn()
+                .map_err(|e| DnsError::runtime(format!("restart: spawn failed: {e}")))?;
+            std::process::exit(0);
+        }
+    }
+
+    #[cfg(not(any(unix, windows)))]
+    {
+        std::process::Command::new(&exe)
+            .args(&args)
+            .spawn()
+            .map_err(|e| DnsError::runtime(format!("restart: spawn failed: {e}")))?;
+        std::process::exit(0);
+    }
+}
+
+/// Detect whether this process is running under the Windows Service Control
+/// Manager by checking if the parent process is `services.exe`.
+///
+/// Uses the already-available `sysinfo` crate — no extra dependencies needed.
+/// Falls back to `false` (assume foreground) on any lookup error.
+#[cfg(windows)]
+fn windows_running_as_service() -> bool {
+    use sysinfo::{Pid, ProcessRefreshKind, ProcessesToUpdate, RefreshKind, System};
+
+    let refresh = ProcessRefreshKind::nothing();
+    let mut sys = System::new_with_specifics(RefreshKind::nothing().with_processes(refresh));
+    sys.refresh_processes(ProcessesToUpdate::All, false);
+
+    let current_pid = Pid::from_u32(std::process::id());
+    sys.process(current_pid)
+        .and_then(|p| p.parent())
+        .and_then(|parent_pid| sys.process(parent_pid))
+        .is_some_and(|parent| {
+            parent
+                .name()
+                .to_string_lossy()
+                .eq_ignore_ascii_case("services.exe")
+        })
 }
 
 fn load_config(options: &StartOptions) -> Result<Config> {
@@ -341,6 +421,7 @@ plugins:
 #[derive(Clone, Copy, Debug)]
 pub(super) enum ShutdownSignal {
     ApiRequest,
+    Restart,
     #[cfg(unix)]
     SigInt,
     #[cfg(unix)]
@@ -363,6 +444,7 @@ impl ShutdownSignal {
     const fn as_str(self) -> &'static str {
         match self {
             ShutdownSignal::ApiRequest => "API_REQUEST",
+            ShutdownSignal::Restart => "RESTART",
             #[cfg(unix)]
             ShutdownSignal::SigInt => "SIGINT",
             #[cfg(unix)]
@@ -436,7 +518,7 @@ async fn wait_for_shutdown_signal() -> Result<ShutdownSignal> {
 }
 
 #[hotpath::main]
-async fn run_async_main(options: StartOptions, config: Config) -> Result<()> {
+async fn run_async_main(options: StartOptions, config: Config) -> Result<ShutdownSignal> {
     let (shutdown_tx, shutdown_rx) = oneshot::channel::<Result<ShutdownSignal>>();
     tokio::spawn(async move {
         let _ = shutdown_tx.send(wait_for_shutdown_signal().await);
@@ -507,7 +589,7 @@ async fn run_async_main(options: StartOptions, config: Config) -> Result<()> {
         signal = shutdown_signal.as_str(),
         "Graceful shutdown complete"
     );
-    Ok(())
+    Ok(shutdown_signal)
 }
 
 async fn wait_for_termination(
@@ -533,6 +615,10 @@ async fn wait_for_termination(
                     Some(ControlCommand::Shutdown) => {
                         info!("Received shutdown request from management API");
                         return Ok(ShutdownSignal::ApiRequest);
+                    }
+                    Some(ControlCommand::Restart) => {
+                        info!("Received restart request from management API");
+                        return Ok(ShutdownSignal::Restart);
                     }
                     Some(ControlCommand::Reload) => {
                         handle_reload_command(assembly, current_config, controller.clone()).await?;

--- a/src/app/cli.rs
+++ b/src/app/cli.rs
@@ -150,9 +150,9 @@ pub struct UpgradeOptions {
     #[arg(long = "skip-webui", default_value_t = false, global = true)]
     pub skip_webui: bool,
 
-    /// Restart strategy after a successful apply.
-    #[arg(long = "restart", value_enum, default_value_t = RestartMode::None, global = true)]
-    pub restart: RestartMode,
+    /// Skip restarting the service after a successful apply.
+    #[arg(long = "no-restart", default_value_t = false, global = true)]
+    pub no_restart: bool,
 
     /// Allow prerelease GitHub releases.
     #[arg(long = "allow-prerelease", default_value_t = false, global = true)]
@@ -174,6 +174,10 @@ pub struct UpgradeOptions {
     /// Disable TLS certificate verification for upgrade downloads.
     #[arg(long = "insecure-skip-verify", default_value_t = false, global = true)]
     pub insecure_skip_verify: bool,
+
+    /// GitHub personal access token for API requests.
+    #[arg(long = "github-token", global = true)]
+    pub github_token: Option<String>,
 }
 
 /// Upgrade subcommands.
@@ -342,8 +346,6 @@ mod tests {
             "./cache",
             "--backup-dir",
             "./backups",
-            "--restart",
-            "service",
             "--allow-prerelease",
             "--timeout",
             "2m",
@@ -364,14 +366,29 @@ mod tests {
                 backup_dir: PathBuf::from("./backups"),
                 webui_dir: PathBuf::from("./webui"),
                 skip_webui: false,
-                restart: RestartMode::Service,
+                no_restart: false,
                 allow_prerelease: true,
                 force: false,
                 timeout: Duration::from_secs(120),
                 socks5: Some("127.0.0.1:1080".to_string()),
                 insecure_skip_verify: true,
+                github_token: None,
             })
         );
+    }
+
+    #[test]
+    fn parse_upgrade_no_restart_flag() {
+        let args = ["oxidns", "upgrade", "apply", "--no-restart"];
+
+        let cli = Cli::parse_from(args);
+        assert!(matches!(
+            cli.command,
+            Command::Upgrade(UpgradeOptions {
+                no_restart: true,
+                ..
+            })
+        ));
     }
 
     #[test]
@@ -390,12 +407,13 @@ mod tests {
                 backup_dir: PathBuf::from("./upgrade-backups"),
                 webui_dir: PathBuf::from("./webui"),
                 skip_webui: false,
-                restart: RestartMode::None,
+                no_restart: false,
                 allow_prerelease: false,
                 force: true,
                 timeout: Duration::from_secs(30),
                 socks5: None,
                 insecure_skip_verify: false,
+                github_token: None,
             })
         );
     }

--- a/src/plugin/executor/upgrade.rs
+++ b/src/plugin/executor/upgrade.rs
@@ -165,6 +165,7 @@ struct UpgradePluginConfig {
     timeout: Option<String>,
     socks5: Option<String>,
     insecure_skip_verify: Option<bool>,
+    github_token: Option<String>,
 }
 
 impl UpgradePluginConfig {
@@ -212,6 +213,7 @@ impl UpgradePluginConfig {
         if let Some(value) = self.insecure_skip_verify {
             config.insecure_skip_verify = value;
         }
+        config.github_token = self.github_token;
         Ok(config)
     }
 }

--- a/src/plugin/mod.rs
+++ b/src/plugin/mod.rs
@@ -41,7 +41,7 @@ pub use registry::{
     PluginBuildSession, PluginCatalog, PluginInitContext, PluginRegistry, PluginResolver,
     PluginRuntime, PluginRuntimeManager, clear_app_controller, current_runtime, destroy_runtime,
     global_catalog, global_manager, init, plugin_count, reload_provider, request_app_reload,
-    server_plugin_count, set_app_controller,
+    request_app_restart, server_plugin_count, set_app_controller,
 };
 #[cfg(test)]
 pub use registry::{reset_runtime_for_test, set_current_runtime_for_test};

--- a/src/plugin/registry.rs
+++ b/src/plugin/registry.rs
@@ -34,8 +34,8 @@ use runtime::TestRuntimeGuard;
 pub use runtime::enable_runtime_test_serialization;
 pub use runtime::{
     PluginRuntimeManager, clear_app_controller, current_runtime, destroy_runtime, global_manager,
-    init, plugin_count, reload_provider, request_app_reload, server_plugin_count,
-    set_app_controller,
+    init, plugin_count, reload_provider, request_app_reload, request_app_restart,
+    server_plugin_count, set_app_controller,
 };
 #[cfg(test)]
 pub use runtime::{reset_runtime_for_test, set_current_runtime_for_test};

--- a/src/plugin/registry/runtime.rs
+++ b/src/plugin/registry/runtime.rs
@@ -123,6 +123,15 @@ impl PluginRuntimeManager {
         })
     }
 
+    pub fn request_app_restart(&self) -> Result<()> {
+        let controller = self
+            .controller()
+            .ok_or_else(|| DnsError::plugin("restart requires application control context"))?;
+        controller
+            .request_restart()
+            .map_err(|err| DnsError::plugin(err.to_string()))
+    }
+
     pub async fn reload_provider(&self, tag: &str) -> Result<()> {
         let runtime = self
             .current_runtime()
@@ -180,6 +189,10 @@ pub fn clear_app_controller() {
 
 pub fn request_app_reload() -> Result<()> {
     global_manager().request_app_reload()
+}
+
+pub fn request_app_restart() -> Result<()> {
+    global_manager().request_app_restart()
 }
 
 pub async fn reload_provider(tag: &str) -> Result<()> {

--- a/src/upgrade.rs
+++ b/src/upgrade.rs
@@ -710,6 +710,14 @@ fn unpack_zip(archive: &std::path::Path, out_dir: &std::path::Path) -> Result<()
     })?;
     let mut zip = zip::ZipArchive::new(file)
         .map_err(|e| DnsError::runtime(format!("failed to read zip archive: {e}")))?;
+    // Canonicalize `out_dir` once so the post-join containment check is
+    // resilient to relative components and current-dir changes.
+    let out_dir_canon = fs::canonicalize(out_dir).map_err(|e| {
+        DnsError::runtime(format!(
+            "failed to canonicalize unpack dir '{}': {e}",
+            out_dir.display()
+        ))
+    })?;
     for i in 0..zip.len() {
         let mut entry = zip
             .by_index(i)
@@ -717,9 +725,31 @@ fn unpack_zip(archive: &std::path::Path, out_dir: &std::path::Path) -> Result<()
         if entry.is_dir() {
             continue;
         }
-        let dest = out_dir.join(entry.name());
-        if let Some(parent) = dest.parent() {
-            fs::create_dir_all(parent)?;
+        // `enclosed_name()` rejects absolute paths and `..` components that
+        // would escape the unpack root, mitigating zip-slip on Windows where
+        // backslashes and drive letters add extra footguns. Treat any
+        // rejected entry as a hard error so a malicious archive cannot
+        // silently skip files and leave the install in a half-applied state.
+        let Some(rel_path) = entry.enclosed_name() else {
+            return Err(DnsError::runtime(format!(
+                "refusing to extract zip entry with unsafe path: '{}'",
+                entry.name()
+            )));
+        };
+        let dest = out_dir_canon.join(&rel_path);
+        // Defense in depth: ensure the resolved parent stays under
+        // `out_dir_canon` even after the join. `enclosed_name()` already
+        // enforces this, but the extra check protects against future zip
+        // crate behavior changes and any host-side symlink trickery.
+        let parent = dest.parent().unwrap_or(&out_dir_canon);
+        fs::create_dir_all(parent).map_err(|e| {
+            DnsError::runtime(format!("failed to create '{}': {e}", parent.display()))
+        })?;
+        if !parent.starts_with(&out_dir_canon) {
+            return Err(DnsError::runtime(format!(
+                "refusing to extract zip entry outside unpack dir: '{}'",
+                rel_path.display()
+            )));
         }
         let mut out = File::create(&dest).map_err(|e| {
             DnsError::runtime(format!("failed to create '{}': {e}", dest.display()))

--- a/src/upgrade.rs
+++ b/src/upgrade.rs
@@ -9,7 +9,7 @@ use std::path::{Path, PathBuf};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use fs2::FileExt;
-use http::header::{HeaderValue, USER_AGENT};
+use http::header::{AUTHORIZATION, HeaderValue, USER_AGENT};
 use semver::Version;
 use serde::Deserialize;
 use sha2::{Digest, Sha256};
@@ -50,6 +50,7 @@ pub struct UpgradeConfig {
     pub timeout: Duration,
     pub socks5: Option<String>,
     pub insecure_skip_verify: bool,
+    pub github_token: Option<String>,
 }
 
 impl Default for UpgradeConfig {
@@ -62,13 +63,14 @@ impl Default for UpgradeConfig {
             backup_dir: PathBuf::from(DEFAULT_BACKUP_DIR),
             webui_dir: PathBuf::from(DEFAULT_WEBUI_DIR),
             skip_webui: false,
-            restart: RestartMode::None,
+            restart: RestartMode::Service,
             allow_prerelease: false,
             force: false,
             cleanup_after_apply: false,
             timeout: Duration::from_secs(30),
             socks5: None,
             insecure_skip_verify: false,
+            github_token: None,
         }
     }
 }
@@ -83,13 +85,18 @@ impl UpgradeConfig {
             backup_dir: options.backup_dir.clone(),
             webui_dir: options.webui_dir.clone(),
             skip_webui: options.skip_webui,
-            restart: options.restart,
+            restart: if options.no_restart {
+                RestartMode::None
+            } else {
+                RestartMode::Service
+            },
             allow_prerelease: options.allow_prerelease,
             force: options.force,
             cleanup_after_apply: false,
             timeout: options.timeout,
             socks5: options.socks5.clone(),
             insecure_skip_verify: options.insecure_skip_verify,
+            github_token: options.github_token.clone(),
         }
     }
 }
@@ -323,10 +330,8 @@ where
     timeout(
         config.timeout,
         client.download_with_progress(
-            HttpRequestOptions::from_url(asset.browser_download_url.as_str()).with_headers(vec![(
-                USER_AGENT,
-                HeaderValue::from_static(GITHUB_USER_AGENT),
-            )]),
+            HttpRequestOptions::from_url(asset.browser_download_url.as_str())
+                .with_headers(github_request_headers(config.github_token.as_deref())),
             &archive_path,
             progress,
         ),
@@ -369,88 +374,102 @@ async fn apply_unchecked(
     config: &UpgradeConfig,
     restart_context: UpgradeContext,
 ) -> Result<ApplyOutcome> {
-    #[cfg(windows)]
-    {
-        let _ = config;
-        return Err(DnsError::runtime(
-            "upgrade apply is not supported on Windows; use check or download",
-        ));
-    }
+    print_cli_apply_step(restart_context, "Acquiring upgrade lock...");
+    let lock_path = config.cache_dir.join(".upgrade.lock");
+    fs::create_dir_all(&config.cache_dir)?;
+    let lock_file = File::create(&lock_path).map_err(|err| {
+        DnsError::runtime(format!(
+            "failed to create upgrade lock '{}': {}",
+            lock_path.display(),
+            err
+        ))
+    })?;
+    lock_file.try_lock_exclusive().map_err(|err| {
+        DnsError::runtime(format!("another upgrade appears to be running: {err}"))
+    })?;
+
+    print_cli_apply_step(
+        restart_context,
+        "Downloading archive and verifying GitHub asset digest...",
+    );
+    let progress_reporter = UpgradeDownloadProgressReporter::new(restart_context);
+    let downloaded = download(config, move |progress| {
+        progress_reporter.report(progress);
+    })
+    .await?;
+    print_cli_apply_step(
+        restart_context,
+        format!(
+            "Archive ready: {} (sha256 {})",
+            downloaded.archive_path.display(),
+            downloaded.sha256
+        ),
+    );
 
     #[cfg(not(windows))]
+    if !downloaded.asset_name.ends_with(".tar.gz") {
+        return Err(DnsError::runtime(format!(
+            "upgrade apply requires a .tar.gz asset, got '{}'",
+            downloaded.asset_name
+        )));
+    }
+    #[cfg(windows)]
+    if !downloaded.asset_name.ends_with(".zip") {
+        return Err(DnsError::runtime(format!(
+            "upgrade apply requires a .zip asset, got '{}'",
+            downloaded.asset_name
+        )));
+    }
+
+    let unpack_dir = config.cache_dir.join(format!(
+        ".unpack-{}",
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs()
+    ));
+    if unpack_dir.exists() {
+        fs::remove_dir_all(&unpack_dir)?;
+    }
+    fs::create_dir_all(&unpack_dir)?;
+    print_cli_apply_step(
+        restart_context,
+        format!("Unpacking archive into {}...", unpack_dir.display()),
+    );
+    #[cfg(not(windows))]
+    unpack_tar_gz(&downloaded.archive_path, &unpack_dir)?;
+    #[cfg(windows)]
+    unpack_zip(&downloaded.archive_path, &unpack_dir)?;
+
+    #[cfg(not(windows))]
+    let extracted = find_extracted_binary(&unpack_dir)?;
+    #[cfg(windows)]
+    let extracted = find_extracted_binary_windows(&unpack_dir)?;
+
+    let current_exe = std::env::current_exe()
+        .map_err(|err| DnsError::runtime(format!("failed to resolve current exe: {err}")))?;
+    fs::create_dir_all(&config.backup_dir)?;
+    let ts = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+    #[cfg(not(windows))]
+    let backup_path = config.backup_dir.join(format!("oxidns-{}-{}", VERSION, ts));
+    #[cfg(windows)]
+    let backup_path = config
+        .backup_dir
+        .join(format!("oxidns-{}-{}.exe", VERSION, ts));
+
+    print_cli_apply_step(
+        restart_context,
+        format!("Creating backup at {}...", backup_path.display()),
+    );
+    print_cli_apply_step(
+        restart_context,
+        format!("Replacing binary at {}...", current_exe.display()),
+    );
+    #[cfg(not(windows))]
     {
-        print_cli_apply_step(restart_context, "Acquiring upgrade lock...");
-        let lock_path = config.cache_dir.join(".upgrade.lock");
-        fs::create_dir_all(&config.cache_dir)?;
-        let lock_file = File::create(&lock_path).map_err(|err| {
-            DnsError::runtime(format!(
-                "failed to create upgrade lock '{}': {}",
-                lock_path.display(),
-                err
-            ))
-        })?;
-        lock_file.try_lock_exclusive().map_err(|err| {
-            DnsError::runtime(format!("another upgrade appears to be running: {err}"))
-        })?;
-
-        print_cli_apply_step(
-            restart_context,
-            "Downloading archive and verifying GitHub asset digest...",
-        );
-        let progress_reporter = UpgradeDownloadProgressReporter::new(restart_context);
-        let downloaded = download(config, move |progress| {
-            progress_reporter.report(progress);
-        })
-        .await?;
-        print_cli_apply_step(
-            restart_context,
-            format!(
-                "Archive ready: {} (sha256 {})",
-                downloaded.archive_path.display(),
-                downloaded.sha256
-            ),
-        );
-        if !downloaded.asset_name.ends_with(".tar.gz") {
-            return Err(DnsError::runtime(format!(
-                "upgrade apply requires a .tar.gz asset, got '{}'",
-                downloaded.asset_name
-            )));
-        }
-
-        let unpack_dir = config.cache_dir.join(format!(
-            ".unpack-{}",
-            SystemTime::now()
-                .duration_since(UNIX_EPOCH)
-                .unwrap_or_default()
-                .as_secs()
-        ));
-        if unpack_dir.exists() {
-            fs::remove_dir_all(&unpack_dir)?;
-        }
-        fs::create_dir_all(&unpack_dir)?;
-        print_cli_apply_step(
-            restart_context,
-            format!("Unpacking archive into {}...", unpack_dir.display()),
-        );
-        unpack_tar_gz(&downloaded.archive_path, &unpack_dir)?;
-
-        let extracted = find_extracted_binary(&unpack_dir)?;
-        let current_exe = std::env::current_exe()
-            .map_err(|err| DnsError::runtime(format!("failed to resolve current exe: {err}")))?;
-        fs::create_dir_all(&config.backup_dir)?;
-        let backup_path = config.backup_dir.join(format!(
-            "oxidns-{}-{}",
-            VERSION,
-            SystemTime::now()
-                .duration_since(UNIX_EPOCH)
-                .unwrap_or_default()
-                .as_secs()
-        ));
-
-        print_cli_apply_step(
-            restart_context,
-            format!("Creating backup at {}...", backup_path.display()),
-        );
         fs::copy(&current_exe, &backup_path).map_err(|err| {
             DnsError::runtime(format!(
                 "failed to create binary backup '{}': {}",
@@ -458,64 +477,63 @@ async fn apply_unchecked(
                 err
             ))
         })?;
-
-        print_cli_apply_step(
-            restart_context,
-            format!("Replacing binary at {}...", current_exe.display()),
-        );
         if let Err(err) = replace_binary(&extracted, &current_exe) {
             let _ = fs::copy(&backup_path, &current_exe);
             return Err(err);
         }
-        print_cli_apply_step(restart_context, "Binary replacement completed.");
-
-        let (webui_path, webui_backup_path) = if config.skip_webui {
-            print_cli_apply_step(restart_context, "Skipping WebUI upgrade (--skip-webui).");
-            (None, None)
-        } else {
-            match find_extracted_webui(&unpack_dir) {
-                None => {
-                    print_cli_apply_step(
-                        restart_context,
-                        "Archive contains no webui directory; skipping WebUI upgrade.",
-                    );
-                    (None, None)
-                }
-                Some(src) => {
-                    print_cli_apply_step(
-                        restart_context,
-                        format!("Installing WebUI into {}...", config.webui_dir.display()),
-                    );
-                    let (path, backup) = replace_webui(
-                        &src,
-                        &config.webui_dir,
-                        &config.backup_dir,
-                        &downloaded.version,
-                    )?;
-                    print_cli_apply_step(restart_context, "WebUI upgrade completed.");
-                    (Some(path), backup)
-                }
-            }
-        };
-
-        if config.cleanup_after_apply {
-            let _ = cleanup_upgrade_artifacts(config);
-        }
-
-        if config.restart == RestartMode::Service {
-            print_cli_apply_step(restart_context, "Restarting installed service...");
-            restart_after_apply(restart_context)?;
-        }
-
-        Ok(ApplyOutcome {
-            installed_version: downloaded.version,
-            asset_name: downloaded.asset_name,
-            backup_path,
-            binary_path: current_exe,
-            webui_path,
-            webui_backup_path,
-        })
     }
+    // Windows: rename running exe to backup then place new binary at original path.
+    // replace_binary_windows() handles backup creation and rollback atomically.
+    #[cfg(windows)]
+    replace_binary_windows(&extracted, &current_exe, &backup_path)?;
+    print_cli_apply_step(restart_context, "Binary replacement completed.");
+
+    let (webui_path, webui_backup_path) = if config.skip_webui {
+        print_cli_apply_step(restart_context, "Skipping WebUI upgrade (--skip-webui).");
+        (None, None)
+    } else {
+        match find_extracted_webui(&unpack_dir) {
+            None => {
+                print_cli_apply_step(
+                    restart_context,
+                    "Archive contains no webui directory; skipping WebUI upgrade.",
+                );
+                (None, None)
+            }
+            Some(src) => {
+                print_cli_apply_step(
+                    restart_context,
+                    format!("Installing WebUI into {}...", config.webui_dir.display()),
+                );
+                let (path, backup) = replace_webui(
+                    &src,
+                    &config.webui_dir,
+                    &config.backup_dir,
+                    &downloaded.version,
+                )?;
+                print_cli_apply_step(restart_context, "WebUI upgrade completed.");
+                (Some(path), backup)
+            }
+        }
+    };
+
+    if config.cleanup_after_apply {
+        let _ = cleanup_upgrade_artifacts(config);
+    }
+
+    if config.restart == RestartMode::Service {
+        print_cli_apply_step(restart_context, "Restarting installed service...");
+        restart_after_apply(restart_context)?;
+    }
+
+    Ok(ApplyOutcome {
+        installed_version: downloaded.version,
+        asset_name: downloaded.asset_name,
+        backup_path,
+        binary_path: current_exe,
+        webui_path,
+        webui_backup_path,
+    })
 }
 
 #[derive(Clone)]
@@ -668,12 +686,99 @@ fn print_cli_apply_step(restart_context: UpgradeContext, message: impl AsRef<str
     }
 }
 
-#[cfg(not(windows))]
 fn restart_after_apply(restart_context: UpgradeContext) -> Result<()> {
     match restart_context {
+        // CLI is a separate process; ask the platform service manager to restart
+        // the running daemon.
         UpgradeContext::Cli => service::restart_installed_service(),
-        UpgradeContext::Plugin => std::process::exit(EXIT_RESTART_REQUIRED),
+        // Plugin runs inside the server process: signal the main event loop to
+        // do a graceful shutdown + exec_restart(), which loads the new binary
+        // already on disk. Fall back to exit(75) if the controller is gone.
+        UpgradeContext::Plugin => {
+            crate::plugin::request_app_restart()
+                .unwrap_or_else(|_| std::process::exit(EXIT_RESTART_REQUIRED));
+            Ok(())
+        }
     }
+}
+
+#[cfg(windows)]
+fn unpack_zip(archive: &std::path::Path, out_dir: &std::path::Path) -> Result<()> {
+    use std::io::Read as _;
+    let file = File::open(archive).map_err(|e| {
+        DnsError::runtime(format!("failed to open zip '{}': {e}", archive.display()))
+    })?;
+    let mut zip = zip::ZipArchive::new(file)
+        .map_err(|e| DnsError::runtime(format!("failed to read zip archive: {e}")))?;
+    for i in 0..zip.len() {
+        let mut entry = zip
+            .by_index(i)
+            .map_err(|e| DnsError::runtime(format!("failed to access zip entry {i}: {e}")))?;
+        if entry.is_dir() {
+            continue;
+        }
+        let dest = out_dir.join(entry.name());
+        if let Some(parent) = dest.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        let mut out = File::create(&dest).map_err(|e| {
+            DnsError::runtime(format!("failed to create '{}': {e}", dest.display()))
+        })?;
+        std::io::copy(&mut entry, &mut out)
+            .map_err(|e| DnsError::runtime(format!("failed to extract '{}': {e}", entry.name())))?;
+    }
+    Ok(())
+}
+
+#[cfg(windows)]
+fn find_extracted_binary_windows(unpack_dir: &std::path::Path) -> Result<PathBuf> {
+    let candidate = unpack_dir.join("oxidns.exe");
+    if candidate.is_file() {
+        return Ok(candidate);
+    }
+    Err(DnsError::runtime(format!(
+        "archive did not contain oxidns.exe at '{}'",
+        candidate.display()
+    )))
+}
+
+/// Windows binary replacement using the rename trick.
+///
+/// Windows prevents overwriting a running executable but allows renaming it.
+/// This function stages the new binary first, renames the running exe to the
+/// backup path, then moves the staged binary to the original path.
+/// `current_exe()` returns the original path even after the rename, so
+/// `exec_restart()` naturally loads the new binary on its next spawn.
+#[cfg(windows)]
+fn replace_binary_windows(source: &Path, target: &Path, backup_path: &Path) -> Result<()> {
+    if let Some(parent) = backup_path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    let staging = target.with_extension("upgrade-new.exe");
+    fs::copy(source, &staging).map_err(|e| {
+        DnsError::runtime(format!(
+            "failed to stage new binary '{}': {e}",
+            staging.display()
+        ))
+    })?;
+    // Rename the running exe to backup (allowed by Windows even while running).
+    if let Err(e) = fs::rename(target, backup_path) {
+        let _ = fs::remove_file(&staging);
+        return Err(DnsError::runtime(format!(
+            "failed to move running binary to backup '{}': {e}",
+            backup_path.display()
+        )));
+    }
+    // Move staged binary to the original path.
+    if let Err(e) = fs::rename(&staging, target) {
+        let _ = fs::rename(backup_path, target); // attempt rollback
+        let _ = fs::remove_file(&staging);
+        return Err(DnsError::runtime(format!(
+            "failed to place new binary at '{}': {e}",
+            target.display()
+        )));
+    }
+    Ok(())
 }
 
 async fn fetch_release(config: &UpgradeConfig) -> Result<GitHubRelease> {
@@ -693,10 +798,8 @@ async fn fetch_release(config: &UpgradeConfig) -> Result<GitHubRelease> {
     let response = timeout(
         config.timeout,
         client.get_request(
-            HttpRequestOptions::from_url(url.as_str()).with_headers(vec![(
-                USER_AGENT,
-                HeaderValue::from_static(GITHUB_USER_AGENT),
-            )]),
+            HttpRequestOptions::from_url(url.as_str())
+                .with_headers(github_request_headers(config.github_token.as_deref())),
         ),
     )
     .await
@@ -711,6 +814,16 @@ async fn fetch_release(config: &UpgradeConfig) -> Result<GitHubRelease> {
         )));
     }
     Ok(release)
+}
+
+fn github_request_headers(token: Option<&str>) -> Vec<(http::header::HeaderName, HeaderValue)> {
+    let mut headers = vec![(USER_AGENT, HeaderValue::from_static(GITHUB_USER_AGENT))];
+    if let Some(token) = token
+        && let Ok(value) = HeaderValue::try_from(format!("Bearer {token}"))
+    {
+        headers.push((AUTHORIZATION, value));
+    }
+    headers
 }
 
 fn build_asset_http_client(config: &UpgradeConfig) -> Result<HttpClient> {
@@ -897,16 +1010,12 @@ fn replace_binary(source: &Path, target: &Path) -> Result<()> {
     })
 }
 
-#[cfg(not(windows))]
 fn find_extracted_webui(unpack_dir: &Path) -> Option<PathBuf> {
     let candidate = unpack_dir.join("webui");
     candidate.is_dir().then_some(candidate)
 }
 
-/// Recursively copies a directory tree using std only. The Next.js static
-/// export contains no symlinks, so files are copied by content; `fs::copy`
-/// preserves Unix permission bits.
-#[cfg(not(windows))]
+/// Recursively copies a directory tree using std only.
 fn copy_dir_all(src: &Path, dst: &Path) -> std::io::Result<()> {
     fs::create_dir_all(dst)?;
     for entry in fs::read_dir(src)? {
@@ -924,7 +1033,6 @@ fn copy_dir_all(src: &Path, dst: &Path) -> std::io::Result<()> {
 
 /// Moves a directory, falling back to a recursive copy when the source and
 /// destination live on different filesystems.
-#[cfg(not(windows))]
 fn move_dir(from: &Path, to: &Path) -> std::io::Result<()> {
     match fs::rename(from, to) {
         Ok(()) => Ok(()),
@@ -949,7 +1057,6 @@ fn move_dir(from: &Path, to: &Path) -> std::io::Result<()> {
 ///
 /// Returns `(installed_path, backup_path)`; `backup_path` is `None` on a fresh
 /// install where `target` did not previously exist.
-#[cfg(not(windows))]
 fn replace_webui(
     unpacked_webui: &Path,
     target: &Path,

--- a/webui/app/(console)/settings/page.tsx
+++ b/webui/app/(console)/settings/page.tsx
@@ -58,7 +58,8 @@ export default function SettingsPage() {
   const applyConfig = useAppStore((s) => s.applyConfig);
   const loadConfig = useAppStore((s) => s.loadConfig);
   const isConfigSaving = useAppStore((s) => s.isConfigSaving);
-  const isApplying = useAppStore((s) => s.isApplying);
+  const isRestarting = useAppStore((s) => s.isRestarting);
+  const restartApp = useAppStore((s) => s.restartApp);
 
   const [backendUrl, setBackendUrl] = useState(serverConfig.url);
   const [requiresAuth, setRequiresAuth] = useState(serverConfig.requiresAuth);
@@ -409,17 +410,20 @@ export default function SettingsPage() {
               <div className="flex flex-wrap gap-2">
                 <Button
                   onClick={() => handleSaveTopLevelConfig(false)}
-                  disabled={isConfigSaving || isApplying || !isConnected}
+                  disabled={isConfigSaving || isRestarting || !isConnected}
                 >
                   保存配置
                 </Button>
                 <Button
                   variant="outline"
-                  onClick={() => handleSaveTopLevelConfig(true)}
-                  disabled={isConfigSaving || isApplying || !isConnected}
+                  onClick={async () => {
+                    await handleSaveTopLevelConfig(false);
+                    await restartApp();
+                  }}
+                  disabled={isConfigSaving || isRestarting || !isConnected}
                 >
                   <RefreshCw className="h-4 w-4 mr-1.5" />
-                  保存并应用
+                  {isRestarting ? "重启中…" : "保存并重启"}
                 </Button>
               </div>
             </CardContent>
@@ -627,17 +631,20 @@ export default function SettingsPage() {
               <div className="flex flex-wrap gap-2">
                 <Button
                   onClick={() => handleSaveTopLevelConfig(false)}
-                  disabled={isConfigSaving || isApplying || !isConnected}
+                  disabled={isConfigSaving || isRestarting || !isConnected}
                 >
                   保存配置
                 </Button>
                 <Button
                   variant="outline"
-                  onClick={() => handleSaveTopLevelConfig(true)}
-                  disabled={isConfigSaving || isApplying || !isConnected}
+                  onClick={async () => {
+                    await handleSaveTopLevelConfig(false);
+                    await restartApp();
+                  }}
+                  disabled={isConfigSaving || isRestarting || !isConnected}
                 >
                   <RefreshCw className="h-4 w-4 mr-1.5" />
-                  保存并应用
+                  {isRestarting ? "重启中…" : "保存并重启"}
                 </Button>
               </div>
             </CardContent>
@@ -727,17 +734,20 @@ export default function SettingsPage() {
               <div className="flex flex-wrap gap-2">
                 <Button
                   onClick={() => handleSaveTopLevelConfig(false)}
-                  disabled={isConfigSaving || isApplying || !isConnected}
+                  disabled={isConfigSaving || isRestarting || !isConnected}
                 >
                   保存配置
                 </Button>
                 <Button
                   variant="outline"
-                  onClick={() => handleSaveTopLevelConfig(true)}
-                  disabled={isConfigSaving || isApplying || !isConnected}
+                  onClick={async () => {
+                    await handleSaveTopLevelConfig(false);
+                    await restartApp();
+                  }}
+                  disabled={isConfigSaving || isRestarting || !isConnected}
                 >
                   <RefreshCw className="h-4 w-4 mr-1.5" />
-                  保存并应用
+                  {isRestarting ? "重启中…" : "保存并重启"}
                 </Button>
               </div>
             </CardContent>

--- a/webui/components/config/config-sync-status.tsx
+++ b/webui/components/config/config-sync-status.tsx
@@ -9,6 +9,7 @@ import {
   GitCompare,
   Undo2,
   RefreshCw,
+  Power,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Spinner } from "@/components/ui/spinner";
@@ -24,6 +25,16 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
 import { useAppStore } from "@/lib/store";
 import { useAuthStore } from "@/lib/auth-store";
 import type { ConfigSnapshot } from "@/lib/config-history";
@@ -109,6 +120,8 @@ const PILL_TONE: Record<"warning" | "destructive", string> = {
 export function ConfigSyncControl() {
   const isConnected = useAuthStore((s) => s.isConnected);
   const applyConfig = useAppStore((s) => s.applyConfig);
+  const restartApp = useAppStore((s) => s.restartApp);
+  const isRestarting = useAppStore((s) => s.isRestarting);
   const restoreSnapshot = useAppStore((s) => s.restoreSnapshot);
   const saveConfig = useAppStore((s) => s.saveConfig);
   const setHistoryOpen = useAppStore((s) => s.setHistoryOpen);
@@ -117,6 +130,7 @@ export function ConfigSyncControl() {
   const { state, label, tone, lastGood } = useConfigSyncStatus();
 
   const [diffOpen, setDiffOpen] = useState(false);
+  const [restartConfirmOpen, setRestartConfirmOpen] = useState(false);
 
   if (!isConnected) return null;
 
@@ -125,6 +139,15 @@ export function ConfigSyncControl() {
       await applyConfig();
     } catch {
       // Surfaced via the snapshot status (red pill + label).
+    }
+  };
+
+  const handleRestart = async () => {
+    try {
+      await restartApp();
+    } catch {
+      // The store surfaces failures via toast/console; UI state recovers via
+      // pollReconnect timing out.
     }
   };
 
@@ -171,7 +194,17 @@ export function ConfigSyncControl() {
         disabled
       >
         <Spinner className="h-3.5 w-3.5" />
-        应用中
+        {isRestarting ? "重启中" : "应用中"}
+      </Button>
+    ) : isRestarting ? (
+      <Button
+        variant="outline"
+        size="sm"
+        className="h-7 gap-1.5 rounded-md px-2.5"
+        disabled
+      >
+        <Spinner className="h-3.5 w-3.5" />
+        重启中
       </Button>
     ) : (
       <Tooltip>
@@ -235,11 +268,23 @@ export function ConfigSyncControl() {
             )}
             <DropdownMenuSeparator />
             <DropdownMenuItem
-              disabled={state === "applying" || state === "error"}
+              disabled={state === "applying" || state === "error" || isRestarting}
               onClick={handleApply}
             >
               <RefreshCw className="h-4 w-4" />
               重载当前配置
+            </DropdownMenuItem>
+            <DropdownMenuItem
+              disabled={state === "applying" || isRestarting}
+              onClick={(event) => {
+                // Prevent the menu's default focus-restore so the AlertDialog
+                // can take focus cleanly after the menu closes.
+                event.preventDefault();
+                setRestartConfirmOpen(true);
+              }}
+            >
+              <Power className="h-4 w-4" />
+              重启服务
             </DropdownMenuItem>
           </DropdownMenuContent>
         </DropdownMenu>
@@ -255,6 +300,26 @@ export function ConfigSyncControl() {
           modifiedTitle="待应用（当前配置）"
         />
       )}
+
+      <AlertDialog
+        open={restartConfirmOpen}
+        onOpenChange={setRestartConfirmOpen}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>重启 OxiDNS 服务？</AlertDialogTitle>
+            <AlertDialogDescription>
+              将以新进程替换正在运行的服务。期间 DNS 解析会短暂中断，所有内存中的状态（如缓存）将被清空。配置会先保存到磁盘再触发重启。
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>取消</AlertDialogCancel>
+            <AlertDialogAction onClick={handleRestart}>
+              确认重启
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </>
   );
 }

--- a/webui/lib/oxidns-api.ts
+++ b/webui/lib/oxidns-api.ts
@@ -383,6 +383,14 @@ export async function requestReload(): Promise<void> {
   await readJsonResponse<unknown>(response);
 }
 
+export async function requestRestart(): Promise<void> {
+  const response = await fetch(apiUrl("/restart"), {
+    method: "POST",
+    headers: apiHeaders(),
+  });
+  await readJsonResponse<unknown>(response);
+}
+
 export async function fetchCacheEntries(
   tag: string,
   options: { limit?: number; cursor?: string; qname?: string } = {},

--- a/webui/lib/store.ts
+++ b/webui/lib/store.ts
@@ -19,6 +19,7 @@ import {
   fetchReloadStatus,
   fetchSystem,
   requestReload,
+  requestRestart,
   saveConfigFile,
   validateConfigText,
   type ConfigFileResponse,
@@ -61,6 +62,7 @@ interface AppState {
   isConfigLoading: boolean;
   isConfigSaving: boolean;
   isApplying: boolean;
+  isRestarting: boolean;
   configModel: OxiDnsConfig;
   configText: string;
   configVersion: string | null;
@@ -87,6 +89,7 @@ interface AppState {
   validateCurrentConfig: () => Promise<void>;
   saveConfig: () => Promise<void>;
   applyConfig: () => Promise<void>;
+  restartApp: () => Promise<void>;
   restoreSnapshot: (id: string) => void;
   rollbackToSnapshot: (id: string) => Promise<void>;
   deleteConfigSnapshot: (id: string) => void;
@@ -121,6 +124,7 @@ export const useAppStore = create<AppState>((set, get) => ({
   isConfigLoading: false,
   isConfigSaving: false,
   isApplying: false,
+  isRestarting: false,
   configModel: initialConfigModel,
   configText: initialConfigText,
   configVersion: null,
@@ -377,6 +381,22 @@ export const useAppStore = create<AppState>((set, get) => ({
     }
   },
 
+  // Save the current config to disk and restart the server process. After the
+  // restart request is accepted the client polls the health endpoint until the
+  // old process has stopped and the new one has come back up, then reloads
+  // the config from the fresh process.
+  restartApp: async () => {
+    set({ isRestarting: true });
+    try {
+      await get().saveConfig();
+      await requestRestart();
+      await pollReconnect();
+      await get().loadConfig();
+    } finally {
+      set({ isRestarting: false });
+    }
+  },
+
   // Load a historical snapshot back into the editor only. It is NOT persisted
   // or applied — the operator still goes through 保存 → 应用, so a rollback
   // also produces its own history entry.
@@ -591,6 +611,38 @@ function pluginCountOf(text: string): number {
 
 function delay(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+// Wait for the server to go down and then come back up after a restart request.
+// Phase 1: poll until health fails (process stopped, max 30s).
+// Phase 2: poll until health succeeds (new process ready, max 60s).
+// Throws if either phase times out.
+async function pollReconnect(): Promise<void> {
+  // Phase 1: wait for the old process to shut down
+  const downDeadline = Date.now() + 30_000;
+  while (Date.now() < downDeadline) {
+    await delay(800);
+    try {
+      await fetchHealth();
+      // Still up — keep waiting
+    } catch {
+      break; // Process is down, move to phase 2
+    }
+  }
+
+  // Phase 2: wait for the new process to come up
+  const upDeadline = Date.now() + 60_000;
+  while (Date.now() < upDeadline) {
+    await delay(1500);
+    try {
+      await fetchHealth();
+      return; // New process is up
+    } catch {
+      // Not yet up, keep polling
+    }
+  }
+
+  throw new Error("重启超时，请刷新页面后手动重新连接");
 }
 
 // Poll the reload status until the backend settles on a new completion.


### PR DESCRIPTION
- New restart pipeline: ControlCommand::Restart, AppController::request_restart, POST /restart, and plugin request_app_restart converge on exec_restart (Unix execvp preserves PID; Windows foreground spawns + exits; Windows SCM exits with code 1 to trigger the OnFailure restart policy).
- upgrade apply now restarts the installed service by default; the old --restart <none|service> flag becomes a --no-restart opt-out toggle, and CLI / plugin defaults are updated to match.
- Windows upgrade is now first-class: zip unpacking, rename-trick binary replacement with rollback, stale .upgrade-new.exe cleanup at startup, and shared WebUI install path (previously Unix-only).
- Add --github-token to the upgrade CLI and plugin config; both release lookup and asset download attach a Bearer Authorization header when set.
- WebUI: "保存并应用" → "保存并重启" in settings, plus a new "重启服务" entry in the top-right config-ops dropdown (with confirmation dialog); new restartApp store action with pollReconnect that waits for the old process to stop and the new one to come back up before reloading config.
- Docs (zh/en) updated for the new flags, default-restart behavior, and Windows upgrade support.