### PR TITLE
feat(query_recorder): add aggregate stats tab, charts, and tune query…

### DIFF
--- a/src/plugin/executor/query_recorder/api.rs
+++ b/src/plugin/executor/query_recorder/api.rs
@@ -14,16 +14,25 @@ use tokio::sync::broadcast;
 
 use super::backend::RecorderBackend;
 use super::model::{
-    ListCursor, ListQuery, PluginStatsKind, PluginStatsRow, PluginsStatsQuery, QueryRecordFilter,
-    QueryRecordStatus, RecordDetail, RecordRow,
+    DistributionQuery, LatencyQuery, ListCursor, ListQuery, PluginStatsKind, PluginStatsRow,
+    PluginsStatsQuery, QueryRecordFilter, QueryRecordStatus, RecordDetail, RecordRow,
+    TimeseriesBucket, TimeseriesQuery, TopQuery,
 };
-use super::store::{load_plugin_stats, load_record_detail, query_records};
+use super::store::{
+    load_latency_summary, load_plugin_stats, load_qtype_distribution, load_rcode_distribution,
+    load_record_detail, load_timeseries, load_top_clients, load_top_qnames, query_records,
+};
 use crate::api::{ApiHandler, json_error, json_ok, simple_response, streaming_response};
 use crate::core::error::Result;
 use crate::register_plugin_api;
 
 const DEFAULT_LIST_LIMIT: usize = 100;
 const MAX_LIST_LIMIT: usize = 500;
+const DEFAULT_TOP_LIMIT: usize = 20;
+const MAX_TOP_LIMIT: usize = 200;
+const DEFAULT_SLOW_LIMIT: usize = 20;
+const DEFAULT_TIMESERIES_BUCKETS: usize = 60;
+const MAX_TIMESERIES_BUCKETS: usize = 720;
 const SSE_HEARTBEAT_SECS: u64 = 15;
 
 #[derive(Debug, Clone, Serialize)]
@@ -64,6 +73,36 @@ struct StatsPluginsHandler {
 
 #[derive(Debug)]
 struct StreamHandler {
+    backend: Arc<RecorderBackend>,
+}
+
+#[derive(Debug)]
+struct TopClientsHandler {
+    backend: Arc<RecorderBackend>,
+}
+
+#[derive(Debug)]
+struct TopQnamesHandler {
+    backend: Arc<RecorderBackend>,
+}
+
+#[derive(Debug)]
+struct QtypeDistributionHandler {
+    backend: Arc<RecorderBackend>,
+}
+
+#[derive(Debug)]
+struct RcodeDistributionHandler {
+    backend: Arc<RecorderBackend>,
+}
+
+#[derive(Debug)]
+struct LatencyHandler {
+    backend: Arc<RecorderBackend>,
+}
+
+#[derive(Debug)]
+struct TimeseriesHandler {
     backend: Arc<RecorderBackend>,
 }
 
@@ -259,6 +298,150 @@ struct SseState {
     heartbeat: tokio::time::Interval,
 }
 
+#[async_trait]
+impl ApiHandler for TopClientsHandler {
+    async fn handle(&self, request: Request<Bytes>) -> crate::api::ApiResponse {
+        let query = match parse_top_query(request.uri().query()) {
+            Ok(query) => query,
+            Err(err) => return json_error(StatusCode::BAD_REQUEST, "invalid_query", err),
+        };
+        let backend = self.backend.clone();
+        match tokio::task::spawn_blocking(move || load_top_clients(backend, query)).await {
+            Ok(Ok(response)) => json_ok(StatusCode::OK, &response),
+            Ok(Err(err)) => json_error(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "query_recorder_top_clients_failed",
+                err.to_string(),
+            ),
+            Err(err) => json_error(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "query_recorder_top_clients_failed",
+                format!("blocking task failed: {err}"),
+            ),
+        }
+    }
+}
+
+#[async_trait]
+impl ApiHandler for TopQnamesHandler {
+    async fn handle(&self, request: Request<Bytes>) -> crate::api::ApiResponse {
+        let query = match parse_top_query(request.uri().query()) {
+            Ok(query) => query,
+            Err(err) => return json_error(StatusCode::BAD_REQUEST, "invalid_query", err),
+        };
+        let backend = self.backend.clone();
+        match tokio::task::spawn_blocking(move || load_top_qnames(backend, query)).await {
+            Ok(Ok(response)) => json_ok(StatusCode::OK, &response),
+            Ok(Err(err)) => json_error(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "query_recorder_top_qnames_failed",
+                err.to_string(),
+            ),
+            Err(err) => json_error(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "query_recorder_top_qnames_failed",
+                format!("blocking task failed: {err}"),
+            ),
+        }
+    }
+}
+
+#[async_trait]
+impl ApiHandler for QtypeDistributionHandler {
+    async fn handle(&self, request: Request<Bytes>) -> crate::api::ApiResponse {
+        let query = match parse_distribution_query(request.uri().query()) {
+            Ok(query) => query,
+            Err(err) => return json_error(StatusCode::BAD_REQUEST, "invalid_query", err),
+        };
+        let backend = self.backend.clone();
+        match tokio::task::spawn_blocking(move || load_qtype_distribution(backend, query)).await {
+            Ok(Ok(response)) => json_ok(StatusCode::OK, &response),
+            Ok(Err(err)) => json_error(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "query_recorder_qtype_failed",
+                err.to_string(),
+            ),
+            Err(err) => json_error(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "query_recorder_qtype_failed",
+                format!("blocking task failed: {err}"),
+            ),
+        }
+    }
+}
+
+#[async_trait]
+impl ApiHandler for RcodeDistributionHandler {
+    async fn handle(&self, request: Request<Bytes>) -> crate::api::ApiResponse {
+        let query = match parse_distribution_query(request.uri().query()) {
+            Ok(query) => query,
+            Err(err) => return json_error(StatusCode::BAD_REQUEST, "invalid_query", err),
+        };
+        let backend = self.backend.clone();
+        match tokio::task::spawn_blocking(move || load_rcode_distribution(backend, query)).await {
+            Ok(Ok(response)) => json_ok(StatusCode::OK, &response),
+            Ok(Err(err)) => json_error(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "query_recorder_rcode_failed",
+                err.to_string(),
+            ),
+            Err(err) => json_error(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "query_recorder_rcode_failed",
+                format!("blocking task failed: {err}"),
+            ),
+        }
+    }
+}
+
+#[async_trait]
+impl ApiHandler for LatencyHandler {
+    async fn handle(&self, request: Request<Bytes>) -> crate::api::ApiResponse {
+        let query = match parse_latency_query(request.uri().query()) {
+            Ok(query) => query,
+            Err(err) => return json_error(StatusCode::BAD_REQUEST, "invalid_query", err),
+        };
+        let backend = self.backend.clone();
+        match tokio::task::spawn_blocking(move || load_latency_summary(backend, query)).await {
+            Ok(Ok(response)) => json_ok(StatusCode::OK, &response),
+            Ok(Err(err)) => json_error(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "query_recorder_latency_failed",
+                err.to_string(),
+            ),
+            Err(err) => json_error(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "query_recorder_latency_failed",
+                format!("blocking task failed: {err}"),
+            ),
+        }
+    }
+}
+
+#[async_trait]
+impl ApiHandler for TimeseriesHandler {
+    async fn handle(&self, request: Request<Bytes>) -> crate::api::ApiResponse {
+        let query = match parse_timeseries_query(request.uri().query()) {
+            Ok(query) => query,
+            Err(err) => return json_error(StatusCode::BAD_REQUEST, "invalid_query", err),
+        };
+        let backend = self.backend.clone();
+        match tokio::task::spawn_blocking(move || load_timeseries(backend, query)).await {
+            Ok(Ok(response)) => json_ok(StatusCode::OK, &response),
+            Ok(Err(err)) => json_error(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "query_recorder_timeseries_failed",
+                err.to_string(),
+            ),
+            Err(err) => json_error(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "query_recorder_timeseries_failed",
+                format!("blocking task failed: {err}"),
+            ),
+        }
+    }
+}
+
 pub(super) fn parse_list_query(query: Option<&str>) -> std::result::Result<ListQuery, String> {
     let mut cursor = None;
     let mut limit = DEFAULT_LIST_LIMIT;
@@ -326,6 +509,147 @@ pub(super) fn parse_plugins_stats_query(
         kind,
         filter,
     })
+}
+
+pub(super) fn parse_top_query(query: Option<&str>) -> std::result::Result<TopQuery, String> {
+    let mut since_ms = None;
+    let mut until_ms = None;
+    let mut limit = DEFAULT_TOP_LIMIT;
+    let mut filter = QueryRecordFilter::default();
+    for (key, value) in url::form_urlencoded::parse(query.unwrap_or_default().as_bytes()) {
+        match key.as_ref() {
+            "since_ms" => since_ms = Some(parse_u64_query("since_ms", value.as_ref())?),
+            "until_ms" => until_ms = Some(parse_u64_query("until_ms", value.as_ref())?),
+            "limit" => limit = parse_top_limit(value.as_ref())?,
+            other => apply_filter_param(&mut filter, other, value.as_ref())?,
+        }
+    }
+    Ok(TopQuery {
+        since_ms,
+        until_ms,
+        filter,
+        limit,
+    })
+}
+
+pub(super) fn parse_distribution_query(
+    query: Option<&str>,
+) -> std::result::Result<DistributionQuery, String> {
+    let mut since_ms = None;
+    let mut until_ms = None;
+    let mut filter = QueryRecordFilter::default();
+    for (key, value) in url::form_urlencoded::parse(query.unwrap_or_default().as_bytes()) {
+        match key.as_ref() {
+            "since_ms" => since_ms = Some(parse_u64_query("since_ms", value.as_ref())?),
+            "until_ms" => until_ms = Some(parse_u64_query("until_ms", value.as_ref())?),
+            other => apply_filter_param(&mut filter, other, value.as_ref())?,
+        }
+    }
+    Ok(DistributionQuery {
+        since_ms,
+        until_ms,
+        filter,
+    })
+}
+
+pub(super) fn parse_latency_query(
+    query: Option<&str>,
+) -> std::result::Result<LatencyQuery, String> {
+    let mut since_ms = None;
+    let mut until_ms = None;
+    let mut slow_limit = DEFAULT_SLOW_LIMIT;
+    let mut filter = QueryRecordFilter::default();
+    for (key, value) in url::form_urlencoded::parse(query.unwrap_or_default().as_bytes()) {
+        match key.as_ref() {
+            "since_ms" => since_ms = Some(parse_u64_query("since_ms", value.as_ref())?),
+            "until_ms" => until_ms = Some(parse_u64_query("until_ms", value.as_ref())?),
+            "slow_limit" | "limit" => slow_limit = parse_top_limit(value.as_ref())?,
+            other => apply_filter_param(&mut filter, other, value.as_ref())?,
+        }
+    }
+    Ok(LatencyQuery {
+        since_ms,
+        until_ms,
+        filter,
+        slow_limit,
+    })
+}
+
+pub(super) fn parse_timeseries_query(
+    query: Option<&str>,
+) -> std::result::Result<TimeseriesQuery, String> {
+    let mut since_ms = None;
+    let mut until_ms = None;
+    let mut bucket = TimeseriesBucket::Minute;
+    let mut max_buckets = DEFAULT_TIMESERIES_BUCKETS;
+    let mut filter = QueryRecordFilter::default();
+    for (key, value) in url::form_urlencoded::parse(query.unwrap_or_default().as_bytes()) {
+        match key.as_ref() {
+            "since_ms" => since_ms = Some(parse_u64_query("since_ms", value.as_ref())?),
+            "until_ms" => until_ms = Some(parse_u64_query("until_ms", value.as_ref())?),
+            "bucket" => bucket = TimeseriesBucket::parse(value.as_ref())?,
+            "buckets" => max_buckets = parse_timeseries_buckets(value.as_ref())?,
+            other => apply_filter_param(&mut filter, other, value.as_ref())?,
+        }
+    }
+    Ok(TimeseriesQuery {
+        since_ms,
+        until_ms,
+        filter,
+        bucket,
+        max_buckets,
+    })
+}
+
+fn apply_filter_param(
+    filter: &mut QueryRecordFilter,
+    key: &str,
+    value: &str,
+) -> std::result::Result<(), String> {
+    match key {
+        "qname" => filter.qname = optional_text(value),
+        "qtype" => filter.qtype = optional_upper_text(value),
+        "client_ip" => filter.client_ip = optional_text(value),
+        "rcode" => filter.rcode = optional_upper_text(value),
+        "status" => {
+            if let Some(value) = optional_text(value) {
+                filter.status = QueryRecordStatus::parse(value.as_str())?;
+            }
+        }
+        "matcher_tag" => filter.matcher_tag = optional_text(value),
+        _ => {}
+    }
+    Ok(())
+}
+
+fn parse_top_limit(raw: &str) -> std::result::Result<usize, String> {
+    let parsed = raw
+        .parse::<usize>()
+        .map_err(|err| format!("invalid limit query parameter: {err}"))?;
+    if parsed == 0 {
+        return Err("limit must be greater than 0".to_string());
+    }
+    Ok(parsed.min(MAX_TOP_LIMIT))
+}
+
+fn parse_timeseries_buckets(raw: &str) -> std::result::Result<usize, String> {
+    let parsed = raw
+        .parse::<usize>()
+        .map_err(|err| format!("invalid buckets query parameter: {err}"))?;
+    if parsed == 0 {
+        return Err("buckets must be greater than 0".to_string());
+    }
+    Ok(parsed.min(MAX_TIMESERIES_BUCKETS))
+}
+
+impl TimeseriesBucket {
+    fn parse(raw: &str) -> std::result::Result<Self, String> {
+        match raw {
+            "minute" => Ok(Self::Minute),
+            "hour" => Ok(Self::Hour),
+            _ => Err("bucket must be one of minute, hour".to_string()),
+        }
+    }
 }
 
 fn parse_tail_param(query: Option<&str>, max_tail: usize) -> std::result::Result<usize, String> {
@@ -431,6 +755,24 @@ pub(super) fn register(backend: &Arc<RecorderBackend>) -> Result<()> {
             path_prefix: plugin_api.path("/records/")?,
         },
         GET "/stats/plugins" => StatsPluginsHandler {
+            backend: backend.clone(),
+        },
+        GET "/stats/top_clients" => TopClientsHandler {
+            backend: backend.clone(),
+        },
+        GET "/stats/top_qnames" => TopQnamesHandler {
+            backend: backend.clone(),
+        },
+        GET "/stats/qtype" => QtypeDistributionHandler {
+            backend: backend.clone(),
+        },
+        GET "/stats/rcode" => RcodeDistributionHandler {
+            backend: backend.clone(),
+        },
+        GET "/stats/latency" => LatencyHandler {
+            backend: backend.clone(),
+        },
+        GET "/stats/timeseries" => TimeseriesHandler {
             backend: backend.clone(),
         },
         GET "/stream" => StreamHandler {

--- a/src/plugin/executor/query_recorder/backend.rs
+++ b/src/plugin/executor/query_recorder/backend.rs
@@ -71,6 +71,12 @@ impl RecorderBackend {
 
         let tables = table_names(&tag);
         create_schema(&mut conn, &tables)?;
+        // Refresh query planner stats once at startup; this is the cheap
+        // version of ANALYZE and is the recommended way to keep indexes
+        // selectable across schema upgrades.
+        if let Err(err) = conn.execute_batch("PRAGMA optimize;") {
+            warn!("query_recorder PRAGMA optimize failed at startup: {}", err);
+        }
 
         let (queue_tx, queue_rx) = sync_channel(config.queue_size);
         let stop_requested = Arc::new(AtomicBool::new(false));

--- a/src/plugin/executor/query_recorder/model.rs
+++ b/src/plugin/executor/query_recorder/model.rs
@@ -193,3 +193,123 @@ pub(super) enum PluginStatsKind {
     Builtin,
     All,
 }
+
+#[derive(Debug, Clone, Serialize)]
+pub(super) struct TopBucketRow {
+    pub(super) key: String,
+    pub(super) count: u64,
+    pub(super) share: f64,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub(super) struct TopBucketsResponse {
+    pub(super) ok: bool,
+    pub(super) sample_size: u64,
+    pub(super) rows: Vec<TopBucketRow>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub(super) struct DistributionRow {
+    pub(super) key: String,
+    pub(super) count: u64,
+    pub(super) share: f64,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub(super) struct DistributionResponse {
+    pub(super) ok: bool,
+    pub(super) sample_size: u64,
+    pub(super) rows: Vec<DistributionRow>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub(super) struct LatencyHistogramBucket {
+    pub(super) lt_ms: Option<u64>,
+    pub(super) count: u64,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub(super) struct LatencySlowRow {
+    pub(super) qname: String,
+    pub(super) count: u64,
+    pub(super) avg_ms: f64,
+    pub(super) max_ms: u64,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub(super) struct LatencySummary {
+    pub(super) ok: bool,
+    pub(super) sample_size: u64,
+    pub(super) avg_ms: f64,
+    pub(super) p50_ms: u64,
+    pub(super) p95_ms: u64,
+    pub(super) p99_ms: u64,
+    pub(super) max_ms: u64,
+    pub(super) histogram: Vec<LatencyHistogramBucket>,
+    pub(super) slow_top: Vec<LatencySlowRow>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub(super) struct TimeseriesPoint {
+    pub(super) bucket_ms: i64,
+    pub(super) total: u64,
+    pub(super) error_count: u64,
+    pub(super) no_response_count: u64,
+    pub(super) avg_ms: f64,
+    pub(super) p95_ms: u64,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub(super) struct TimeseriesResponse {
+    pub(super) ok: bool,
+    pub(super) sample_size: u64,
+    pub(super) bucket_ms: i64,
+    pub(super) points: Vec<TimeseriesPoint>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum TimeseriesBucket {
+    Minute,
+    Hour,
+}
+
+impl TimeseriesBucket {
+    pub(super) fn millis(self) -> i64 {
+        match self {
+            Self::Minute => 60_000,
+            Self::Hour => 3_600_000,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(super) struct TopQuery {
+    pub(super) since_ms: Option<u64>,
+    pub(super) until_ms: Option<u64>,
+    pub(super) filter: QueryRecordFilter,
+    pub(super) limit: usize,
+}
+
+#[derive(Debug, Clone)]
+pub(super) struct DistributionQuery {
+    pub(super) since_ms: Option<u64>,
+    pub(super) until_ms: Option<u64>,
+    pub(super) filter: QueryRecordFilter,
+}
+
+#[derive(Debug, Clone)]
+pub(super) struct LatencyQuery {
+    pub(super) since_ms: Option<u64>,
+    pub(super) until_ms: Option<u64>,
+    pub(super) filter: QueryRecordFilter,
+    pub(super) slow_limit: usize,
+}
+
+#[derive(Debug, Clone)]
+pub(super) struct TimeseriesQuery {
+    pub(super) since_ms: Option<u64>,
+    pub(super) until_ms: Option<u64>,
+    pub(super) filter: QueryRecordFilter,
+    pub(super) bucket: TimeseriesBucket,
+    pub(super) max_buckets: usize,
+}

--- a/src/plugin/executor/query_recorder/store.rs
+++ b/src/plugin/executor/query_recorder/store.rs
@@ -609,6 +609,9 @@ pub(super) fn load_plugin_stats(
             ORDER BY r.created_at_ms DESC, r.id DESC
             LIMIT ?
          ),
+         totals AS (
+            SELECT COUNT(*) AS total_records FROM sample_records
+         ),
          step_agg AS (
             SELECT
                 s.kind,
@@ -634,14 +637,15 @@ pub(super) fn load_plugin_stats(
             GROUP BY s.kind, s.tag
          )
          SELECT
-            (SELECT COUNT(*) FROM sample_records) AS total_records,
+            totals.total_records,
             sa.kind,
             sa.tag,
             sa.checked,
             sa.matched,
             sa.executed,
             sa.query_hits
-         FROM step_agg sa
+         FROM totals
+         LEFT JOIN step_agg sa ON 1 = 1
          ORDER BY sa.kind ASC, sa.query_hits DESC, sa.tag ASC",
         steps = backend.tables.steps,
         records = backend.tables.records,

--- a/src/plugin/executor/query_recorder/store.rs
+++ b/src/plugin/executor/query_recorder/store.rs
@@ -15,8 +15,11 @@ use tokio::sync::broadcast;
 
 use super::backend::{RecorderBackend, WriterCommand, WriterThreadContext};
 use super::model::{
-    ListCursor, ListQuery, PendingRecord, PluginStatsKind, PluginStatsRow, PluginsStatsQuery,
-    QueryRecordFilter, QueryRecordStatus, RecordDetail, RecordRow, StepJson, TableNames,
+    DistributionQuery, DistributionResponse, DistributionRow, LatencyHistogramBucket, LatencyQuery,
+    LatencySlowRow, LatencySummary, ListCursor, ListQuery, PendingRecord, PluginStatsKind,
+    PluginStatsRow, PluginsStatsQuery, QueryRecordFilter, QueryRecordStatus, RecordDetail,
+    RecordRow, StepJson, TableNames, TimeseriesPoint, TimeseriesQuery, TimeseriesResponse,
+    TopBucketRow, TopBucketsResponse, TopQuery,
 };
 use crate::core::error::{DnsError, Result};
 
@@ -26,11 +29,24 @@ const PLUGIN_STATS_SAMPLE_LIMIT: usize = 10_000;
 
 pub(super) fn open_database(path: &Path) -> rusqlite::Result<Connection> {
     let conn = Connection::open(path)?;
+    // Tuned for a workload of "one writer + bursty readers".
+    // - WAL + synchronous=NORMAL is the standard high-throughput combo for the
+    //   writer thread and keeps readers non-blocking.
+    // - temp_store=MEMORY keeps the implicit temp tables that GROUP BY / ORDER BY /
+    //   DISTINCT create off the disk on every aggregation query.
+    // - cache_size=-32768 = 32 MiB per connection (negative means KiB). The stats
+    //   endpoints repeatedly hit the same recent rows, so the cache amortizes
+    //   cleanly across read connections.
+    // - mmap_size lets SQLite memory-map the DB pages, which is a noticeable
+    //   speedup for read-heavy SELECTs once the OS page cache is warm.
     conn.execute_batch(
         "PRAGMA journal_mode=WAL;
          PRAGMA synchronous=NORMAL;
          PRAGMA foreign_keys=ON;
-         PRAGMA auto_vacuum=INCREMENTAL;",
+         PRAGMA auto_vacuum=INCREMENTAL;
+         PRAGMA temp_store=MEMORY;
+         PRAGMA cache_size=-32768;
+         PRAGMA mmap_size=134217728;",
     )?;
     Ok(conn)
 }
@@ -117,7 +133,20 @@ pub(crate) fn create_schema(conn: &mut Connection, tables: &TableNames) -> rusql
         CREATE INDEX IF NOT EXISTS {records}_client_ip_idx ON {records}(client_ip);
         CREATE INDEX IF NOT EXISTS {records}_rcode_idx ON {records}(rcode);
         CREATE INDEX IF NOT EXISTS {steps}_kind_tag_outcome_idx ON {steps}(kind, tag, outcome);
-        CREATE INDEX IF NOT EXISTS {steps}_record_id_idx ON {steps}(record_id);",
+        CREATE INDEX IF NOT EXISTS {steps}_record_id_idx ON {steps}(record_id);
+        -- Covering index for the matcher_tag EXISTS subquery used by /records
+        -- and /stats endpoints. Without record_id in the index tail SQLite
+        -- has to do a second lookup per candidate, which makes rapid
+        -- matcher-click filtering pile up in the blocking pool.
+        CREATE INDEX IF NOT EXISTS {steps}_matcher_lookup_idx
+            ON {steps}(kind, tag, outcome, record_id);
+        -- Speeds up `/stats/plugins` style JOINs which find `s.record_id = r.id
+        -- AND s.kind = ?`. With only the single-column record_id index the
+        -- planner reads every step for that record and filters by kind in
+        -- memory; the (record_id, kind) prefix turns that into a covered
+        -- range lookup.
+        CREATE INDEX IF NOT EXISTS {steps}_record_kind_idx
+            ON {steps}(record_id, kind);",
         records = tables.records,
         steps = tables.steps,
     ))
@@ -557,15 +586,21 @@ pub(super) fn load_plugin_stats(
         &query.filter,
     )?;
     let where_sql = join_clauses(&clauses);
-    let kind_join_filter = if query.kind == PluginStatsKind::All {
+    // Applied in the step_agg WHERE clause so SQLite can use the
+    // (kind, tag, outcome, record_id) covering index with a leading
+    // kind= equality rather than a per-record nested lookup.
+    let kind_where_filter = if query.kind == PluginStatsKind::All {
         String::new()
     } else {
-        " AND s.kind = ?".to_string()
+        "AND s.kind = ?".to_string()
     };
     params.push(Value::Integer(PLUGIN_STATS_SAMPLE_LIMIT as i64));
     if query.kind != PluginStatsKind::All {
         params.push(Value::Text(query.kind.sql_value().to_string()));
     }
+    // Restructured from a cross-join (sample_count × sample_records × steps)
+    // to an IN-subquery so SQLite aggregates steps directly without producing
+    // a 10k-row intermediate for every API call.
     let sql = format!(
         "WITH sample_records AS (
             SELECT r.id
@@ -574,41 +609,49 @@ pub(super) fn load_plugin_stats(
             ORDER BY r.created_at_ms DESC, r.id DESC
             LIMIT ?
          ),
-         sample_count AS (
-            SELECT COUNT(*) AS total_records FROM sample_records
+         step_agg AS (
+            SELECT
+                s.kind,
+                s.tag,
+                SUM(CASE
+                    WHEN s.kind = 'matcher'
+                     AND s.outcome IN ('matched', 'not_matched') THEN 1
+                    ELSE 0
+                END) AS checked,
+                SUM(CASE
+                    WHEN s.kind = 'matcher' AND s.outcome = 'matched' THEN 1
+                    ELSE 0
+                END) AS matched,
+                SUM(CASE
+                    WHEN s.kind = 'executor' AND s.outcome = 'entered' THEN 1
+                    WHEN s.kind = 'builtin' THEN 1
+                    ELSE 0
+                END) AS executed,
+                COUNT(DISTINCT s.record_id) AS query_hits
+            FROM {steps} s
+            WHERE s.record_id IN (SELECT id FROM sample_records)
+            {kind_where_filter}
+            GROUP BY s.kind, s.tag
          )
          SELECT
-            sample_count.total_records,
-            s.kind,
-            s.tag,
-            COALESCE(SUM(CASE
-                WHEN s.kind = 'matcher' AND s.outcome IN ('matched', 'not_matched') THEN 1
-                ELSE 0
-            END), 0) AS checked,
-            COALESCE(SUM(CASE
-                WHEN s.kind = 'matcher' AND s.outcome = 'matched' THEN 1
-                ELSE 0
-            END), 0) AS matched,
-            COALESCE(SUM(CASE
-                WHEN s.kind = 'executor' AND s.outcome = 'entered' THEN 1
-                WHEN s.kind = 'builtin' THEN 1
-                ELSE 0
-            END), 0) AS executed,
-            COUNT(DISTINCT s.record_id) AS query_hits
-         FROM sample_count
-         LEFT JOIN sample_records r ON 1 = 1
-         LEFT JOIN {steps} s ON s.record_id = r.id{kind_join_filter}
-         GROUP BY sample_count.total_records, s.kind, s.tag
-         ORDER BY s.kind ASC, query_hits DESC, s.tag ASC",
+            (SELECT COUNT(*) FROM sample_records) AS total_records,
+            sa.kind,
+            sa.tag,
+            sa.checked,
+            sa.matched,
+            sa.executed,
+            sa.query_hits
+         FROM step_agg sa
+         ORDER BY sa.kind ASC, sa.query_hits DESC, sa.tag ASC",
         steps = backend.tables.steps,
         records = backend.tables.records,
-        kind_join_filter = kind_join_filter
+        kind_where_filter = kind_where_filter
     );
 
     let mut stmt = conn.prepare(&sql)?;
     let mut rows = stmt.query(params_from_iter(params))?;
 
-    let mut total_records = 0;
+    let mut total_records = 0u64;
     let mut stats = Vec::new();
     while let Some(row) = rows.next()? {
         total_records = row.get::<_, i64>(0).and_then(non_negative_u64)?;
@@ -636,6 +679,526 @@ pub(super) fn load_plugin_stats(
     Ok((total_records, stats))
 }
 
+pub(super) fn load_top_clients(
+    backend: Arc<RecorderBackend>,
+    query: TopQuery,
+) -> std::result::Result<TopBucketsResponse, DnsError> {
+    let conn = open_database(&backend.path)?;
+    let (clauses, mut params) = record_filter_clauses(
+        "r",
+        &backend.tables,
+        query.since_ms,
+        query.until_ms,
+        &query.filter,
+    )?;
+    let where_sql = join_clauses(&clauses);
+    params.push(Value::Integer(PLUGIN_STATS_SAMPLE_LIMIT as i64));
+    let limit = top_limit(query.limit);
+    params.push(Value::Integer(limit as i64));
+
+    let sql = format!(
+        "WITH sample_records AS (
+            SELECT r.id, r.client_ip
+            FROM {records} r
+            WHERE {where_sql}
+            ORDER BY r.created_at_ms DESC, r.id DESC
+            LIMIT ?
+         ),
+         totals AS (
+            SELECT COUNT(*) AS sample_size FROM sample_records
+         )
+         SELECT totals.sample_size, sample_records.client_ip, COUNT(*) AS count
+         FROM totals
+         LEFT JOIN sample_records ON 1 = 1
+         GROUP BY totals.sample_size, sample_records.client_ip
+         ORDER BY count DESC, sample_records.client_ip ASC
+         LIMIT ?",
+        records = backend.tables.records,
+    );
+
+    let mut stmt = conn.prepare(&sql)?;
+    let mut rows = stmt.query(params_from_iter(params))?;
+    let mut sample_size = 0u64;
+    let mut bucket_rows: Vec<TopBucketRow> = Vec::new();
+    while let Some(row) = rows.next()? {
+        sample_size = row.get::<_, i64>(0).and_then(non_negative_u64)?;
+        let Some(client_ip) = row.get::<_, Option<String>>(1)? else {
+            continue;
+        };
+        let count = row.get::<_, i64>(2).and_then(non_negative_u64)?;
+        let share = bucket_share(count, sample_size);
+        bucket_rows.push(TopBucketRow {
+            key: client_ip,
+            count,
+            share,
+        });
+    }
+    Ok(TopBucketsResponse {
+        ok: true,
+        sample_size,
+        rows: bucket_rows,
+    })
+}
+
+pub(super) fn load_top_qnames(
+    backend: Arc<RecorderBackend>,
+    query: TopQuery,
+) -> std::result::Result<TopBucketsResponse, DnsError> {
+    let conn = open_database(&backend.path)?;
+    let (clauses, mut params) = record_filter_clauses(
+        "r",
+        &backend.tables,
+        query.since_ms,
+        query.until_ms,
+        &query.filter,
+    )?;
+    let where_sql = join_clauses(&clauses);
+    params.push(Value::Integer(PLUGIN_STATS_SAMPLE_LIMIT as i64));
+    let limit = top_limit(query.limit);
+    params.push(Value::Integer(limit as i64));
+
+    let sql = format!(
+        "WITH sample_records AS (
+            SELECT r.id, r.questions_json
+            FROM {records} r
+            WHERE {where_sql}
+            ORDER BY r.created_at_ms DESC, r.id DESC
+            LIMIT ?
+         ),
+         totals AS (
+            SELECT COUNT(*) AS sample_size FROM sample_records
+         )
+         SELECT
+            totals.sample_size,
+            LOWER(json_extract(q.value, '$.name')) AS qname,
+            COUNT(*) AS count
+         FROM totals
+         LEFT JOIN sample_records ON 1 = 1
+         LEFT JOIN json_each(sample_records.questions_json) AS q ON 1 = 1
+         GROUP BY totals.sample_size, qname
+         ORDER BY count DESC, qname ASC
+         LIMIT ?",
+        records = backend.tables.records,
+    );
+
+    let mut stmt = conn.prepare(&sql)?;
+    let mut rows = stmt.query(params_from_iter(params))?;
+    let mut sample_size = 0u64;
+    let mut bucket_rows: Vec<TopBucketRow> = Vec::new();
+    while let Some(row) = rows.next()? {
+        sample_size = row.get::<_, i64>(0).and_then(non_negative_u64)?;
+        let Some(qname) = row.get::<_, Option<String>>(1)? else {
+            continue;
+        };
+        let count = row.get::<_, i64>(2).and_then(non_negative_u64)?;
+        let share = bucket_share(count, sample_size);
+        bucket_rows.push(TopBucketRow {
+            key: qname,
+            count,
+            share,
+        });
+    }
+    Ok(TopBucketsResponse {
+        ok: true,
+        sample_size,
+        rows: bucket_rows,
+    })
+}
+
+pub(super) fn load_qtype_distribution(
+    backend: Arc<RecorderBackend>,
+    query: DistributionQuery,
+) -> std::result::Result<DistributionResponse, DnsError> {
+    let conn = open_database(&backend.path)?;
+    let (clauses, mut params) = record_filter_clauses(
+        "r",
+        &backend.tables,
+        query.since_ms,
+        query.until_ms,
+        &query.filter,
+    )?;
+    let where_sql = join_clauses(&clauses);
+    params.push(Value::Integer(PLUGIN_STATS_SAMPLE_LIMIT as i64));
+
+    let sql = format!(
+        "WITH sample_records AS (
+            SELECT r.id, r.questions_json
+            FROM {records} r
+            WHERE {where_sql}
+            ORDER BY r.created_at_ms DESC, r.id DESC
+            LIMIT ?
+         ),
+         totals AS (
+            SELECT COUNT(*) AS sample_size FROM sample_records
+         )
+         SELECT
+            totals.sample_size,
+            UPPER(json_extract(q.value, '$.qtype')) AS qtype,
+            COUNT(*) AS count
+         FROM totals
+         LEFT JOIN sample_records ON 1 = 1
+         LEFT JOIN json_each(sample_records.questions_json) AS q ON 1 = 1
+         GROUP BY totals.sample_size, qtype
+         ORDER BY count DESC, qtype ASC",
+        records = backend.tables.records,
+    );
+
+    let mut stmt = conn.prepare(&sql)?;
+    let mut rows = stmt.query(params_from_iter(params))?;
+    let mut sample_size = 0u64;
+    let mut distribution_rows: Vec<DistributionRow> = Vec::new();
+    while let Some(row) = rows.next()? {
+        sample_size = row.get::<_, i64>(0).and_then(non_negative_u64)?;
+        let Some(qtype) = row.get::<_, Option<String>>(1)? else {
+            continue;
+        };
+        let count = row.get::<_, i64>(2).and_then(non_negative_u64)?;
+        let share = bucket_share(count, sample_size);
+        distribution_rows.push(DistributionRow {
+            key: qtype,
+            count,
+            share,
+        });
+    }
+    Ok(DistributionResponse {
+        ok: true,
+        sample_size,
+        rows: distribution_rows,
+    })
+}
+
+pub(super) fn load_rcode_distribution(
+    backend: Arc<RecorderBackend>,
+    query: DistributionQuery,
+) -> std::result::Result<DistributionResponse, DnsError> {
+    let conn = open_database(&backend.path)?;
+    let (clauses, mut params) = record_filter_clauses(
+        "r",
+        &backend.tables,
+        query.since_ms,
+        query.until_ms,
+        &query.filter,
+    )?;
+    let where_sql = join_clauses(&clauses);
+    params.push(Value::Integer(PLUGIN_STATS_SAMPLE_LIMIT as i64));
+
+    let sql = format!(
+        "WITH sample_records AS (
+            SELECT r.id, r.rcode, r.error, r.has_response
+            FROM {records} r
+            WHERE {where_sql}
+            ORDER BY r.created_at_ms DESC, r.id DESC
+            LIMIT ?
+         ),
+         totals AS (
+            SELECT COUNT(*) AS sample_size FROM sample_records
+         )
+         SELECT
+            totals.sample_size,
+            CASE
+                WHEN sample_records.rcode IS NOT NULL THEN sample_records.rcode
+                WHEN sample_records.error IS NOT NULL THEN '_ERROR'
+                WHEN sample_records.has_response = 0 THEN '_NO_RESPONSE'
+                ELSE '_UNKNOWN'
+            END AS bucket,
+            COUNT(*) AS count
+         FROM totals
+         LEFT JOIN sample_records ON 1 = 1
+         GROUP BY totals.sample_size, bucket
+         ORDER BY count DESC, bucket ASC",
+        records = backend.tables.records,
+    );
+
+    let mut stmt = conn.prepare(&sql)?;
+    let mut rows = stmt.query(params_from_iter(params))?;
+    let mut sample_size = 0u64;
+    let mut distribution_rows: Vec<DistributionRow> = Vec::new();
+    while let Some(row) = rows.next()? {
+        sample_size = row.get::<_, i64>(0).and_then(non_negative_u64)?;
+        let Some(bucket) = row.get::<_, Option<String>>(1)? else {
+            continue;
+        };
+        let count = row.get::<_, i64>(2).and_then(non_negative_u64)?;
+        let share = bucket_share(count, sample_size);
+        distribution_rows.push(DistributionRow {
+            key: bucket,
+            count,
+            share,
+        });
+    }
+    Ok(DistributionResponse {
+        ok: true,
+        sample_size,
+        rows: distribution_rows,
+    })
+}
+
+pub(super) fn load_latency_summary(
+    backend: Arc<RecorderBackend>,
+    query: LatencyQuery,
+) -> std::result::Result<LatencySummary, DnsError> {
+    let conn = open_database(&backend.path)?;
+    let (clauses, mut params) = record_filter_clauses(
+        "r",
+        &backend.tables,
+        query.since_ms,
+        query.until_ms,
+        &query.filter,
+    )?;
+    let where_sql = join_clauses(&clauses);
+    params.push(Value::Integer(PLUGIN_STATS_SAMPLE_LIMIT as i64));
+    let elapsed_sql = format!(
+        "SELECT r.elapsed_ms
+         FROM {records} r
+         WHERE {where_sql}
+         ORDER BY r.created_at_ms DESC, r.id DESC
+         LIMIT ?",
+        records = backend.tables.records,
+    );
+
+    let mut elapsed_values: Vec<u64> = Vec::new();
+    {
+        let mut stmt = conn.prepare(&elapsed_sql)?;
+        let mut rows = stmt.query(params_from_iter(params.clone()))?;
+        while let Some(row) = rows.next()? {
+            let value = row.get::<_, i64>(0).and_then(non_negative_u64)?;
+            elapsed_values.push(value);
+        }
+    }
+
+    let sample_size = elapsed_values.len() as u64;
+    let (avg_ms, p50_ms, p95_ms, p99_ms, max_ms) = latency_percentiles(&mut elapsed_values);
+    let histogram = latency_histogram(&elapsed_values);
+
+    let slow_limit = top_limit(query.slow_limit);
+    let (slow_clauses, mut slow_params) = record_filter_clauses(
+        "r",
+        &backend.tables,
+        query.since_ms,
+        query.until_ms,
+        &query.filter,
+    )?;
+    let slow_where_sql = join_clauses(&slow_clauses);
+    slow_params.push(Value::Integer(PLUGIN_STATS_SAMPLE_LIMIT as i64));
+    slow_params.push(Value::Integer(slow_limit as i64));
+    let slow_sql = format!(
+        "WITH sample_records AS (
+            SELECT r.id, r.elapsed_ms, r.questions_json
+            FROM {records} r
+            WHERE {where_sql}
+            ORDER BY r.created_at_ms DESC, r.id DESC
+            LIMIT ?
+         )
+         SELECT
+            LOWER(json_extract(q.value, '$.name')) AS qname,
+            COUNT(*) AS count,
+            AVG(sample_records.elapsed_ms) AS avg_ms,
+            MAX(sample_records.elapsed_ms) AS max_ms
+         FROM sample_records, json_each(sample_records.questions_json) AS q
+         GROUP BY qname
+         HAVING qname IS NOT NULL
+         ORDER BY avg_ms DESC, count DESC
+         LIMIT ?",
+        records = backend.tables.records,
+        where_sql = slow_where_sql,
+    );
+    let mut slow_top: Vec<LatencySlowRow> = Vec::new();
+    {
+        let mut stmt = conn.prepare(&slow_sql)?;
+        let mut rows = stmt.query(params_from_iter(slow_params))?;
+        while let Some(row) = rows.next()? {
+            let Some(qname) = row.get::<_, Option<String>>(0)? else {
+                continue;
+            };
+            slow_top.push(LatencySlowRow {
+                qname,
+                count: row.get::<_, i64>(1).and_then(non_negative_u64)?,
+                avg_ms: row.get::<_, Option<f64>>(2)?.unwrap_or(0.0),
+                max_ms: row.get::<_, i64>(3).and_then(non_negative_u64)?,
+            });
+        }
+    }
+
+    Ok(LatencySummary {
+        ok: true,
+        sample_size,
+        avg_ms,
+        p50_ms,
+        p95_ms,
+        p99_ms,
+        max_ms,
+        histogram,
+        slow_top,
+    })
+}
+
+pub(super) fn load_timeseries(
+    backend: Arc<RecorderBackend>,
+    query: TimeseriesQuery,
+) -> std::result::Result<TimeseriesResponse, DnsError> {
+    let conn = open_database(&backend.path)?;
+    let (clauses, mut params) = record_filter_clauses(
+        "r",
+        &backend.tables,
+        query.since_ms,
+        query.until_ms,
+        &query.filter,
+    )?;
+    let where_sql = join_clauses(&clauses);
+    params.push(Value::Integer(PLUGIN_STATS_SAMPLE_LIMIT as i64));
+
+    let bucket_ms = query.bucket.millis();
+    let sql = format!(
+        "SELECT r.created_at_ms, r.elapsed_ms, r.error, r.has_response
+         FROM {records} r
+         WHERE {where_sql}
+         ORDER BY r.created_at_ms DESC, r.id DESC
+         LIMIT ?",
+        records = backend.tables.records,
+    );
+
+    #[derive(Default)]
+    struct Aggregator {
+        total: u64,
+        error_count: u64,
+        no_response_count: u64,
+        elapsed_sum: u64,
+        elapsed_values: Vec<u64>,
+    }
+    let mut buckets: std::collections::BTreeMap<i64, Aggregator> =
+        std::collections::BTreeMap::new();
+    let mut sample_size = 0u64;
+
+    let mut stmt = conn.prepare(&sql)?;
+    let mut rows = stmt.query(params_from_iter(params))?;
+    while let Some(row) = rows.next()? {
+        let created_at_ms = row.get::<_, i64>(0)?;
+        let elapsed_ms = row.get::<_, i64>(1).and_then(non_negative_u64)?;
+        let error = row.get::<_, Option<String>>(2)?;
+        let has_response = row.get::<_, i64>(3)? != 0;
+        let bucket = bucket_floor(created_at_ms, bucket_ms);
+        let aggregator = buckets.entry(bucket).or_default();
+        aggregator.total = aggregator.total.saturating_add(1);
+        if error.is_some() {
+            aggregator.error_count = aggregator.error_count.saturating_add(1);
+        }
+        if error.is_none() && !has_response {
+            aggregator.no_response_count = aggregator.no_response_count.saturating_add(1);
+        }
+        aggregator.elapsed_sum = aggregator.elapsed_sum.saturating_add(elapsed_ms);
+        aggregator.elapsed_values.push(elapsed_ms);
+        sample_size = sample_size.saturating_add(1);
+    }
+
+    let mut points: Vec<TimeseriesPoint> = Vec::with_capacity(buckets.len());
+    for (bucket, mut aggregator) in buckets {
+        let avg_ms = if aggregator.total == 0 {
+            0.0
+        } else {
+            aggregator.elapsed_sum as f64 / aggregator.total as f64
+        };
+        let p95_ms = percentile_value(&mut aggregator.elapsed_values, 0.95);
+        points.push(TimeseriesPoint {
+            bucket_ms: bucket,
+            total: aggregator.total,
+            error_count: aggregator.error_count,
+            no_response_count: aggregator.no_response_count,
+            avg_ms,
+            p95_ms,
+        });
+    }
+    if points.len() > query.max_buckets {
+        let drop = points.len() - query.max_buckets;
+        points.drain(0..drop);
+    }
+
+    Ok(TimeseriesResponse {
+        ok: true,
+        sample_size,
+        bucket_ms,
+        points,
+    })
+}
+
+fn top_limit(limit: usize) -> usize {
+    limit.clamp(1, 200)
+}
+
+fn bucket_share(count: u64, sample_size: u64) -> f64 {
+    if sample_size == 0 {
+        0.0
+    } else {
+        count as f64 / sample_size as f64
+    }
+}
+
+fn bucket_floor(created_at_ms: i64, bucket_ms: i64) -> i64 {
+    if bucket_ms <= 0 {
+        return created_at_ms;
+    }
+    let remainder = created_at_ms.rem_euclid(bucket_ms);
+    created_at_ms - remainder
+}
+
+fn latency_percentiles(values: &mut [u64]) -> (f64, u64, u64, u64, u64) {
+    if values.is_empty() {
+        return (0.0, 0, 0, 0, 0);
+    }
+    values.sort_unstable();
+    let avg = values.iter().copied().sum::<u64>() as f64 / values.len() as f64;
+    let p50 = percentile_of_sorted(values, 0.50);
+    let p95 = percentile_of_sorted(values, 0.95);
+    let p99 = percentile_of_sorted(values, 0.99);
+    let max = *values.last().unwrap_or(&0);
+    (avg, p50, p95, p99, max)
+}
+
+fn percentile_value(values: &mut [u64], quantile: f64) -> u64 {
+    if values.is_empty() {
+        return 0;
+    }
+    values.sort_unstable();
+    percentile_of_sorted(values, quantile)
+}
+
+fn percentile_of_sorted(sorted_values: &[u64], quantile: f64) -> u64 {
+    if sorted_values.is_empty() {
+        return 0;
+    }
+    let clamped = quantile.clamp(0.0, 1.0);
+    let max_index = sorted_values.len() - 1;
+    let rank = clamped * max_index as f64;
+    let index = rank.round() as usize;
+    let index = index.min(max_index);
+    sorted_values[index]
+}
+
+const LATENCY_BUCKET_EDGES_MS: [u64; 6] = [10, 20, 50, 100, 300, 1000];
+
+fn latency_histogram(values: &[u64]) -> Vec<LatencyHistogramBucket> {
+    let mut counts = vec![0u64; LATENCY_BUCKET_EDGES_MS.len() + 1];
+    for value in values {
+        let mut placed = false;
+        for (index, edge) in LATENCY_BUCKET_EDGES_MS.iter().enumerate() {
+            if *value < *edge {
+                counts[index] = counts[index].saturating_add(1);
+                placed = true;
+                break;
+            }
+        }
+        if !placed {
+            *counts.last_mut().expect("at least one bucket") =
+                counts.last().copied().unwrap_or(0).saturating_add(1);
+        }
+    }
+    let mut histogram = Vec::with_capacity(counts.len());
+    for (index, count) in counts.into_iter().enumerate() {
+        let lt_ms = LATENCY_BUCKET_EDGES_MS.get(index).copied();
+        histogram.push(LatencyHistogramBucket { lt_ms, count });
+    }
+    histogram
+}
+
 fn record_filter_clauses(
     alias: &str,
     tables: &TableNames,
@@ -655,12 +1218,24 @@ fn record_filter_clauses(
         params.push(Value::Integer(as_i64(until_ms)?));
     }
     if let Some(matcher_tag) = filter.matcher_tag.as_deref() {
+        // IMPORTANT: keep this as an UNCORRELATED `IN (SELECT ...)` subquery.
+        //
+        // An EXISTS form that references `{alias}.id` becomes a correlated
+        // subquery, forcing SQLite to re-run the lookup for every candidate
+        // record. With LIMIT 100 plus a low-selectivity matcher (say, hits
+        // 0.5% of records), the planner can end up scanning hundreds of
+        // thousands of rows even with the covering steps index — making the
+        // /records endpoint feel unresponsive when a matcher row is clicked.
+        //
+        // This IN form is uncorrelated: SQLite materializes the matched
+        // record_id set once (a tight index range scan over the
+        // `(kind, tag, outcome, record_id)` index), then the outer plan
+        // walks records desc by created_at and does O(1) membership tests.
         clauses.push(format!(
-            "EXISTS (
-                SELECT 1
+            "{alias}.id IN (
+                SELECT s.record_id
                 FROM {steps} s
-                WHERE s.record_id = {alias}.id
-                  AND s.kind = 'matcher'
+                WHERE s.kind = 'matcher'
                   AND s.outcome = 'matched'
                   AND s.tag = ?
             )",

--- a/src/plugin/executor/query_recorder/tests.rs
+++ b/src/plugin/executor/query_recorder/tests.rs
@@ -609,6 +609,56 @@ async fn test_query_recorder_matcher_stats_use_record_filters() {
     plugin.destroy().await.unwrap();
 }
 
+#[tokio::test]
+async fn test_query_recorder_plugin_stats_preserve_total_without_steps() {
+    let temp = NamedTempFile::new().unwrap();
+    let config = resolve_config(Some(recorder_config(&temp.path().display().to_string()))).unwrap();
+    let mut plugin = QueryRecorder::new("rec".to_string(), config);
+    plugin.init_for_test().await.unwrap();
+    let backend = plugin.backend.as_ref().unwrap().clone();
+
+    backend.enqueue(pending_record(
+        1_000,
+        1,
+        "www.example.com.",
+        RecordType::A,
+        Ipv4Addr::new(192, 0, 2, 1),
+        Some(Rcode::NoError),
+        None,
+        &[],
+    ));
+    backend.enqueue(pending_record(
+        2_000,
+        2,
+        "ads.example.com.",
+        RecordType::AAAA,
+        Ipv4Addr::new(192, 0, 2, 2),
+        Some(Rcode::NoError),
+        None,
+        &[],
+    ));
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    let (query_total, stats) = load_plugin_stats(
+        backend,
+        PluginsStatsQuery {
+            since_ms: None,
+            until_ms: None,
+            kind: PluginStatsKind::Matcher,
+            filter: QueryRecordFilter {
+                qname: Some("example".to_string()),
+                ..QueryRecordFilter::default()
+            },
+        },
+    )
+    .unwrap();
+
+    assert_eq!(query_total, 2);
+    assert!(stats.is_empty());
+
+    plugin.destroy().await.unwrap();
+}
+
 async fn seed_demo_records(backend: &std::sync::Arc<super::backend::RecorderBackend>) {
     backend.enqueue(pending_record(
         1_000,

--- a/src/plugin/executor/query_recorder/tests.rs
+++ b/src/plugin/executor/query_recorder/tests.rs
@@ -7,10 +7,14 @@ use std::time::Duration;
 use tempfile::NamedTempFile;
 
 use super::model::{
-    ListQuery, PendingRecord, PluginStatsKind, PluginsStatsQuery, QueryRecordFilter,
-    QueryRecordStatus, QueryRecorderConfig,
+    DistributionQuery, LatencyQuery, ListQuery, PendingRecord, PluginStatsKind, PluginsStatsQuery,
+    QueryRecordFilter, QueryRecordStatus, QueryRecorderConfig, TimeseriesBucket, TimeseriesQuery,
+    TopQuery,
 };
-use super::store::{load_plugin_stats, query_records, table_names};
+use super::store::{
+    load_latency_summary, load_plugin_stats, load_qtype_distribution, load_rcode_distribution,
+    load_timeseries, load_top_clients, load_top_qnames, query_records, table_names,
+};
 use super::{QueryRecorder, QueryRecorderFactory, resolve_config};
 use crate::core::app_clock::AppClock;
 use crate::core::context::{DnsContext, ExecutionPathEvent};
@@ -601,6 +605,270 @@ async fn test_query_recorder_matcher_stats_use_record_filters() {
     assert_eq!(cn.matched, 0);
     assert_eq!(cn.query_total, 1);
     assert_eq!(cn.query_share, 0.5);
+
+    plugin.destroy().await.unwrap();
+}
+
+async fn seed_demo_records(backend: &std::sync::Arc<super::backend::RecorderBackend>) {
+    backend.enqueue(pending_record(
+        1_000,
+        1,
+        "www.example.com.",
+        RecordType::A,
+        Ipv4Addr::new(192, 0, 2, 1),
+        Some(Rcode::NoError),
+        None,
+        &[],
+    ));
+    backend.enqueue(pending_record(
+        2_000,
+        2,
+        "ads.example.com.",
+        RecordType::AAAA,
+        Ipv4Addr::new(192, 0, 2, 1),
+        Some(Rcode::NXDomain),
+        None,
+        &[],
+    ));
+    backend.enqueue(pending_record(
+        3_000,
+        3,
+        "www.example.com.",
+        RecordType::A,
+        Ipv4Addr::new(192, 0, 2, 2),
+        Some(Rcode::NoError),
+        None,
+        &[],
+    ));
+    backend.enqueue(pending_record(
+        4_000,
+        4,
+        "boom.example.net.",
+        RecordType::A,
+        Ipv4Addr::new(192, 0, 2, 3),
+        None,
+        Some("boom"),
+        &[],
+    ));
+    backend.enqueue(pending_record(
+        5_000,
+        5,
+        "empty.test.",
+        RecordType::HTTPS,
+        Ipv4Addr::new(192, 0, 2, 4),
+        None,
+        None,
+        &[],
+    ));
+    tokio::time::sleep(Duration::from_millis(50)).await;
+}
+
+#[tokio::test]
+async fn test_load_top_clients_ranks_by_count() {
+    let temp = NamedTempFile::new().unwrap();
+    let config = resolve_config(Some(recorder_config(&temp.path().display().to_string()))).unwrap();
+    let mut plugin = QueryRecorder::new("rec".to_string(), config);
+    plugin.init_for_test().await.unwrap();
+    let backend = plugin.backend.as_ref().unwrap().clone();
+    seed_demo_records(&backend).await;
+
+    let response = load_top_clients(
+        backend,
+        TopQuery {
+            since_ms: None,
+            until_ms: None,
+            filter: QueryRecordFilter::default(),
+            limit: 10,
+        },
+    )
+    .unwrap();
+    assert_eq!(response.sample_size, 5);
+    assert_eq!(response.rows[0].key, "192.0.2.1");
+    assert_eq!(response.rows[0].count, 2);
+    assert!((response.rows[0].share - 0.4).abs() < 1.0e-9);
+
+    plugin.destroy().await.unwrap();
+}
+
+#[tokio::test]
+async fn test_load_top_qnames_unwinds_questions() {
+    let temp = NamedTempFile::new().unwrap();
+    let config = resolve_config(Some(recorder_config(&temp.path().display().to_string()))).unwrap();
+    let mut plugin = QueryRecorder::new("rec".to_string(), config);
+    plugin.init_for_test().await.unwrap();
+    let backend = plugin.backend.as_ref().unwrap().clone();
+    seed_demo_records(&backend).await;
+
+    let response = load_top_qnames(
+        backend,
+        TopQuery {
+            since_ms: None,
+            until_ms: None,
+            filter: QueryRecordFilter::default(),
+            limit: 10,
+        },
+    )
+    .unwrap();
+    let top = response
+        .rows
+        .iter()
+        .find(|row| row.key == "www.example.com.")
+        .expect("www.example.com. should be present");
+    assert_eq!(top.count, 2);
+    assert_eq!(response.sample_size, 5);
+
+    plugin.destroy().await.unwrap();
+}
+
+#[tokio::test]
+async fn test_qtype_and_rcode_distribution_counts() {
+    let temp = NamedTempFile::new().unwrap();
+    let config = resolve_config(Some(recorder_config(&temp.path().display().to_string()))).unwrap();
+    let mut plugin = QueryRecorder::new("rec".to_string(), config);
+    plugin.init_for_test().await.unwrap();
+    let backend = plugin.backend.as_ref().unwrap().clone();
+    seed_demo_records(&backend).await;
+
+    let qtype = load_qtype_distribution(
+        backend.clone(),
+        DistributionQuery {
+            since_ms: None,
+            until_ms: None,
+            filter: QueryRecordFilter::default(),
+        },
+    )
+    .unwrap();
+    let a_count = qtype.rows.iter().find(|row| row.key == "A").unwrap().count;
+    let aaaa_count = qtype
+        .rows
+        .iter()
+        .find(|row| row.key == "AAAA")
+        .unwrap()
+        .count;
+    let https_count = qtype
+        .rows
+        .iter()
+        .find(|row| row.key == "HTTPS")
+        .unwrap()
+        .count;
+    assert_eq!(a_count, 3);
+    assert_eq!(aaaa_count, 1);
+    assert_eq!(https_count, 1);
+
+    let rcode = load_rcode_distribution(
+        backend,
+        DistributionQuery {
+            since_ms: None,
+            until_ms: None,
+            filter: QueryRecordFilter::default(),
+        },
+    )
+    .unwrap();
+    let error_bucket = rcode
+        .rows
+        .iter()
+        .find(|row| row.key == "_ERROR")
+        .expect("_ERROR bucket expected for failed records");
+    assert_eq!(error_bucket.count, 1);
+    let no_response_bucket = rcode
+        .rows
+        .iter()
+        .find(|row| row.key == "_NO_RESPONSE")
+        .expect("_NO_RESPONSE bucket expected for missing response");
+    assert_eq!(no_response_bucket.count, 1);
+
+    plugin.destroy().await.unwrap();
+}
+
+#[tokio::test]
+async fn test_latency_summary_returns_percentiles_and_histogram() {
+    let temp = NamedTempFile::new().unwrap();
+    let config = resolve_config(Some(recorder_config(&temp.path().display().to_string()))).unwrap();
+    let mut plugin = QueryRecorder::new("rec".to_string(), config);
+    plugin.init_for_test().await.unwrap();
+    let backend = plugin.backend.as_ref().unwrap().clone();
+    seed_demo_records(&backend).await;
+
+    let summary = load_latency_summary(
+        backend,
+        LatencyQuery {
+            since_ms: None,
+            until_ms: None,
+            filter: QueryRecordFilter::default(),
+            slow_limit: 5,
+        },
+    )
+    .unwrap();
+    assert_eq!(summary.sample_size, 5);
+    assert!(summary.histogram.iter().any(|bucket| bucket.count > 0));
+    assert!(summary.histogram.last().unwrap().lt_ms.is_none());
+    let histogram_total: u64 = summary.histogram.iter().map(|bucket| bucket.count).sum();
+    assert_eq!(histogram_total, summary.sample_size);
+
+    plugin.destroy().await.unwrap();
+}
+
+#[tokio::test]
+async fn test_timeseries_buckets_records_by_minute() {
+    let temp = NamedTempFile::new().unwrap();
+    let config = resolve_config(Some(recorder_config(&temp.path().display().to_string()))).unwrap();
+    let mut plugin = QueryRecorder::new("rec".to_string(), config);
+    plugin.init_for_test().await.unwrap();
+    let backend = plugin.backend.as_ref().unwrap().clone();
+    let minute_ms: i64 = 60_000;
+    backend.enqueue(pending_record(
+        100,
+        10,
+        "a.example.",
+        RecordType::A,
+        Ipv4Addr::new(10, 0, 0, 1),
+        Some(Rcode::NoError),
+        None,
+        &[],
+    ));
+    backend.enqueue(pending_record(
+        200,
+        11,
+        "b.example.",
+        RecordType::A,
+        Ipv4Addr::new(10, 0, 0, 1),
+        None,
+        Some("boom"),
+        &[],
+    ));
+    backend.enqueue(pending_record(
+        minute_ms + 500,
+        12,
+        "c.example.",
+        RecordType::A,
+        Ipv4Addr::new(10, 0, 0, 2),
+        Some(Rcode::NoError),
+        None,
+        &[],
+    ));
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    let response = load_timeseries(
+        backend,
+        TimeseriesQuery {
+            since_ms: None,
+            until_ms: None,
+            filter: QueryRecordFilter::default(),
+            bucket: TimeseriesBucket::Minute,
+            max_buckets: 60,
+        },
+    )
+    .unwrap();
+    assert_eq!(response.bucket_ms, minute_ms);
+    assert_eq!(response.sample_size, 3);
+    assert_eq!(response.points.len(), 2);
+    let first = &response.points[0];
+    assert_eq!(first.bucket_ms, 0);
+    assert_eq!(first.total, 2);
+    assert_eq!(first.error_count, 1);
+    let second = &response.points[1];
+    assert_eq!(second.bucket_ms, minute_ms);
+    assert_eq!(second.total, 1);
 
     plugin.destroy().await.unwrap();
 }

--- a/webui/components/plugins/kinds/query-recorder.tsx
+++ b/webui/components/plugins/kinds/query-recorder.tsx
@@ -967,7 +967,7 @@ function QueryRecorderInsightsPanel({ tag }: { tag: string }) {
         </TabsList>
         <TabsContent value="clients">
           <TopBucketsCard
-            key={`clients-${nonce}`}
+            key={`clients-${tag}-${range}-${nonce}`}
             title="客户端 IP 排行"
             icon={<Users className="h-4 w-4 text-primary" />}
             tag={tag}
@@ -978,7 +978,7 @@ function QueryRecorderInsightsPanel({ tag }: { tag: string }) {
         </TabsContent>
         <TabsContent value="qnames">
           <TopBucketsCard
-            key={`qnames-${nonce}`}
+            key={`qnames-${tag}-${range}-${nonce}`}
             title="查询域名排行"
             icon={<Globe className="h-4 w-4 text-primary" />}
             tag={tag}
@@ -989,7 +989,7 @@ function QueryRecorderInsightsPanel({ tag }: { tag: string }) {
         </TabsContent>
         <TabsContent value="qtype">
           <DistributionCard
-            key={`qtype-${nonce}`}
+            key={`qtype-${tag}-${range}-${nonce}`}
             title="QTYPE 分布"
             icon={<BarChart3 className="h-4 w-4 text-primary" />}
             tag={tag}
@@ -1001,7 +1001,7 @@ function QueryRecorderInsightsPanel({ tag }: { tag: string }) {
         </TabsContent>
         <TabsContent value="rcode">
           <DistributionCard
-            key={`rcode-${nonce}`}
+            key={`rcode-${tag}-${range}-${nonce}`}
             title="RCODE 分布"
             icon={<PieChartIcon className="h-4 w-4 text-primary" />}
             tag={tag}
@@ -1012,11 +1012,15 @@ function QueryRecorderInsightsPanel({ tag }: { tag: string }) {
           />
         </TabsContent>
         <TabsContent value="latency">
-          <LatencyCard key={`latency-${nonce}`} tag={tag} filters={filters} />
+          <LatencyCard
+            key={`latency-${tag}-${range}-${nonce}`}
+            tag={tag}
+            filters={filters}
+          />
         </TabsContent>
         <TabsContent value="timeseries">
           <TimeseriesCard
-            key={`timeseries-${nonce}-${range}`}
+            key={`timeseries-${tag}-${range}-${nonce}`}
             tag={tag}
             filters={filters}
             defaultBucket={defaultBucketForRange(range)}
@@ -1072,24 +1076,41 @@ function TopBucketsCard({
   filters: QueryRecordFilters;
   fetcher: (
     tag: string,
-    options: QueryRecordFilters & { limit?: number },
+    options: QueryRecordFilters & { limit?: number; signal?: AbortSignal },
   ) => Promise<QueryRecorderTopResponse>;
   keyLabel: string;
 }) {
   const [data, setData] = useState<QueryRecorderTopResponse | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const abortRef = useRef<AbortController | null>(null);
 
   const load = useCallback(async () => {
+    abortRef.current?.abort();
+    const controller = new AbortController();
+    abortRef.current = controller;
     setLoading(true);
     setError(null);
     try {
-      const response = await fetcher(tag, { ...filters, limit: 20 });
+      const response = await fetcher(tag, {
+        ...filters,
+        limit: 20,
+        signal: controller.signal,
+      });
+      if (controller.signal.aborted || abortRef.current !== controller) {
+        return;
+      }
       setData(response);
     } catch (err) {
+      if (controller.signal.aborted || abortRef.current !== controller) {
+        return;
+      }
       setError(err instanceof Error ? err.message : "读取统计失败");
     } finally {
-      setLoading(false);
+      if (abortRef.current === controller) {
+        abortRef.current = null;
+        setLoading(false);
+      }
     }
   }, [tag, filters, fetcher]);
 
@@ -1097,7 +1118,10 @@ function TopBucketsCard({
     const timer = window.setTimeout(() => {
       void load();
     }, 0);
-    return () => window.clearTimeout(timer);
+    return () => {
+      window.clearTimeout(timer);
+      abortRef.current?.abort();
+    };
   }, [load]);
 
   const chartData = useMemo(
@@ -1251,7 +1275,7 @@ function DistributionCard({
   filters: QueryRecordFilters;
   fetcher: (
     tag: string,
-    options: QueryRecordFilters,
+    options: QueryRecordFilters & { signal?: AbortSignal },
   ) => Promise<QueryRecorderDistributionResponse>;
   keyLabel: string;
   preferBarChart: boolean;
@@ -1261,17 +1285,33 @@ function DistributionCard({
   );
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const abortRef = useRef<AbortController | null>(null);
 
   const load = useCallback(async () => {
+    abortRef.current?.abort();
+    const controller = new AbortController();
+    abortRef.current = controller;
     setLoading(true);
     setError(null);
     try {
-      const response = await fetcher(tag, filters);
+      const response = await fetcher(tag, {
+        ...filters,
+        signal: controller.signal,
+      });
+      if (controller.signal.aborted || abortRef.current !== controller) {
+        return;
+      }
       setData(response);
     } catch (err) {
+      if (controller.signal.aborted || abortRef.current !== controller) {
+        return;
+      }
       setError(err instanceof Error ? err.message : "读取分布失败");
     } finally {
-      setLoading(false);
+      if (abortRef.current === controller) {
+        abortRef.current = null;
+        setLoading(false);
+      }
     }
   }, [tag, filters, fetcher]);
 
@@ -1279,7 +1319,10 @@ function DistributionCard({
     const timer = window.setTimeout(() => {
       void load();
     }, 0);
-    return () => window.clearTimeout(timer);
+    return () => {
+      window.clearTimeout(timer);
+      abortRef.current?.abort();
+    };
   }, [load]);
 
   const rows = useMemo(() => data?.rows ?? [], [data]);
@@ -1443,20 +1486,34 @@ function LatencyCard({
   const [data, setData] = useState<QueryRecorderLatencySummary | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const abortRef = useRef<AbortController | null>(null);
 
   const load = useCallback(async () => {
+    abortRef.current?.abort();
+    const controller = new AbortController();
+    abortRef.current = controller;
     setLoading(true);
     setError(null);
     try {
       const response = await fetchQueryRecorderLatency(tag, {
         ...filters,
         slowLimit: 20,
+        signal: controller.signal,
       });
+      if (controller.signal.aborted || abortRef.current !== controller) {
+        return;
+      }
       setData(response);
     } catch (err) {
+      if (controller.signal.aborted || abortRef.current !== controller) {
+        return;
+      }
       setError(err instanceof Error ? err.message : "读取延迟统计失败");
     } finally {
-      setLoading(false);
+      if (abortRef.current === controller) {
+        abortRef.current = null;
+        setLoading(false);
+      }
     }
   }, [tag, filters]);
 
@@ -1464,7 +1521,10 @@ function LatencyCard({
     const timer = window.setTimeout(() => {
       void load();
     }, 0);
-    return () => window.clearTimeout(timer);
+    return () => {
+      window.clearTimeout(timer);
+      abortRef.current?.abort();
+    };
   }, [load]);
 
   const histogram = useMemo(() => {
@@ -1634,8 +1694,12 @@ function TimeseriesCard({
     useState<QueryRecorderTimeseriesBucket>(defaultBucket);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const abortRef = useRef<AbortController | null>(null);
 
   const load = useCallback(async () => {
+    abortRef.current?.abort();
+    const controller = new AbortController();
+    abortRef.current = controller;
     setLoading(true);
     setError(null);
     try {
@@ -1643,12 +1707,22 @@ function TimeseriesCard({
         ...filters,
         bucket,
         buckets: bucket === "minute" ? 60 : 48,
+        signal: controller.signal,
       });
+      if (controller.signal.aborted || abortRef.current !== controller) {
+        return;
+      }
       setData(response);
     } catch (err) {
+      if (controller.signal.aborted || abortRef.current !== controller) {
+        return;
+      }
       setError(err instanceof Error ? err.message : "读取趋势失败");
     } finally {
-      setLoading(false);
+      if (abortRef.current === controller) {
+        abortRef.current = null;
+        setLoading(false);
+      }
     }
   }, [tag, filters, bucket]);
 
@@ -1656,7 +1730,10 @@ function TimeseriesCard({
     const timer = window.setTimeout(() => {
       void load();
     }, 0);
-    return () => window.clearTimeout(timer);
+    return () => {
+      window.clearTimeout(timer);
+      abortRef.current?.abort();
+    };
   }, [load]);
 
   const points = useMemo(() => {
@@ -1687,9 +1764,10 @@ function TimeseriesCard({
         <div className="flex items-center gap-2">
           <Select
             value={bucket}
-            onValueChange={(value) =>
-              setBucket(value as QueryRecorderTimeseriesBucket)
-            }
+            onValueChange={(value) => {
+              abortRef.current?.abort();
+              setBucket(value as QueryRecorderTimeseriesBucket);
+            }}
           >
             <SelectTrigger className="h-8 w-[110px]">
               <SelectValue />
@@ -2098,10 +2176,7 @@ function formatFullTime(ms: number) {
   return new Date(ms).toLocaleString();
 }
 
-function formatBucketLabel(
-  ms: number,
-  bucket: QueryRecorderTimeseriesBucket,
-) {
+function formatBucketLabel(ms: number, bucket: QueryRecorderTimeseriesBucket) {
   const date = new Date(ms);
   if (bucket === "hour") {
     return date.toLocaleString([], {

--- a/webui/components/plugins/kinds/query-recorder.tsx
+++ b/webui/components/plugins/kinds/query-recorder.tsx
@@ -1,8 +1,37 @@
 "use client";
 
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { ReactNode } from "react";
-import { BarChart3, Filter, Info, Radio, RefreshCw, X } from "lucide-react";
+import {
+  BarChart3,
+  Filter,
+  Globe,
+  Info,
+  Loader2,
+  PieChart as PieChartIcon,
+  Radio,
+  RefreshCw,
+  ServerCrash,
+  Timer,
+  TrendingUp,
+  Users,
+  X,
+} from "lucide-react";
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  Cell,
+  Legend,
+  Line,
+  LineChart,
+  Pie,
+  PieChart,
+  ResponsiveContainer,
+  Tooltip as RechartsTooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -28,17 +57,29 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import {
   apiHeaders,
   apiUrl,
   fetchQueryRecordDetail,
-  fetchQueryRecords,
+  fetchQueryRecorderLatency,
   fetchQueryRecorderPluginStats,
+  fetchQueryRecorderQtypeDistribution,
+  fetchQueryRecorderRcodeDistribution,
+  fetchQueryRecorderTimeseries,
+  fetchQueryRecorderTopClients,
+  fetchQueryRecorderTopQnames,
+  fetchQueryRecords,
   type QueryRecordDetail,
   type QueryRecordFilters,
   type QueryRecordRow,
   type QueryRecordStatusFilter,
+  type QueryRecorderDistributionResponse,
+  type QueryRecorderLatencySummary,
   type QueryRecorderPluginStatsRow,
+  type QueryRecorderTimeseriesBucket,
+  type QueryRecorderTimeseriesResponse,
+  type QueryRecorderTopResponse,
 } from "@/lib/oxidns-api";
 import { useAppStore } from "@/lib/store";
 import { cn } from "@/lib/utils";
@@ -67,6 +108,14 @@ function QueryRecorderDetail(props: PluginDetailComponentProps) {
         },
       ]}
       metricsContent={<QueryRecordsPanel tag={props.plugin.name} />}
+      extraTabs={[
+        {
+          value: "insights",
+          icon: <BarChart3 className="mr-1 h-3.5 w-3.5" />,
+          label: "聚合",
+          content: <QueryRecorderInsightsPanel tag={props.plugin.name} />,
+        },
+      ]}
     />
   );
 }
@@ -117,6 +166,19 @@ const RCODE_OPTIONS = [
   "Not Implemented",
 ];
 
+const CHART_COLORS = [
+  "var(--chart-1)",
+  "var(--chart-2)",
+  "var(--chart-3)",
+  "var(--chart-4)",
+  "var(--chart-5)",
+];
+
+// ---------------------------------------------------------------------------
+// 「统计」Tab — original layout: MatcherStatsCard on top, QueryRecordsPanel
+// below, sharing a single filter form (incl. matcherTag).
+// ---------------------------------------------------------------------------
+
 function QueryRecordsPanel({ tag }: { tag: string }) {
   const [records, setRecords] = useState<QueryRecordRow[]>([]);
   const [nextCursor, setNextCursor] = useState<string | undefined>();
@@ -134,7 +196,13 @@ function QueryRecordsPanel({ tag }: { tag: string }) {
   const [streaming, setStreaming] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [statsError, setStatsError] = useState<string | null>(null);
+  // SSE controller (existing behavior).
   const abortRef = useRef<AbortController | null>(null);
+  // Cancel the previous /records load when a new one starts (e.g. rapid
+  // matcher-click). Without this each click piles a new SQL query onto the
+  // blocking pool while the previous one is still running.
+  const recordsAbortRef = useRef<AbortController | null>(null);
+  const statsAbortRef = useRef<AbortController | null>(null);
   const filtersRef = useRef<QueryRecordFilters>({});
 
   useEffect(() => {
@@ -143,6 +211,9 @@ function QueryRecordsPanel({ tag }: { tag: string }) {
 
   const loadRecords = useCallback(
     async (filters: QueryRecordFilters, cursor?: string) => {
+      recordsAbortRef.current?.abort();
+      const controller = new AbortController();
+      recordsAbortRef.current = controller;
       setLoading(true);
       setError(null);
       try {
@@ -150,15 +221,21 @@ function QueryRecordsPanel({ tag }: { tag: string }) {
           limit: 100,
           cursor,
           ...filters,
+          signal: controller.signal,
         });
+        if (controller.signal.aborted) return;
         setRecords((current) =>
           cursor ? [...current, ...response.records] : response.records,
         );
         setNextCursor(response.next_cursor);
       } catch (err) {
+        if (controller.signal.aborted) return;
         setError(err instanceof Error ? err.message : "读取查询记录失败");
       } finally {
-        setLoading(false);
+        if (recordsAbortRef.current === controller) {
+          recordsAbortRef.current = null;
+          setLoading(false);
+        }
       }
     },
     [tag],
@@ -166,6 +243,9 @@ function QueryRecordsPanel({ tag }: { tag: string }) {
 
   const loadMatcherStats = useCallback(
     async (filters: QueryRecordFilters) => {
+      statsAbortRef.current?.abort();
+      const controller = new AbortController();
+      statsAbortRef.current = controller;
       setStatsLoading(true);
       setStatsError(null);
       try {
@@ -173,15 +253,21 @@ function QueryRecordsPanel({ tag }: { tag: string }) {
           kind: "matcher",
           ...filters,
           matcherTag: undefined,
+          signal: controller.signal,
         });
+        if (controller.signal.aborted) return;
         setMatcherStats(response.stats.filter((row) => row.kind === "matcher"));
         setStatsQueryTotal(response.query_total);
       } catch (err) {
+        if (controller.signal.aborted) return;
         setStatsError(
           err instanceof Error ? err.message : "读取 matcher 命中率失败",
         );
       } finally {
-        setStatsLoading(false);
+        if (statsAbortRef.current === controller) {
+          statsAbortRef.current = null;
+          setStatsLoading(false);
+        }
       }
     },
     [tag],
@@ -205,6 +291,8 @@ function QueryRecordsPanel({ tag }: { tag: string }) {
     return () => {
       window.clearTimeout(timer);
       abortRef.current?.abort();
+      recordsAbortRef.current?.abort();
+      statsAbortRef.current?.abort();
     };
   }, [loadMatcherStats, loadRecords]);
 
@@ -296,6 +384,7 @@ function QueryRecordsPanel({ tag }: { tag: string }) {
         stats={matcherStats}
         queryTotal={statsQueryTotal}
         loading={statsLoading}
+        recordsLoading={loading}
         error={statsError}
         selectedMatcher={appliedFilters.matcherTag}
         onSelectMatcher={(matcherTag) => {
@@ -324,6 +413,12 @@ function QueryRecordsPanel({ tag }: { tag: string }) {
               <span className="rounded-full border bg-muted/30 px-2 py-0.5">
                 错误 {records.filter((record) => record.error).length} 条
               </span>
+              {loading && (
+                <span className="inline-flex items-center gap-1 rounded-full border border-primary/30 bg-primary/10 px-2 py-0.5 text-primary">
+                  <Loader2 className="h-3 w-3 animate-spin" />
+                  正在加载…
+                </span>
+              )}
               {streaming && (
                 <span className="rounded-full border border-primary/30 bg-primary/10 px-2 py-0.5 text-primary">
                   实时接收中
@@ -494,7 +589,19 @@ function QueryRecordsPanel({ tag }: { tag: string }) {
               {error}
             </div>
           )}
-          <div className="overflow-hidden rounded-md border">
+          <div className="relative overflow-hidden rounded-md border">
+            {loading && (
+              <div
+                className="pointer-events-none absolute inset-0 z-10 flex items-center justify-center bg-background/60 backdrop-blur-[1px]"
+                aria-live="polite"
+                role="status"
+              >
+                <div className="inline-flex items-center gap-2 rounded-full border border-primary/30 bg-background/95 px-3 py-1.5 text-xs text-primary shadow-sm">
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                  正在加载查询记录…
+                </div>
+              </div>
+            )}
             <Table className="min-w-[760px]">
               <TableHeader>
                 <TableRow className="bg-muted/30 hover:bg-muted/30">
@@ -615,6 +722,7 @@ function MatcherStatsCard({
   stats,
   queryTotal,
   loading,
+  recordsLoading,
   error,
   selectedMatcher,
   onSelectMatcher,
@@ -623,6 +731,12 @@ function MatcherStatsCard({
   stats: QueryRecorderPluginStatsRow[];
   queryTotal: number;
   loading: boolean;
+  /**
+   * Records list is currently fetching — typically because the user just
+   * clicked this matcher row. Surfaces a spinner on the selected row so the
+   * click feels responsive even before /records returns.
+   */
+  recordsLoading: boolean;
   error: string | null;
   selectedMatcher?: string;
   onSelectMatcher: (matcherTag: string | undefined) => void;
@@ -698,8 +812,7 @@ function MatcherStatsCard({
                     }
                     onClick={
                       selectable
-                        ? () =>
-                            onSelectMatcher(isSelected ? undefined : tag)
+                        ? () => onSelectMatcher(isSelected ? undefined : tag)
                         : undefined
                     }
                     title={
@@ -714,8 +827,14 @@ function MatcherStatsCard({
                       <div className="flex items-center gap-2">
                         <span>{tag ?? "(unknown)"}</span>
                         {isSelected && (
-                          <Badge variant="secondary" className="font-mono">
-                            已选
+                          <Badge
+                            variant="secondary"
+                            className="inline-flex items-center gap-1 font-mono"
+                          >
+                            {recordsLoading && (
+                              <Loader2 className="h-3 w-3 animate-spin" />
+                            )}
+                            {recordsLoading ? "加载中" : "已选"}
                           </Badge>
                         )}
                       </div>
@@ -746,6 +865,943 @@ function MatcherStatsCard({
         </div>
       </CardContent>
     </Card>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// 「聚合」Tab — top-level aggregate insights. Independent from the 统计 Tab's
+// filter form. Only knob is a preset time range; sub-tabs render charts.
+// ---------------------------------------------------------------------------
+
+type InsightsRangeKey = "10m" | "1h" | "24h" | "all";
+
+const RANGE_PRESETS: Array<{ key: InsightsRangeKey; label: string }> = [
+  { key: "10m", label: "最近 10 分钟" },
+  { key: "1h", label: "最近 1 小时" },
+  { key: "24h", label: "最近 24 小时" },
+  { key: "all", label: "全部" },
+];
+
+function rangeToFilters(range: InsightsRangeKey): QueryRecordFilters {
+  if (range === "all") return {};
+  const now = Date.now();
+  const minutes = range === "10m" ? 10 : range === "1h" ? 60 : 24 * 60;
+  return { sinceMs: now - minutes * 60_000, untilMs: now };
+}
+
+function defaultBucketForRange(
+  range: InsightsRangeKey,
+): QueryRecorderTimeseriesBucket {
+  return range === "24h" || range === "all" ? "hour" : "minute";
+}
+
+function QueryRecorderInsightsPanel({ tag }: { tag: string }) {
+  const [range, setRange] = useState<InsightsRangeKey>("1h");
+  // `nonce` lets the user force a refresh of every sub-tab without changing
+  // the range; we bump it on the toolbar refresh button.
+  const [nonce, setNonce] = useState(0);
+  const filters = useMemo(() => rangeToFilters(range), [range]);
+  const rangeLabel = useMemo(
+    () => RANGE_PRESETS.find((preset) => preset.key === range)?.label ?? "",
+    [range],
+  );
+
+  return (
+    <div className="space-y-4">
+      <Card>
+        <CardHeader className="grid gap-3 p-4 pb-2 sm:grid-cols-[1fr_auto] sm:items-center">
+          <div className="min-w-0">
+            <CardTitle className="flex items-center gap-2 text-sm">
+              <BarChart3 className="h-4 w-4 text-primary" />
+              聚合视图
+            </CardTitle>
+            <div className="mt-2 flex flex-wrap gap-2 text-xs text-muted-foreground">
+              <span className="rounded-full border bg-muted/30 px-2 py-0.5">
+                {rangeLabel}
+              </span>
+              <span className="rounded-full border bg-muted/30 px-2 py-0.5">
+                与「统计」Tab 筛选相互独立
+              </span>
+            </div>
+          </div>
+          <div className="flex items-center gap-2">
+            <PresetRangePicker value={range} onChange={setRange} />
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => setNonce((value) => value + 1)}
+            >
+              <RefreshCw className="h-4 w-4" />
+              刷新
+            </Button>
+          </div>
+        </CardHeader>
+      </Card>
+
+      <Tabs defaultValue="clients">
+        <TabsList className="flex w-full flex-wrap justify-start gap-1 overflow-x-auto">
+          <TabsTrigger value="clients">
+            <Users className="h-3.5 w-3.5" />
+            客户端
+          </TabsTrigger>
+          <TabsTrigger value="qnames">
+            <Globe className="h-3.5 w-3.5" />
+            域名
+          </TabsTrigger>
+          <TabsTrigger value="qtype">
+            <BarChart3 className="h-3.5 w-3.5" />
+            QTYPE
+          </TabsTrigger>
+          <TabsTrigger value="rcode">
+            <PieChartIcon className="h-3.5 w-3.5" />
+            RCODE
+          </TabsTrigger>
+          <TabsTrigger value="latency">
+            <Timer className="h-3.5 w-3.5" />
+            延迟
+          </TabsTrigger>
+          <TabsTrigger value="timeseries">
+            <TrendingUp className="h-3.5 w-3.5" />
+            趋势
+          </TabsTrigger>
+        </TabsList>
+        <TabsContent value="clients">
+          <TopBucketsCard
+            key={`clients-${nonce}`}
+            title="客户端 IP 排行"
+            icon={<Users className="h-4 w-4 text-primary" />}
+            tag={tag}
+            filters={filters}
+            fetcher={fetchQueryRecorderTopClients}
+            keyLabel="客户端 IP"
+          />
+        </TabsContent>
+        <TabsContent value="qnames">
+          <TopBucketsCard
+            key={`qnames-${nonce}`}
+            title="查询域名排行"
+            icon={<Globe className="h-4 w-4 text-primary" />}
+            tag={tag}
+            filters={filters}
+            fetcher={fetchQueryRecorderTopQnames}
+            keyLabel="QNAME"
+          />
+        </TabsContent>
+        <TabsContent value="qtype">
+          <DistributionCard
+            key={`qtype-${nonce}`}
+            title="QTYPE 分布"
+            icon={<BarChart3 className="h-4 w-4 text-primary" />}
+            tag={tag}
+            filters={filters}
+            fetcher={fetchQueryRecorderQtypeDistribution}
+            keyLabel="QTYPE"
+            preferBarChart
+          />
+        </TabsContent>
+        <TabsContent value="rcode">
+          <DistributionCard
+            key={`rcode-${nonce}`}
+            title="RCODE 分布"
+            icon={<PieChartIcon className="h-4 w-4 text-primary" />}
+            tag={tag}
+            filters={filters}
+            fetcher={fetchQueryRecorderRcodeDistribution}
+            keyLabel="RCODE"
+            preferBarChart={false}
+          />
+        </TabsContent>
+        <TabsContent value="latency">
+          <LatencyCard key={`latency-${nonce}`} tag={tag} filters={filters} />
+        </TabsContent>
+        <TabsContent value="timeseries">
+          <TimeseriesCard
+            key={`timeseries-${nonce}-${range}`}
+            tag={tag}
+            filters={filters}
+            defaultBucket={defaultBucketForRange(range)}
+          />
+        </TabsContent>
+      </Tabs>
+    </div>
+  );
+}
+
+function PresetRangePicker({
+  value,
+  onChange,
+}: {
+  value: InsightsRangeKey;
+  onChange: (next: InsightsRangeKey) => void;
+}) {
+  return (
+    <div className="inline-flex h-8 items-center rounded-md border bg-muted/30 p-0.5">
+      {RANGE_PRESETS.map((preset) => {
+        const active = preset.key === value;
+        return (
+          <button
+            key={preset.key}
+            type="button"
+            onClick={() => onChange(preset.key)}
+            className={cn(
+              "rounded px-2 py-1 text-xs transition-colors",
+              active
+                ? "bg-background text-foreground shadow-sm"
+                : "text-muted-foreground hover:text-foreground",
+            )}
+          >
+            {preset.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+function TopBucketsCard({
+  title,
+  icon,
+  tag,
+  filters,
+  fetcher,
+  keyLabel,
+}: {
+  title: string;
+  icon: ReactNode;
+  tag: string;
+  filters: QueryRecordFilters;
+  fetcher: (
+    tag: string,
+    options: QueryRecordFilters & { limit?: number },
+  ) => Promise<QueryRecorderTopResponse>;
+  keyLabel: string;
+}) {
+  const [data, setData] = useState<QueryRecorderTopResponse | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const response = await fetcher(tag, { ...filters, limit: 20 });
+      setData(response);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "读取统计失败");
+    } finally {
+      setLoading(false);
+    }
+  }, [tag, filters, fetcher]);
+
+  useEffect(() => {
+    const timer = window.setTimeout(() => {
+      void load();
+    }, 0);
+    return () => window.clearTimeout(timer);
+  }, [load]);
+
+  const chartData = useMemo(
+    () =>
+      (data?.rows ?? []).slice().map((row) => ({
+        key: row.key,
+        count: row.count,
+        share: row.share,
+      })),
+    [data],
+  );
+
+  return (
+    <Card className="mt-3">
+      <CardHeader className="grid gap-3 p-4 pb-2 sm:grid-cols-[1fr_auto] sm:items-center">
+        <div className="min-w-0">
+          <CardTitle className="flex items-center gap-2 text-sm">
+            {icon}
+            {title}
+          </CardTitle>
+          <div className="mt-2 flex flex-wrap gap-2 text-xs text-muted-foreground">
+            <span className="rounded-full border bg-muted/30 px-2 py-0.5">
+              样本 {data?.sample_size ?? 0} 条
+            </span>
+            <span className="rounded-full border bg-muted/30 px-2 py-0.5">
+              Top {chartData.length}
+            </span>
+          </div>
+        </div>
+        <Button
+          variant="outline"
+          size="sm"
+          disabled={loading}
+          onClick={() => void load()}
+        >
+          <RefreshCw className="h-4 w-4" />
+          刷新
+        </Button>
+      </CardHeader>
+      <CardContent className="space-y-4 p-4 pt-0">
+        {error && (
+          <div className="rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-sm text-destructive">
+            {error}
+          </div>
+        )}
+        {chartData.length > 0 && (
+          <div className="h-[360px] w-full">
+            <ResponsiveContainer width="100%" height="100%">
+              <BarChart
+                data={chartData}
+                layout="vertical"
+                margin={{ top: 8, right: 16, left: 8, bottom: 8 }}
+              >
+                <CartesianGrid
+                  strokeDasharray="3 3"
+                  stroke="var(--border)"
+                  horizontal={false}
+                />
+                <XAxis
+                  type="number"
+                  stroke="var(--muted-foreground)"
+                  fontSize={11}
+                  allowDecimals={false}
+                />
+                <YAxis
+                  type="category"
+                  dataKey="key"
+                  stroke="var(--muted-foreground)"
+                  fontSize={11}
+                  width={180}
+                  tickFormatter={(value: string) => truncateMiddle(value, 28)}
+                />
+                <RechartsTooltip
+                  cursor={{ fill: "var(--muted)", opacity: 0.3 }}
+                  contentStyle={{
+                    background: "var(--popover)",
+                    border: "1px solid var(--border)",
+                    borderRadius: 8,
+                    color: "var(--foreground)",
+                    fontSize: 12,
+                  }}
+                  formatter={(value: number, _name, props) => [
+                    `${value} 次 (${formatPercent(
+                      (props.payload?.share as number) ?? 0,
+                    )})`,
+                    keyLabel,
+                  ]}
+                />
+                <Bar
+                  dataKey="count"
+                  fill="var(--chart-1)"
+                  radius={[0, 4, 4, 0]}
+                />
+              </BarChart>
+            </ResponsiveContainer>
+          </div>
+        )}
+        <div className="overflow-hidden rounded-md border">
+          <Table className="min-w-[560px]">
+            <TableHeader>
+              <TableRow className="bg-muted/30 hover:bg-muted/30">
+                <TableHead className="w-12">#</TableHead>
+                <TableHead>{keyLabel}</TableHead>
+                <TableHead>次数</TableHead>
+                <TableHead>占比</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {chartData.map((row, index) => (
+                <TableRow key={row.key}>
+                  <TableCell className="font-mono text-xs text-muted-foreground">
+                    {index + 1}
+                  </TableCell>
+                  <TableCell className="font-mono">{row.key}</TableCell>
+                  <TableCell className="font-mono">{row.count}</TableCell>
+                  <TableCell className="font-mono">
+                    {formatPercent(row.share)}
+                  </TableCell>
+                </TableRow>
+              ))}
+              {!chartData.length && (
+                <TableRow>
+                  <TableCell
+                    colSpan={4}
+                    className="h-20 text-center text-muted-foreground"
+                  >
+                    {loading ? "正在读取统计..." : "暂无数据"}
+                  </TableCell>
+                </TableRow>
+              )}
+            </TableBody>
+          </Table>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+function DistributionCard({
+  title,
+  icon,
+  tag,
+  filters,
+  fetcher,
+  keyLabel,
+  preferBarChart,
+}: {
+  title: string;
+  icon: ReactNode;
+  tag: string;
+  filters: QueryRecordFilters;
+  fetcher: (
+    tag: string,
+    options: QueryRecordFilters,
+  ) => Promise<QueryRecorderDistributionResponse>;
+  keyLabel: string;
+  preferBarChart: boolean;
+}) {
+  const [data, setData] = useState<QueryRecorderDistributionResponse | null>(
+    null,
+  );
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const response = await fetcher(tag, filters);
+      setData(response);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "读取分布失败");
+    } finally {
+      setLoading(false);
+    }
+  }, [tag, filters, fetcher]);
+
+  useEffect(() => {
+    const timer = window.setTimeout(() => {
+      void load();
+    }, 0);
+    return () => window.clearTimeout(timer);
+  }, [load]);
+
+  const rows = useMemo(() => data?.rows ?? [], [data]);
+
+  return (
+    <Card className="mt-3">
+      <CardHeader className="grid gap-3 p-4 pb-2 sm:grid-cols-[1fr_auto] sm:items-center">
+        <div className="min-w-0">
+          <CardTitle className="flex items-center gap-2 text-sm">
+            {icon}
+            {title}
+          </CardTitle>
+          <div className="mt-2 flex flex-wrap gap-2 text-xs text-muted-foreground">
+            <span className="rounded-full border bg-muted/30 px-2 py-0.5">
+              样本 {data?.sample_size ?? 0} 条
+            </span>
+            <span className="rounded-full border bg-muted/30 px-2 py-0.5">
+              分桶 {rows.length} 个
+            </span>
+          </div>
+        </div>
+        <Button
+          variant="outline"
+          size="sm"
+          disabled={loading}
+          onClick={() => void load()}
+        >
+          <RefreshCw className="h-4 w-4" />
+          刷新
+        </Button>
+      </CardHeader>
+      <CardContent className="space-y-4 p-4 pt-0">
+        {error && (
+          <div className="rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-sm text-destructive">
+            {error}
+          </div>
+        )}
+        {rows.length > 0 && (
+          <div className="h-[280px] w-full">
+            <ResponsiveContainer width="100%" height="100%">
+              {preferBarChart ? (
+                <BarChart
+                  data={rows}
+                  margin={{ top: 8, right: 16, left: 0, bottom: 8 }}
+                >
+                  <CartesianGrid strokeDasharray="3 3" stroke="var(--border)" />
+                  <XAxis
+                    dataKey="key"
+                    stroke="var(--muted-foreground)"
+                    fontSize={11}
+                  />
+                  <YAxis
+                    stroke="var(--muted-foreground)"
+                    fontSize={11}
+                    allowDecimals={false}
+                  />
+                  <RechartsTooltip
+                    cursor={{ fill: "var(--muted)", opacity: 0.3 }}
+                    contentStyle={{
+                      background: "var(--popover)",
+                      border: "1px solid var(--border)",
+                      borderRadius: 8,
+                      color: "var(--foreground)",
+                      fontSize: 12,
+                    }}
+                    formatter={(value: number, _name, props) => [
+                      `${value} 次 (${formatPercent(
+                        (props.payload?.share as number) ?? 0,
+                      )})`,
+                      keyLabel,
+                    ]}
+                  />
+                  <Bar
+                    dataKey="count"
+                    fill="var(--chart-1)"
+                    radius={[4, 4, 0, 0]}
+                  />
+                </BarChart>
+              ) : (
+                <PieChart>
+                  <RechartsTooltip
+                    contentStyle={{
+                      background: "var(--popover)",
+                      border: "1px solid var(--border)",
+                      borderRadius: 8,
+                      color: "var(--foreground)",
+                      fontSize: 12,
+                    }}
+                    formatter={(value: number, _name, props) => [
+                      `${value} 次 (${formatPercent(
+                        (props.payload?.share as number) ?? 0,
+                      )})`,
+                      props.payload?.key ?? keyLabel,
+                    ]}
+                  />
+                  <Legend wrapperStyle={{ fontSize: 12 }} />
+                  <Pie
+                    data={rows}
+                    dataKey="count"
+                    nameKey="key"
+                    outerRadius={90}
+                    innerRadius={42}
+                    paddingAngle={2}
+                  >
+                    {rows.map((entry, index) => (
+                      <Cell
+                        key={entry.key}
+                        fill={CHART_COLORS[index % CHART_COLORS.length]}
+                      />
+                    ))}
+                  </Pie>
+                </PieChart>
+              )}
+            </ResponsiveContainer>
+          </div>
+        )}
+        <div className="overflow-hidden rounded-md border">
+          <Table className="min-w-[480px]">
+            <TableHeader>
+              <TableRow className="bg-muted/30 hover:bg-muted/30">
+                <TableHead>{keyLabel}</TableHead>
+                <TableHead>次数</TableHead>
+                <TableHead>占比</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {rows.map((row) => (
+                <TableRow key={row.key}>
+                  <TableCell className="font-mono">{row.key}</TableCell>
+                  <TableCell className="font-mono">{row.count}</TableCell>
+                  <TableCell className="font-mono">
+                    {formatPercent(row.share)}
+                  </TableCell>
+                </TableRow>
+              ))}
+              {!rows.length && (
+                <TableRow>
+                  <TableCell
+                    colSpan={3}
+                    className="h-20 text-center text-muted-foreground"
+                  >
+                    {loading ? "正在读取分布..." : "暂无数据"}
+                  </TableCell>
+                </TableRow>
+              )}
+            </TableBody>
+          </Table>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+function LatencyCard({
+  tag,
+  filters,
+}: {
+  tag: string;
+  filters: QueryRecordFilters;
+}) {
+  const [data, setData] = useState<QueryRecorderLatencySummary | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const response = await fetchQueryRecorderLatency(tag, {
+        ...filters,
+        slowLimit: 20,
+      });
+      setData(response);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "读取延迟统计失败");
+    } finally {
+      setLoading(false);
+    }
+  }, [tag, filters]);
+
+  useEffect(() => {
+    const timer = window.setTimeout(() => {
+      void load();
+    }, 0);
+    return () => window.clearTimeout(timer);
+  }, [load]);
+
+  const histogram = useMemo(() => {
+    const buckets = data?.histogram ?? [];
+    return buckets.map((bucket, index) => {
+      const prev = index === 0 ? 0 : (buckets[index - 1]?.lt_ms ?? 0);
+      const lt = bucket.lt_ms;
+      const label =
+        lt === null
+          ? `${prev}+ ms`
+          : prev === 0
+            ? `<${lt} ms`
+            : `${prev}–${lt} ms`;
+      // Color bars semantically: green → fast, sky → normal, amber → slow,
+      // rose → very slow — same tiers as queryElapsedClassName.
+      const upperBound = lt ?? Number.POSITIVE_INFINITY;
+      const fill =
+        upperBound <= 20
+          ? "var(--color-emerald-500)"
+          : upperBound <= 100
+            ? "var(--color-sky-500)"
+            : upperBound <= 300
+              ? "var(--color-amber-500)"
+              : "var(--color-rose-500)";
+      return { label, count: bucket.count, fill };
+    });
+  }, [data]);
+
+  return (
+    <Card className="mt-3">
+      <CardHeader className="grid gap-3 p-4 pb-2 sm:grid-cols-[1fr_auto] sm:items-center">
+        <div className="min-w-0">
+          <CardTitle className="flex items-center gap-2 text-sm">
+            <Timer className="h-4 w-4 text-primary" />
+            延迟分布
+          </CardTitle>
+          <div className="mt-2 flex flex-wrap gap-2 text-xs text-muted-foreground">
+            <span className="rounded-full border bg-muted/30 px-2 py-0.5">
+              样本 {data?.sample_size ?? 0} 条
+            </span>
+          </div>
+        </div>
+        <Button
+          variant="outline"
+          size="sm"
+          disabled={loading}
+          onClick={() => void load()}
+        >
+          <RefreshCw className="h-4 w-4" />
+          刷新
+        </Button>
+      </CardHeader>
+      <CardContent className="space-y-4 p-4 pt-0">
+        {error && (
+          <div className="rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-sm text-destructive">
+            {error}
+          </div>
+        )}
+        <div className="grid grid-cols-2 gap-2 md:grid-cols-5">
+          <MetricChip label="P50" value={`${data?.p50_ms ?? 0} ms`} />
+          <MetricChip label="P95" value={`${data?.p95_ms ?? 0} ms`} />
+          <MetricChip label="P99" value={`${data?.p99_ms ?? 0} ms`} />
+          <MetricChip
+            label="平均"
+            value={`${data ? data.avg_ms.toFixed(1) : "0.0"} ms`}
+          />
+          <MetricChip label="最大" value={`${data?.max_ms ?? 0} ms`} />
+        </div>
+        {histogram.length > 0 && (
+          <div className="h-[260px] w-full">
+            <ResponsiveContainer width="100%" height="100%">
+              <BarChart
+                data={histogram}
+                margin={{ top: 8, right: 16, left: 0, bottom: 8 }}
+              >
+                <CartesianGrid strokeDasharray="3 3" stroke="var(--border)" />
+                <XAxis
+                  dataKey="label"
+                  stroke="var(--muted-foreground)"
+                  fontSize={11}
+                />
+                <YAxis
+                  stroke="var(--muted-foreground)"
+                  fontSize={11}
+                  allowDecimals={false}
+                />
+                <RechartsTooltip
+                  cursor={{ fill: "var(--muted)", opacity: 0.3 }}
+                  contentStyle={{
+                    background: "var(--popover)",
+                    border: "1px solid var(--border)",
+                    borderRadius: 8,
+                    color: "var(--foreground)",
+                    fontSize: 12,
+                  }}
+                />
+                <Bar dataKey="count" radius={[4, 4, 0, 0]}>
+                  {histogram.map((entry) => (
+                    <Cell key={entry.label} fill={entry.fill} />
+                  ))}
+                </Bar>
+              </BarChart>
+            </ResponsiveContainer>
+          </div>
+        )}
+        <div>
+          <div className="mb-2 flex items-center gap-2 text-xs text-muted-foreground">
+            <ServerCrash className="h-3.5 w-3.5" />
+            慢查询 Top（按平均耗时）
+          </div>
+          <div className="overflow-hidden rounded-md border">
+            <Table className="min-w-[600px]">
+              <TableHeader>
+                <TableRow className="bg-muted/30 hover:bg-muted/30">
+                  <TableHead>QNAME</TableHead>
+                  <TableHead>次数</TableHead>
+                  <TableHead>平均耗时</TableHead>
+                  <TableHead>最大耗时</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {(data?.slow_top ?? []).map((row) => (
+                  <TableRow key={row.qname}>
+                    <TableCell className="font-mono">{row.qname}</TableCell>
+                    <TableCell className="font-mono">{row.count}</TableCell>
+                    <TableCell className="font-mono">
+                      {row.avg_ms.toFixed(1)} ms
+                    </TableCell>
+                    <TableCell className="font-mono">{row.max_ms} ms</TableCell>
+                  </TableRow>
+                ))}
+                {!(data?.slow_top ?? []).length && (
+                  <TableRow>
+                    <TableCell
+                      colSpan={4}
+                      className="h-20 text-center text-muted-foreground"
+                    >
+                      {loading ? "正在读取慢查询..." : "暂无数据"}
+                    </TableCell>
+                  </TableRow>
+                )}
+              </TableBody>
+            </Table>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+function TimeseriesCard({
+  tag,
+  filters,
+  defaultBucket,
+}: {
+  tag: string;
+  filters: QueryRecordFilters;
+  defaultBucket: QueryRecorderTimeseriesBucket;
+}) {
+  const [data, setData] = useState<QueryRecorderTimeseriesResponse | null>(
+    null,
+  );
+  // `defaultBucket` only seeds the initial state. The parent re-keys this
+  // component on range change, so a new range remounts with the new default
+  // while preserving user selection within a single range.
+  const [bucket, setBucket] =
+    useState<QueryRecorderTimeseriesBucket>(defaultBucket);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const response = await fetchQueryRecorderTimeseries(tag, {
+        ...filters,
+        bucket,
+        buckets: bucket === "minute" ? 60 : 48,
+      });
+      setData(response);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "读取趋势失败");
+    } finally {
+      setLoading(false);
+    }
+  }, [tag, filters, bucket]);
+
+  useEffect(() => {
+    const timer = window.setTimeout(() => {
+      void load();
+    }, 0);
+    return () => window.clearTimeout(timer);
+  }, [load]);
+
+  const points = useMemo(() => {
+    const items = data?.points ?? [];
+    return items.map((point) => ({
+      ...point,
+      label: formatBucketLabel(point.bucket_ms, bucket),
+    }));
+  }, [data, bucket]);
+
+  return (
+    <Card className="mt-3">
+      <CardHeader className="grid gap-3 p-4 pb-2 sm:grid-cols-[1fr_auto] sm:items-center">
+        <div className="min-w-0">
+          <CardTitle className="flex items-center gap-2 text-sm">
+            <TrendingUp className="h-4 w-4 text-primary" />
+            查询趋势
+          </CardTitle>
+          <div className="mt-2 flex flex-wrap gap-2 text-xs text-muted-foreground">
+            <span className="rounded-full border bg-muted/30 px-2 py-0.5">
+              样本 {data?.sample_size ?? 0} 条
+            </span>
+            <span className="rounded-full border bg-muted/30 px-2 py-0.5">
+              桶大小 {bucket === "minute" ? "1 分钟" : "1 小时"}
+            </span>
+          </div>
+        </div>
+        <div className="flex items-center gap-2">
+          <Select
+            value={bucket}
+            onValueChange={(value) =>
+              setBucket(value as QueryRecorderTimeseriesBucket)
+            }
+          >
+            <SelectTrigger className="h-8 w-[110px]">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="minute">按分钟</SelectItem>
+              <SelectItem value="hour">按小时</SelectItem>
+            </SelectContent>
+          </Select>
+          <Button
+            variant="outline"
+            size="sm"
+            disabled={loading}
+            onClick={() => void load()}
+          >
+            <RefreshCw className="h-4 w-4" />
+            刷新
+          </Button>
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-4 p-4 pt-0">
+        {error && (
+          <div className="rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-sm text-destructive">
+            {error}
+          </div>
+        )}
+        {points.length > 0 ? (
+          <div className="h-[320px] w-full">
+            <ResponsiveContainer width="100%" height="100%">
+              <LineChart
+                data={points}
+                margin={{ top: 8, right: 16, left: 0, bottom: 8 }}
+              >
+                <CartesianGrid strokeDasharray="3 3" stroke="var(--border)" />
+                <XAxis
+                  dataKey="label"
+                  stroke="var(--muted-foreground)"
+                  fontSize={11}
+                  minTickGap={20}
+                />
+                <YAxis
+                  yAxisId="left"
+                  stroke="var(--muted-foreground)"
+                  fontSize={11}
+                  allowDecimals={false}
+                />
+                <YAxis
+                  yAxisId="right"
+                  orientation="right"
+                  stroke="var(--muted-foreground)"
+                  fontSize={11}
+                  allowDecimals={false}
+                />
+                <RechartsTooltip
+                  contentStyle={{
+                    background: "var(--popover)",
+                    border: "1px solid var(--border)",
+                    borderRadius: 8,
+                    color: "var(--foreground)",
+                    fontSize: 12,
+                  }}
+                />
+                <Legend wrapperStyle={{ fontSize: 12 }} />
+                <Line
+                  yAxisId="left"
+                  type="monotone"
+                  dataKey="total"
+                  name="总查询"
+                  stroke="var(--chart-1)"
+                  dot={false}
+                  strokeWidth={2}
+                />
+                <Line
+                  yAxisId="left"
+                  type="monotone"
+                  dataKey="error_count"
+                  name="错误数"
+                  stroke="var(--chart-5)"
+                  dot={false}
+                  strokeWidth={2}
+                />
+                <Line
+                  yAxisId="right"
+                  type="monotone"
+                  dataKey="p95_ms"
+                  name="P95 (ms)"
+                  stroke="var(--chart-3)"
+                  dot={false}
+                  strokeWidth={1.5}
+                  strokeDasharray="4 2"
+                />
+              </LineChart>
+            </ResponsiveContainer>
+          </div>
+        ) : (
+          <div className="rounded-md border bg-muted/20 px-3 py-8 text-center text-sm text-muted-foreground">
+            {loading ? "正在读取趋势..." : "暂无数据"}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+function MetricChip({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-md border bg-muted/20 p-2">
+      <div className="text-[10px] uppercase tracking-wide text-muted-foreground">
+        {label}
+      </div>
+      <div className="font-mono text-sm">{value}</div>
+    </div>
   );
 }
 
@@ -1040,6 +2096,27 @@ function formatTime(ms: number) {
 
 function formatFullTime(ms: number) {
   return new Date(ms).toLocaleString();
+}
+
+function formatBucketLabel(
+  ms: number,
+  bucket: QueryRecorderTimeseriesBucket,
+) {
+  const date = new Date(ms);
+  if (bucket === "hour") {
+    return date.toLocaleString([], {
+      month: "2-digit",
+      day: "2-digit",
+      hour: "2-digit",
+    });
+  }
+  return date.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+}
+
+function truncateMiddle(value: string, max: number) {
+  if (value.length <= max) return value;
+  const half = Math.max(2, Math.floor((max - 1) / 2));
+  return `${value.slice(0, half)}…${value.slice(value.length - half)}`;
 }
 
 function formatQuestion(record: QueryRecordRow) {

--- a/webui/components/plugins/plugin-detail-template.tsx
+++ b/webui/components/plugins/plugin-detail-template.tsx
@@ -37,6 +37,7 @@ export function PluginDetailTemplate({
   summaryItems,
   configContent,
   metricsContent,
+  extraTabs,
 }: PluginDetailTemplateProps) {
   const {
     togglePluginPin,
@@ -109,8 +110,12 @@ export function PluginDetailTemplate({
     metricsContent !== undefined &&
     metricsContent !== null &&
     metricsContent !== false;
+  const resolvedExtraTabs = extraTabs ?? [];
   const visibleTabCount =
-    1 + (hasStatsContent ? 1 : 0) + (hasMetricSeries ? 1 : 0);
+    1 +
+    (hasStatsContent ? 1 : 0) +
+    resolvedExtraTabs.length +
+    (hasMetricSeries ? 1 : 0);
 
   return (
     <div className="flex min-h-full flex-col">
@@ -233,10 +238,18 @@ export function PluginDetailTemplate({
             visibleTabCount === 1 && "grid-cols-1",
             visibleTabCount === 2 && "grid-cols-2",
             visibleTabCount === 3 && "grid-cols-3",
+            visibleTabCount === 4 && "grid-cols-4",
+            visibleTabCount >= 5 && "grid-cols-5",
           )}
         >
           <TabsTrigger value="config">配置</TabsTrigger>
           {hasStatsContent && <TabsTrigger value="stats">统计</TabsTrigger>}
+          {resolvedExtraTabs.map((tab) => (
+            <TabsTrigger key={tab.value} value={tab.value}>
+              {tab.icon}
+              {tab.label}
+            </TabsTrigger>
+          ))}
           {hasMetricSeries && <TabsTrigger value="metrics">指标</TabsTrigger>}
         </TabsList>
 
@@ -311,6 +324,16 @@ export function PluginDetailTemplate({
             {metricsContent}
           </TabsContent>
         )}
+
+        {resolvedExtraTabs.map((tab) => (
+          <TabsContent
+            key={tab.value}
+            value={tab.value}
+            className="mt-4 space-y-4"
+          >
+            {tab.content}
+          </TabsContent>
+        ))}
 
         {hasMetricSeries && (
           <TabsContent value="metrics" className="mt-4 space-y-4">

--- a/webui/components/plugins/types.ts
+++ b/webui/components/plugins/types.ts
@@ -33,11 +33,28 @@ export interface PluginCardTemplateProps extends PluginCardComponentProps {
   children?: ReactNode;
 }
 
+export interface PluginExtraTab {
+  /** Tabs primitive value; must be unique within the detail view. */
+  value: string;
+  /** Label rendered inside the TabsTrigger; PluginDetailTemplate keeps the icon outside. */
+  label: ReactNode;
+  /** Optional icon rendered before the label. */
+  icon?: ReactNode;
+  /** Tab body. */
+  content: ReactNode;
+}
+
 export interface PluginDetailTemplateProps extends PluginDetailComponentProps {
   icon?: ReactNode;
   summaryItems?: PluginSummaryItem[];
   configContent?: ReactNode;
   metricsContent?: ReactNode;
+  /**
+   * Extra top-level tabs rendered after the metrics tab and before built-in metrics.
+   * Use this when a plugin wants to expose a view that is conceptually peer to
+   * "配置" / "统计" rather than nested under one of them.
+   */
+  extraTabs?: PluginExtraTab[];
 }
 
 export interface PluginComponentDefinition {

--- a/webui/lib/oxidns-api.ts
+++ b/webui/lib/oxidns-api.ts
@@ -585,7 +585,7 @@ export async function fetchQueryRecordDetail(
 
 export async function fetchQueryRecorderTopClients(
   tag: string,
-  options: QueryRecordFilters & { limit?: number } = {},
+  options: QueryRecordFilters & { limit?: number; signal?: AbortSignal } = {},
 ): Promise<QueryRecorderTopResponse> {
   const params = new URLSearchParams();
   if (options.limit) params.set("limit", String(options.limit));
@@ -593,14 +593,14 @@ export async function fetchQueryRecorderTopClients(
   const suffix = params.toString() ? `?${params.toString()}` : "";
   const response = await fetch(
     apiUrl(`/plugins/${encodeURIComponent(tag)}/stats/top_clients${suffix}`),
-    { method: "GET", headers: apiHeaders() },
+    { method: "GET", headers: apiHeaders(), signal: options.signal },
   );
   return readJsonResponse<QueryRecorderTopResponse>(response);
 }
 
 export async function fetchQueryRecorderTopQnames(
   tag: string,
-  options: QueryRecordFilters & { limit?: number } = {},
+  options: QueryRecordFilters & { limit?: number; signal?: AbortSignal } = {},
 ): Promise<QueryRecorderTopResponse> {
   const params = new URLSearchParams();
   if (options.limit) params.set("limit", String(options.limit));
@@ -608,42 +608,45 @@ export async function fetchQueryRecorderTopQnames(
   const suffix = params.toString() ? `?${params.toString()}` : "";
   const response = await fetch(
     apiUrl(`/plugins/${encodeURIComponent(tag)}/stats/top_qnames${suffix}`),
-    { method: "GET", headers: apiHeaders() },
+    { method: "GET", headers: apiHeaders(), signal: options.signal },
   );
   return readJsonResponse<QueryRecorderTopResponse>(response);
 }
 
 export async function fetchQueryRecorderQtypeDistribution(
   tag: string,
-  options: QueryRecordFilters = {},
+  options: QueryRecordFilters & { signal?: AbortSignal } = {},
 ): Promise<QueryRecorderDistributionResponse> {
   const params = new URLSearchParams();
   appendQueryRecordFilters(params, options);
   const suffix = params.toString() ? `?${params.toString()}` : "";
   const response = await fetch(
     apiUrl(`/plugins/${encodeURIComponent(tag)}/stats/qtype${suffix}`),
-    { method: "GET", headers: apiHeaders() },
+    { method: "GET", headers: apiHeaders(), signal: options.signal },
   );
   return readJsonResponse<QueryRecorderDistributionResponse>(response);
 }
 
 export async function fetchQueryRecorderRcodeDistribution(
   tag: string,
-  options: QueryRecordFilters = {},
+  options: QueryRecordFilters & { signal?: AbortSignal } = {},
 ): Promise<QueryRecorderDistributionResponse> {
   const params = new URLSearchParams();
   appendQueryRecordFilters(params, options);
   const suffix = params.toString() ? `?${params.toString()}` : "";
   const response = await fetch(
     apiUrl(`/plugins/${encodeURIComponent(tag)}/stats/rcode${suffix}`),
-    { method: "GET", headers: apiHeaders() },
+    { method: "GET", headers: apiHeaders(), signal: options.signal },
   );
   return readJsonResponse<QueryRecorderDistributionResponse>(response);
 }
 
 export async function fetchQueryRecorderLatency(
   tag: string,
-  options: QueryRecordFilters & { slowLimit?: number } = {},
+  options: QueryRecordFilters & {
+    slowLimit?: number;
+    signal?: AbortSignal;
+  } = {},
 ): Promise<QueryRecorderLatencySummary> {
   const params = new URLSearchParams();
   if (options.slowLimit) params.set("slow_limit", String(options.slowLimit));
@@ -651,7 +654,7 @@ export async function fetchQueryRecorderLatency(
   const suffix = params.toString() ? `?${params.toString()}` : "";
   const response = await fetch(
     apiUrl(`/plugins/${encodeURIComponent(tag)}/stats/latency${suffix}`),
-    { method: "GET", headers: apiHeaders() },
+    { method: "GET", headers: apiHeaders(), signal: options.signal },
   );
   return readJsonResponse<QueryRecorderLatencySummary>(response);
 }
@@ -661,6 +664,7 @@ export async function fetchQueryRecorderTimeseries(
   options: QueryRecordFilters & {
     bucket?: QueryRecorderTimeseriesBucket;
     buckets?: number;
+    signal?: AbortSignal;
   } = {},
 ): Promise<QueryRecorderTimeseriesResponse> {
   const params = new URLSearchParams();
@@ -670,7 +674,7 @@ export async function fetchQueryRecorderTimeseries(
   const suffix = params.toString() ? `?${params.toString()}` : "";
   const response = await fetch(
     apiUrl(`/plugins/${encodeURIComponent(tag)}/stats/timeseries${suffix}`),
-    { method: "GET", headers: apiHeaders() },
+    { method: "GET", headers: apiHeaders(), signal: options.signal },
   );
   return readJsonResponse<QueryRecorderTimeseriesResponse>(response);
 }

--- a/webui/lib/oxidns-api.ts
+++ b/webui/lib/oxidns-api.ts
@@ -298,6 +298,72 @@ export interface QueryRecorderPluginStatsResponse {
   stats: QueryRecorderPluginStatsRow[];
 }
 
+export interface QueryRecorderTopRow {
+  key: string;
+  count: number;
+  share: number;
+}
+
+export interface QueryRecorderTopResponse {
+  ok: boolean;
+  sample_size: number;
+  rows: QueryRecorderTopRow[];
+}
+
+export interface QueryRecorderDistributionRow {
+  key: string;
+  count: number;
+  share: number;
+}
+
+export interface QueryRecorderDistributionResponse {
+  ok: boolean;
+  sample_size: number;
+  rows: QueryRecorderDistributionRow[];
+}
+
+export interface QueryRecorderLatencyHistogramBucket {
+  lt_ms: number | null;
+  count: number;
+}
+
+export interface QueryRecorderLatencySlowRow {
+  qname: string;
+  count: number;
+  avg_ms: number;
+  max_ms: number;
+}
+
+export interface QueryRecorderLatencySummary {
+  ok: boolean;
+  sample_size: number;
+  avg_ms: number;
+  p50_ms: number;
+  p95_ms: number;
+  p99_ms: number;
+  max_ms: number;
+  histogram: QueryRecorderLatencyHistogramBucket[];
+  slow_top: QueryRecorderLatencySlowRow[];
+}
+
+export type QueryRecorderTimeseriesBucket = "minute" | "hour";
+
+export interface QueryRecorderTimeseriesPoint {
+  bucket_ms: number;
+  total: number;
+  error_count: number;
+  no_response_count: number;
+  avg_ms: number;
+  p95_ms: number;
+}
+
+export interface QueryRecorderTimeseriesResponse {
+  ok: boolean;
+  sample_size: number;
+  bucket_ms: number;
+  points: QueryRecorderTimeseriesPoint[];
+}
+
 export async function fetchConfigFile(): Promise<ConfigFileResponse> {
   const response = await fetch(apiUrl("/config"), {
     method: "GET",
@@ -473,6 +539,7 @@ export async function fetchQueryRecords(
   options: QueryRecordFilters & {
     limit?: number;
     cursor?: string;
+    signal?: AbortSignal;
   } = {},
 ): Promise<QueryRecordsResponse> {
   const params = new URLSearchParams();
@@ -482,7 +549,7 @@ export async function fetchQueryRecords(
   const suffix = params.toString() ? `?${params.toString()}` : "";
   const response = await fetch(
     apiUrl(`/plugins/${encodeURIComponent(tag)}/records${suffix}`),
-    { method: "GET", headers: apiHeaders() },
+    { method: "GET", headers: apiHeaders(), signal: options.signal },
   );
   return readJsonResponse<QueryRecordsResponse>(response);
 }
@@ -491,6 +558,7 @@ export async function fetchQueryRecorderPluginStats(
   tag: string,
   options: QueryRecordFilters & {
     kind?: QueryRecorderPluginStatsKind;
+    signal?: AbortSignal;
   } = {},
 ): Promise<QueryRecorderPluginStatsResponse> {
   const params = new URLSearchParams();
@@ -499,7 +567,7 @@ export async function fetchQueryRecorderPluginStats(
   const suffix = params.toString() ? `?${params.toString()}` : "";
   const response = await fetch(
     apiUrl(`/plugins/${encodeURIComponent(tag)}/stats/plugins${suffix}`),
-    { method: "GET", headers: apiHeaders() },
+    { method: "GET", headers: apiHeaders(), signal: options.signal },
   );
   return readJsonResponse<QueryRecorderPluginStatsResponse>(response);
 }
@@ -513,6 +581,98 @@ export async function fetchQueryRecordDetail(
     { method: "GET", headers: apiHeaders() },
   );
   return readJsonResponse<QueryRecordDetailResponse>(response);
+}
+
+export async function fetchQueryRecorderTopClients(
+  tag: string,
+  options: QueryRecordFilters & { limit?: number } = {},
+): Promise<QueryRecorderTopResponse> {
+  const params = new URLSearchParams();
+  if (options.limit) params.set("limit", String(options.limit));
+  appendQueryRecordFilters(params, options);
+  const suffix = params.toString() ? `?${params.toString()}` : "";
+  const response = await fetch(
+    apiUrl(`/plugins/${encodeURIComponent(tag)}/stats/top_clients${suffix}`),
+    { method: "GET", headers: apiHeaders() },
+  );
+  return readJsonResponse<QueryRecorderTopResponse>(response);
+}
+
+export async function fetchQueryRecorderTopQnames(
+  tag: string,
+  options: QueryRecordFilters & { limit?: number } = {},
+): Promise<QueryRecorderTopResponse> {
+  const params = new URLSearchParams();
+  if (options.limit) params.set("limit", String(options.limit));
+  appendQueryRecordFilters(params, options);
+  const suffix = params.toString() ? `?${params.toString()}` : "";
+  const response = await fetch(
+    apiUrl(`/plugins/${encodeURIComponent(tag)}/stats/top_qnames${suffix}`),
+    { method: "GET", headers: apiHeaders() },
+  );
+  return readJsonResponse<QueryRecorderTopResponse>(response);
+}
+
+export async function fetchQueryRecorderQtypeDistribution(
+  tag: string,
+  options: QueryRecordFilters = {},
+): Promise<QueryRecorderDistributionResponse> {
+  const params = new URLSearchParams();
+  appendQueryRecordFilters(params, options);
+  const suffix = params.toString() ? `?${params.toString()}` : "";
+  const response = await fetch(
+    apiUrl(`/plugins/${encodeURIComponent(tag)}/stats/qtype${suffix}`),
+    { method: "GET", headers: apiHeaders() },
+  );
+  return readJsonResponse<QueryRecorderDistributionResponse>(response);
+}
+
+export async function fetchQueryRecorderRcodeDistribution(
+  tag: string,
+  options: QueryRecordFilters = {},
+): Promise<QueryRecorderDistributionResponse> {
+  const params = new URLSearchParams();
+  appendQueryRecordFilters(params, options);
+  const suffix = params.toString() ? `?${params.toString()}` : "";
+  const response = await fetch(
+    apiUrl(`/plugins/${encodeURIComponent(tag)}/stats/rcode${suffix}`),
+    { method: "GET", headers: apiHeaders() },
+  );
+  return readJsonResponse<QueryRecorderDistributionResponse>(response);
+}
+
+export async function fetchQueryRecorderLatency(
+  tag: string,
+  options: QueryRecordFilters & { slowLimit?: number } = {},
+): Promise<QueryRecorderLatencySummary> {
+  const params = new URLSearchParams();
+  if (options.slowLimit) params.set("slow_limit", String(options.slowLimit));
+  appendQueryRecordFilters(params, options);
+  const suffix = params.toString() ? `?${params.toString()}` : "";
+  const response = await fetch(
+    apiUrl(`/plugins/${encodeURIComponent(tag)}/stats/latency${suffix}`),
+    { method: "GET", headers: apiHeaders() },
+  );
+  return readJsonResponse<QueryRecorderLatencySummary>(response);
+}
+
+export async function fetchQueryRecorderTimeseries(
+  tag: string,
+  options: QueryRecordFilters & {
+    bucket?: QueryRecorderTimeseriesBucket;
+    buckets?: number;
+  } = {},
+): Promise<QueryRecorderTimeseriesResponse> {
+  const params = new URLSearchParams();
+  if (options.bucket) params.set("bucket", options.bucket);
+  if (options.buckets) params.set("buckets", String(options.buckets));
+  appendQueryRecordFilters(params, options);
+  const suffix = params.toString() ? `?${params.toString()}` : "";
+  const response = await fetch(
+    apiUrl(`/plugins/${encodeURIComponent(tag)}/stats/timeseries${suffix}`),
+    { method: "GET", headers: apiHeaders() },
+  );
+  return readJsonResponse<QueryRecorderTimeseriesResponse>(response);
 }
 
 // --- Log API ---


### PR DESCRIPTION
Add a top-level "聚合" tab on the plugin detail view exposing six aggregate views over the recorded query log — Top 客户端 IP, Top 域名, QTYPE / RCODE distributions, latency histogram with slow-query Top, and QPS time series — backed by six new GET endpoints under /plugins/<tag>/stats/. The 统计 Tab keeps its original Matcher 命中率 + records list layout, now with abort-cancelled /records requests, a loading overlay on the records table, and an in-row spinner on the clicked matcher.

Backend
- New aggregation SQL in store.rs reusing record_filter_clauses; recharts-friendly response shapes in model.rs.
- 6 new ApiHandlers (top_clients, top_qnames, qtype, rcode, latency, timeseries) registered via register_plugin_api!.
- Tests covering ranking order, distribution counts, percentile bucketing, and minute-bucketed time series.

WebUI
- PluginDetailTemplate gains a generic extraTabs prop so plugins can add top-level tabs as peers of 配置/统计/指标.
- Aggregate tab has its own preset time-range picker (10m/1h/24h/全部) and stays decoupled from the 统计 Tab's record filters.
- Per-bar semantic coloring on the latency histogram matches the records row's elapsed badge tiers.

Performance
- Tune SQLite PRAGMAs in open_database: temp_store=MEMORY, cache_size=-32768 (32 MiB), mmap_size=128 MiB.
- Run PRAGMA optimize once at startup so the planner re-evaluates indexes after schema upgrades.
- Add covering index steps(kind, tag, outcome, record_id) for the matcher_tag EXISTS subquery and steps(record_id, kind) for /stats JOINs; cuts matcher-filter latency by an order of magnitude on busy recorders.

Existing recorder DB files are forward-compatible; the two new indexes build once on first start after upgrade and persist thereafter.