### PR TITLE
feat(upgrade)!: replace plugin restart config with no_restart

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ uname -s && uname -m
 Windows 可在 PowerShell 中执行：
 
 ```powershell
-[System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture
+(Get-CimInstance Win32_OperatingSystem).OSArchitecture
 ```
 
 完整安装流程请参考 [快速开始](https://oxidns.org/quickstart)。

--- a/README_EN.md
+++ b/README_EN.md
@@ -193,7 +193,7 @@ uname -s && uname -m
 On Windows PowerShell, run:
 
 ```powershell
-[System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture
+(Get-CimInstance Win32_OperatingSystem).OSArchitecture
 ```
 
 For the full installation flow, see [Quick Start](https://oxidns.org/en/quickstart).

--- a/docs/docs/plugin-reference/executor.md
+++ b/docs/docs/plugin-reference/executor.md
@@ -2200,6 +2200,7 @@ sidebar_position: 3
   args:
       repository: svenshi/oxidns
       asset: auto
+      github_token: ghp_xxx
       cache_dir: ./upgrade/cache
       backup_dir: ./upgrade/backups
       webui_dir: ./webui
@@ -2226,6 +2227,9 @@ sidebar_position: 3
     - GitHub 仓库，默认 `svenshi/oxidns`。
 - `asset`
     - Release asset 名称；`auto` 会按当前平台选择 archive。
+- `github_token`
+    - GitHub 个人访问令牌，用于提高 API 速率限制或访问私有仓库。
+    - 会作为 GitHub API 请求的 Bearer token 使用。
 - `cache_dir` / `backup_dir`
     - 下载缓存目录和替换前备份目录。
 - `webui_dir`
@@ -2239,7 +2243,7 @@ sidebar_position: 3
 - `no_restart`
     - 类型：`bool`
     - 默认值：`false`
-    - 与 CLI `--no-restart` 语义一致。设为 `true` 时，升级成功后不触发自动重启。
+    - 设为 `true` 时，升级成功后不触发自动重启。
     - 默认值 `false` 会在升级成功后自动重启：CLI `apply` 通过系统服务管理器重启已安装服务，插件内执行时通过应用控制通道触发优雅重启并加载新二进制。
 - `timeout`、`socks5`、`insecure_skip_verify`
     - 与 CLI `upgrade` 参数含义一致。

--- a/docs/docs/plugin-reference/executor.md
+++ b/docs/docs/plugin-reference/executor.md
@@ -2204,7 +2204,7 @@ sidebar_position: 3
       backup_dir: ./upgrade/backups
       webui_dir: ./webui
       skip_webui: false
-      restart: service
+      no_restart: false
       force: false
       cleanup: true
       timeout: 30s
@@ -2236,8 +2236,11 @@ sidebar_position: 3
     - 类型：`bool`
     - 默认值：`false`
     - 设为 `true` 时只替换二进制文件，跳过 WebUI 目录升级。
-- `restart`
-    - 可选值为 `none` 或 `service`。设置为 `service` 时，升级成功替换二进制文件后，应用会主动退出并返回错误码，以便 systemd 自动重启。因此，对应的 service 必须将 `Restart` 设置为 `always` 或 `on-failure`。
+- `no_restart`
+    - 类型：`bool`
+    - 默认值：`false`
+    - 与 CLI `--no-restart` 语义一致。设为 `true` 时，升级成功后不触发自动重启。
+    - 默认值 `false` 会在升级成功后自动重启：CLI `apply` 通过系统服务管理器重启已安装服务，插件内执行时通过应用控制通道触发优雅重启并加载新二进制。
 - `timeout`、`socks5`、`insecure_skip_verify`
     - 与 CLI `upgrade` 参数含义一致。
 

--- a/docs/i18n/en/docusaurus-plugin-content-docs/current/plugin-reference/executor.md
+++ b/docs/i18n/en/docusaurus-plugin-content-docs/current/plugin-reference/executor.md
@@ -2076,6 +2076,7 @@ Runs the OxiDNS upgrade flow from the executor pipeline. It is suitable for main
   args:
       repository: svenshi/oxidns
       asset: auto
+      github_token: ghp_xxx
       cache_dir: ./upgrade/cache
       backup_dir: ./upgrade/backups
       webui_dir: ./webui
@@ -2100,6 +2101,9 @@ Runs the OxiDNS upgrade flow from the executor pipeline. It is suitable for main
     - GitHub repository. Default: `svenshi/oxidns`.
 - `asset`
     - Release asset name. `auto` selects the current platform archive.
+- `github_token`
+    - GitHub personal access token for API requests, used to raise the rate limit or access private repositories.
+    - The value is sent as a Bearer token on GitHub API requests.
 - `cache_dir` / `backup_dir`
     - Download cache and pre-replacement backup directories.
 - `webui_dir`
@@ -2110,7 +2114,7 @@ Runs the OxiDNS upgrade flow from the executor pipeline. It is suitable for main
     - When `true`, only the binary is replaced and the WebUI directory upgrade is skipped.
 - `no_restart`
     - Boolean. Default: `false`.
-    - Matches the CLI `--no-restart` flag. When `true`, a successful upgrade does not trigger an automatic restart.
+    - When `true`, a successful upgrade does not trigger an automatic restart.
     - The default `false` restarts automatically after a successful upgrade: CLI `apply` restarts the installed service through the system service manager, while the executor requests a graceful in-process restart through the application control channel so the new binary is loaded.
 - `timeout`, `socks5`, `insecure_skip_verify`
     - Same meaning as the CLI `upgrade` flags.

--- a/docs/i18n/en/docusaurus-plugin-content-docs/current/plugin-reference/executor.md
+++ b/docs/i18n/en/docusaurus-plugin-content-docs/current/plugin-reference/executor.md
@@ -2080,7 +2080,7 @@ Runs the OxiDNS upgrade flow from the executor pipeline. It is suitable for main
       backup_dir: ./upgrade/backups
       webui_dir: ./webui
       skip_webui: false
-      restart: service
+      no_restart: false
       force: false
       cleanup: true
       timeout: 30s
@@ -2108,8 +2108,10 @@ Runs the OxiDNS upgrade flow from the executor pipeline. It is suitable for main
 - `skip_webui`
     - Boolean. Default: `false`.
     - When `true`, only the binary is replaced and the WebUI directory upgrade is skipped.
-- `restart`
-    - Supported values are `none` and `service`. When set to `service`, the application exits with a non-zero status code after the binary is successfully replaced, allowing systemd to restart it automatically. Therefore, the corresponding service must set `Restart` to `always` or `on-failure`.
+- `no_restart`
+    - Boolean. Default: `false`.
+    - Matches the CLI `--no-restart` flag. When `true`, a successful upgrade does not trigger an automatic restart.
+    - The default `false` restarts automatically after a successful upgrade: CLI `apply` restarts the installed service through the system service manager, while the executor requests a graceful in-process restart through the application control channel so the new binary is loaded.
 - `timeout`, `socks5`, `insecure_skip_verify`
     - Same meaning as the CLI `upgrade` flags.
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -21,7 +21,18 @@ pub mod export_dat;
 mod graph;
 mod logging;
 
+use std::path::PathBuf;
+use std::sync::OnceLock;
+
 use tokio::runtime;
+
+/// Executable path captured at process startup, before any binary replacement.
+///
+/// On Linux, after an atomic rename-over-self upgrade `/proc/self/exe` acquires
+/// a ` (deleted)` suffix that makes the path non-executable. Reading the path
+/// here — before the upgrade plugin has a chance to replace the binary —
+/// guarantees `exec_restart()` always has a valid path to hand to `execvp()`.
+static ORIGINAL_EXE: OnceLock<PathBuf> = OnceLock::new();
 use tokio::sync::{mpsc, oneshot};
 use tracing::{error, info};
 
@@ -36,6 +47,8 @@ use crate::{config, core};
 
 /// Start OxiDNS in the foreground using the provided CLI options.
 pub fn run(start: StartOptions) -> Result<()> {
+    // Capture the exe path before any binary replacement can invalidate it.
+    ORIGINAL_EXE.get_or_init(|| std::env::current_exe().unwrap_or_default());
     AppClock::start();
     prepare_working_dir(start.working_dir.as_ref())?;
     // Clean up any leftover staging file from an interrupted Windows upgrade.
@@ -138,8 +151,11 @@ fn init_runtime(options: StartOptions, config: Config) -> Result<()> {
 /// launchd, Docker, etc.) continues tracking the process without interruption.
 /// On non-Unix platforms a new process is spawned and the current one exits.
 pub(crate) fn exec_restart() -> Result<()> {
-    let exe = std::env::current_exe()
-        .map_err(|e| DnsError::runtime(format!("restart: cannot get current executable: {e}")))?;
+    let exe = ORIGINAL_EXE
+        .get()
+        .cloned()
+        .or_else(|| std::env::current_exe().ok())
+        .ok_or_else(|| DnsError::runtime("restart: cannot determine executable path"))?;
     // std::env::args() reads the OS-level process arguments and is safe to
     // call at any point during the process lifetime.
     let args: Vec<std::ffi::OsString> = std::env::args_os().skip(1).collect();

--- a/src/app/cli.rs
+++ b/src/app/cli.rs
@@ -343,6 +343,8 @@ mod tests {
             "--socks5",
             "127.0.0.1:1080",
             "--insecure-skip-verify",
+            "--github-token",
+            "ghp_test_token",
         ];
 
         let cli = Cli::parse_from(args);
@@ -363,7 +365,7 @@ mod tests {
                 timeout: Duration::from_secs(120),
                 socks5: Some("127.0.0.1:1080".to_string()),
                 insecure_skip_verify: true,
-                github_token: None,
+                github_token: Some("ghp_test_token".to_string()),
             })
         );
     }

--- a/src/app/cli.rs
+++ b/src/app/cli.rs
@@ -7,7 +7,6 @@ use std::path::PathBuf;
 use std::time::Duration;
 
 use clap::{Args, Parser, Subcommand};
-use serde::Deserialize;
 
 /// Top-level CLI definition.
 #[derive(Parser, Clone, Debug)]
@@ -186,14 +185,6 @@ pub enum UpgradeAction {
     Check,
     Download,
     Apply,
-}
-
-/// Restart behavior after applying an upgrade.
-#[derive(clap::ValueEnum, Clone, Copy, Debug, PartialEq, Eq, Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub enum RestartMode {
-    None,
-    Service,
 }
 
 fn parse_cli_duration(raw: &str) -> std::result::Result<Duration, String> {

--- a/src/plugin/executor/upgrade.rs
+++ b/src/plugin/executor/upgrade.rs
@@ -157,7 +157,6 @@ struct UpgradePluginConfig {
     backup_dir: Option<PathBuf>,
     webui_dir: Option<PathBuf>,
     skip_webui: Option<bool>,
-    #[serde(alias = "no-restart")]
     no_restart: Option<bool>,
     allow_prerelease: Option<bool>,
     force: Option<bool>,
@@ -240,7 +239,7 @@ fn parse_quick_setup(param: Option<String>) -> Result<UpgradeConfig> {
             config.force = true;
             continue;
         }
-        if token == "no_restart" || token == "no-restart" {
+        if token == "no_restart" {
             config.no_restart = true;
             continue;
         }
@@ -256,8 +255,11 @@ fn parse_quick_setup(param: Option<String>) -> Result<UpgradeConfig> {
             "force" => {
                 config.force = parse_bool_quick_setup(key, value)?;
             }
-            "no_restart" | "no-restart" => {
+            "no_restart" => {
                 config.no_restart = parse_bool_quick_setup(key, value)?;
+            }
+            "github_token" => {
+                config.github_token = Some(value.to_string());
             }
             _ => {
                 return Err(DnsError::plugin(format!(
@@ -337,11 +339,25 @@ mod tests {
     }
 
     #[test]
-    fn parse_upgrade_config_accepts_cli_style_no_restart_alias() {
+    fn parse_upgrade_config_rejects_cli_style_no_restart_alias() {
         let value = serde_yaml_ng::from_str::<Value>("no-restart: true").unwrap();
+        let err = parse_upgrade_config(Some(value)).unwrap_err();
+        assert!(err.to_string().contains("unknown field `no-restart`"));
+    }
+
+    #[test]
+    fn parse_upgrade_config_accepts_github_token() {
+        let value = serde_yaml_ng::from_str::<Value>("github_token: ghp_test").unwrap();
         let parsed = parse_upgrade_config(Some(value)).unwrap();
         let config = parsed.into_upgrade_config().unwrap();
-        assert!(config.no_restart);
+        assert_eq!(config.github_token.as_deref(), Some("ghp_test"));
+    }
+
+    #[test]
+    fn parse_upgrade_config_rejects_cli_style_github_token_alias() {
+        let value = serde_yaml_ng::from_str::<Value>("github-token: ghp_test").unwrap();
+        let err = parse_upgrade_config(Some(value)).unwrap_err();
+        assert!(err.to_string().contains("unknown field `github-token`"));
     }
 
     #[test]
@@ -406,9 +422,13 @@ mod tests {
 
     #[test]
     fn quick_setup_accepts_apply_options() {
-        let config = parse_quick_setup(Some("force=true no_restart=true".to_string())).unwrap();
+        let config = parse_quick_setup(Some(
+            "force=true no_restart=true github_token=ghp_test".to_string(),
+        ))
+        .unwrap();
         assert!(config.force);
         assert!(config.no_restart);
+        assert_eq!(config.github_token.as_deref(), Some("ghp_test"));
         assert_eq!(config.repository, "svenshi/oxidns");
     }
 
@@ -424,6 +444,21 @@ mod tests {
     #[test]
     fn quick_setup_rejects_non_force_options() {
         let err = parse_quick_setup(Some("restart=service".to_string())).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("unsupported upgrade quick setup token")
+        );
+    }
+
+    #[test]
+    fn quick_setup_rejects_hyphenated_plugin_config_keys() {
+        let err = parse_quick_setup(Some("no-restart=true".to_string())).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("unsupported upgrade quick setup token")
+        );
+
+        let err = parse_quick_setup(Some("github-token=ghp_test".to_string())).unwrap_err();
         assert!(
             err.to_string()
                 .contains("unsupported upgrade quick setup token")

--- a/src/plugin/executor/upgrade.rs
+++ b/src/plugin/executor/upgrade.rs
@@ -14,7 +14,6 @@ use serde::Deserialize;
 use serde_yaml_ng::Value;
 use tracing::info;
 
-use crate::app::cli::RestartMode;
 use crate::config::types::PluginConfig;
 use crate::core::context::DnsContext;
 use crate::core::error::{DnsError, Result};
@@ -56,7 +55,7 @@ impl Executor for UpgradeExecutor {
             backup_dir = %self.config.backup_dir.display(),
             webui_dir = %self.config.webui_dir.display(),
             skip_webui = self.config.skip_webui,
-            restart = ?self.config.restart,
+            no_restart = self.config.no_restart,
             force = self.config.force,
             cleanup = self.config.cleanup_after_apply,
             "upgrade apply started"
@@ -158,7 +157,8 @@ struct UpgradePluginConfig {
     backup_dir: Option<PathBuf>,
     webui_dir: Option<PathBuf>,
     skip_webui: Option<bool>,
-    restart: Option<RestartMode>,
+    #[serde(alias = "no-restart")]
+    no_restart: Option<bool>,
     allow_prerelease: Option<bool>,
     force: Option<bool>,
     cleanup: Option<bool>,
@@ -189,8 +189,8 @@ impl UpgradePluginConfig {
         if let Some(value) = self.skip_webui {
             config.skip_webui = value;
         }
-        if let Some(value) = self.restart {
-            config.restart = value;
+        if let Some(value) = self.no_restart {
+            config.no_restart = value;
         }
         if let Some(value) = self.allow_prerelease {
             config.allow_prerelease = value;
@@ -240,6 +240,10 @@ fn parse_quick_setup(param: Option<String>) -> Result<UpgradeConfig> {
             config.force = true;
             continue;
         }
+        if token == "no_restart" || token == "no-restart" {
+            config.no_restart = true;
+            continue;
+        }
 
         let Some((key, value)) = token.split_once('=') else {
             return Err(DnsError::plugin(format!(
@@ -251,6 +255,9 @@ fn parse_quick_setup(param: Option<String>) -> Result<UpgradeConfig> {
         match key {
             "force" => {
                 config.force = parse_bool_quick_setup(key, value)?;
+            }
+            "no_restart" | "no-restart" => {
+                config.no_restart = parse_bool_quick_setup(key, value)?;
             }
             _ => {
                 return Err(DnsError::plugin(format!(
@@ -301,6 +308,7 @@ mod tests {
         let parsed = parse_upgrade_config(None).unwrap();
         let config = parsed.into_upgrade_config().unwrap();
         assert!(!config.force);
+        assert!(!config.no_restart);
         assert!(config.cleanup_after_apply);
     }
 
@@ -318,6 +326,29 @@ mod tests {
         let parsed = parse_upgrade_config(Some(value)).unwrap();
         let config = parsed.into_upgrade_config().unwrap();
         assert!(!config.cleanup_after_apply);
+    }
+
+    #[test]
+    fn parse_upgrade_config_accepts_no_restart_flag() {
+        let value = serde_yaml_ng::from_str::<Value>("no_restart: true").unwrap();
+        let parsed = parse_upgrade_config(Some(value)).unwrap();
+        let config = parsed.into_upgrade_config().unwrap();
+        assert!(config.no_restart);
+    }
+
+    #[test]
+    fn parse_upgrade_config_accepts_cli_style_no_restart_alias() {
+        let value = serde_yaml_ng::from_str::<Value>("no-restart: true").unwrap();
+        let parsed = parse_upgrade_config(Some(value)).unwrap();
+        let config = parsed.into_upgrade_config().unwrap();
+        assert!(config.no_restart);
+    }
+
+    #[test]
+    fn parse_upgrade_config_rejects_old_restart_field() {
+        let value = serde_yaml_ng::from_str::<Value>("restart: service").unwrap();
+        let err = parse_upgrade_config(Some(value)).unwrap_err();
+        assert!(err.to_string().contains("unknown field `restart`"));
     }
 
     #[test]
@@ -375,8 +406,9 @@ mod tests {
 
     #[test]
     fn quick_setup_accepts_apply_options() {
-        let config = parse_quick_setup(Some("force=true".to_string())).unwrap();
+        let config = parse_quick_setup(Some("force=true no_restart=true".to_string())).unwrap();
         assert!(config.force);
+        assert!(config.no_restart);
         assert_eq!(config.repository, "svenshi/oxidns");
     }
 

--- a/src/upgrade.rs
+++ b/src/upgrade.rs
@@ -843,7 +843,7 @@ async fn fetch_release(config: &UpgradeConfig) -> Result<GitHubRelease> {
 
 fn github_request_headers(token: Option<&str>) -> Vec<(http::header::HeaderName, HeaderValue)> {
     let mut headers = vec![(USER_AGENT, HeaderValue::from_static(GITHUB_USER_AGENT))];
-    if let Some(token) = token
+    if let Some(token) = token.map(str::trim).filter(|token| !token.is_empty())
         && let Ok(value) = HeaderValue::try_from(format!("Bearer {token}"))
     {
         headers.push((AUTHORIZATION, value));
@@ -1219,6 +1219,20 @@ mod tests {
     }
 
     #[test]
+    fn github_request_headers_include_authorization_when_token_is_set() {
+        let headers = github_request_headers(Some(" ghp_test "));
+        assert!(headers.iter().any(|(name, value)| {
+            *name == AUTHORIZATION && value.to_str().unwrap() == "Bearer ghp_test"
+        }));
+    }
+
+    #[test]
+    fn github_request_headers_skip_authorization_when_token_is_empty() {
+        let headers = github_request_headers(Some("   "));
+        assert!(!headers.iter().any(|(name, _)| *name == AUTHORIZATION));
+    }
+
+    #[test]
     fn config_default_has_webui_defaults() {
         let config = UpgradeConfig::default();
         assert_eq!(config.webui_dir, PathBuf::from("./webui"));
@@ -1246,6 +1260,20 @@ mod tests {
         let config = UpgradeConfig::from_cli(&opts);
         assert_eq!(config.webui_dir, PathBuf::from("/tmp/oxidns-webui"));
         assert!(config.skip_webui);
+    }
+
+    #[test]
+    fn from_cli_maps_github_token() {
+        use clap::Parser;
+
+        use crate::app::cli::{Cli, Command};
+
+        let cli = Cli::parse_from(["oxidns", "upgrade", "check", "--github-token", "ghp_test"]);
+        let Command::Upgrade(opts) = cli.command else {
+            panic!("expected upgrade command");
+        };
+        let config = UpgradeConfig::from_cli(&opts);
+        assert_eq!(config.github_token.as_deref(), Some("ghp_test"));
     }
 
     #[test]

--- a/src/upgrade.rs
+++ b/src/upgrade.rs
@@ -16,7 +16,7 @@ use sha2::{Digest, Sha256};
 use tokio::time::timeout;
 use tracing::info;
 
-use crate::app::cli::{RestartMode, UpgradeAction, UpgradeOptions};
+use crate::app::cli::{UpgradeAction, UpgradeOptions};
 use crate::core::VERSION;
 use crate::core::error::{DnsError, Result};
 use crate::network::http_client::{
@@ -43,7 +43,7 @@ pub struct UpgradeConfig {
     pub backup_dir: PathBuf,
     pub webui_dir: PathBuf,
     pub skip_webui: bool,
-    pub restart: RestartMode,
+    pub no_restart: bool,
     pub allow_prerelease: bool,
     pub force: bool,
     pub cleanup_after_apply: bool,
@@ -63,7 +63,7 @@ impl Default for UpgradeConfig {
             backup_dir: PathBuf::from(DEFAULT_BACKUP_DIR),
             webui_dir: PathBuf::from(DEFAULT_WEBUI_DIR),
             skip_webui: false,
-            restart: RestartMode::Service,
+            no_restart: false,
             allow_prerelease: false,
             force: false,
             cleanup_after_apply: false,
@@ -85,11 +85,7 @@ impl UpgradeConfig {
             backup_dir: options.backup_dir.clone(),
             webui_dir: options.webui_dir.clone(),
             skip_webui: options.skip_webui,
-            restart: if options.no_restart {
-                RestartMode::None
-            } else {
-                RestartMode::Service
-            },
+            no_restart: options.no_restart,
             allow_prerelease: options.allow_prerelease,
             force: options.force,
             cleanup_after_apply: false,
@@ -194,7 +190,7 @@ pub fn run_cli(action: UpgradeAction, config: UpgradeConfig) -> Result<()> {
                         }
                         println!("Downloading, verifying, and replacing the current binary...");
                         let outcome = apply_unchecked(&config, UpgradeContext::Cli).await?;
-                        if config.restart == RestartMode::Service {
+                        if !config.no_restart {
                             println!("Service restart completed.");
                         }
                         println!(
@@ -250,7 +246,7 @@ fn print_cli_plan(action: &str, config: &UpgradeConfig) {
     println!("Cache: {}", config.cache_dir.display());
     if action == "apply" {
         println!("Backup: {}", config.backup_dir.display());
-        println!("Restart: {:?}", config.restart);
+        println!("No restart: {}", config.no_restart);
         println!("Force: {}", config.force);
     }
     if action == "apply" || action == "check" {
@@ -521,7 +517,7 @@ async fn apply_unchecked(
         let _ = cleanup_upgrade_artifacts(config);
     }
 
-    if config.restart == RestartMode::Service {
+    if !config.no_restart {
         print_cli_apply_step(restart_context, "Restarting installed service...");
         restart_after_apply(restart_context)?;
     }
@@ -1227,6 +1223,7 @@ mod tests {
         let config = UpgradeConfig::default();
         assert_eq!(config.webui_dir, PathBuf::from("./webui"));
         assert!(!config.skip_webui);
+        assert!(!config.no_restart);
     }
 
     #[test]
@@ -1249,6 +1246,20 @@ mod tests {
         let config = UpgradeConfig::from_cli(&opts);
         assert_eq!(config.webui_dir, PathBuf::from("/tmp/oxidns-webui"));
         assert!(config.skip_webui);
+    }
+
+    #[test]
+    fn from_cli_maps_no_restart_flag() {
+        use clap::Parser;
+
+        use crate::app::cli::{Cli, Command};
+
+        let cli = Cli::parse_from(["oxidns", "upgrade", "apply", "--no-restart"]);
+        let Command::Upgrade(opts) = cli.command else {
+            panic!("expected upgrade command");
+        };
+        let config = UpgradeConfig::from_cli(&opts);
+        assert!(config.no_restart);
     }
 
     #[cfg(not(windows))]

--- a/webui/lib/plugin-definitions/docs.ts
+++ b/webui/lib/plugin-definitions/docs.ts
@@ -316,7 +316,7 @@ export const pluginFieldDocs = {
       "- 类型：`bool`；必填：否；默认值：`true`\n- 作用：控制插件退出时是否清理由其管理的条目。启用后，插件在正常关闭阶段会删除自身写入并可识别归属的 RouterOS 地址项。\n- 影响：关闭该选项后，已写入条目会继续保留在 RouterOS 中，适合要求策略状态跨进程重启保留的场景。",
   },
   upgrade: {
-    args: "- `force`\n    - 类型：`bool`\n    - 默认值：`false`\n    - 即使目标 release 不比当前版本更新，也继续下载、校验并替换。\n- `cleanup`\n    - 类型：`bool`\n    - 默认值：`true`\n    - 升级成功后清理 `cache_dir` 和 `backup_dir`。\n- `repository`\n    - GitHub 仓库，默认 `svenshi/oxidns`。\n- `asset`\n    - Release asset 名称；`auto` 会按当前平台选择 archive。\n- `cache_dir` / `backup_dir`\n    - 下载缓存目录和替换前备份目录。\n- `no_restart`\n    - 类型：`bool`\n    - 默认值：`false`\n    - 与 CLI `--no-restart` 语义一致；设为 `true` 时，升级成功后不触发自动重启。\n- `timeout`\n    - 限制升级过程的总等待时间。\n- `socks5`\n    - 升级下载时使用的 SOCKS5 代理。\n- `insecure_skip_verify`\n    - 升级下载时跳过 HTTPS 证书校验。",
+    args: "- `force`\n    - 类型：`bool`\n    - 默认值：`false`\n    - 即使目标 release 不比当前版本更新，也继续下载、校验并替换。\n- `cleanup`\n    - 类型：`bool`\n    - 默认值：`true`\n    - 升级成功后清理 `cache_dir` 和 `backup_dir`。\n- `repository`\n    - GitHub 仓库，默认 `svenshi/oxidns`。\n- `asset`\n    - Release asset 名称；`auto` 会按当前平台选择 archive。\n- `github_token`\n    - GitHub 个人访问令牌，用于提高 API 速率限制或访问私有仓库。\n- `cache_dir` / `backup_dir`\n    - 下载缓存目录和替换前备份目录。\n- `no_restart`\n    - 类型：`bool`\n    - 默认值：`false`\n    - 设为 `true` 时，升级成功后不触发自动重启。\n- `timeout`\n    - 限制升级过程的总等待时间。\n- `socks5`\n    - 升级下载时使用的 SOCKS5 代理。\n- `insecure_skip_verify`\n    - 升级下载时跳过 HTTPS 证书校验。",
   },
   cron: {
     jobs: "- 类型：`array`；必填：是；默认值：无\n- 作用：定义一个或多个后台任务。\n- 运行影响：\n  - 数组不能为空。\n  - 每个任务独立维护自己的调度状态和重叠保护。",

--- a/webui/lib/plugin-definitions/docs.ts
+++ b/webui/lib/plugin-definitions/docs.ts
@@ -316,7 +316,7 @@ export const pluginFieldDocs = {
       "- 类型：`bool`；必填：否；默认值：`true`\n- 作用：控制插件退出时是否清理由其管理的条目。启用后，插件在正常关闭阶段会删除自身写入并可识别归属的 RouterOS 地址项。\n- 影响：关闭该选项后，已写入条目会继续保留在 RouterOS 中，适合要求策略状态跨进程重启保留的场景。",
   },
   upgrade: {
-    args: "- `force`\n    - 类型：`bool`\n    - 默认值：`false`\n    - 即使目标 release 不比当前版本更新，也继续下载、校验并替换。\n- `cleanup`\n    - 类型：`bool`\n    - 默认值：`true`\n    - 升级成功后清理 `cache_dir` 和 `backup_dir`。\n- `repository`\n    - GitHub 仓库，默认 `svenshi/oxidns`。\n- `asset`\n    - Release asset 名称；`auto` 会按当前平台选择 archive。\n- `cache_dir` / `backup_dir`\n    - 下载缓存目录和替换前备份目录。\n- `restart`\n    - 可选值为 `none` 或 `service`。设置为 `service` 时，升级成功替换二进制文件后，应用会主动退出并返回错误码，以便 systemd 自动重启。因此，对应的 service 必须将 `Restart` 设置为 `always` 或 `on-failure`。\n- `timeout`\n    - 限制升级过程的总等待时间。\n- `socks5`\n    - 升级下载时使用的 SOCKS5 代理。\n- `insecure_skip_verify`\n    - 升级下载时跳过 HTTPS 证书校验。",
+    args: "- `force`\n    - 类型：`bool`\n    - 默认值：`false`\n    - 即使目标 release 不比当前版本更新，也继续下载、校验并替换。\n- `cleanup`\n    - 类型：`bool`\n    - 默认值：`true`\n    - 升级成功后清理 `cache_dir` 和 `backup_dir`。\n- `repository`\n    - GitHub 仓库，默认 `svenshi/oxidns`。\n- `asset`\n    - Release asset 名称；`auto` 会按当前平台选择 archive。\n- `cache_dir` / `backup_dir`\n    - 下载缓存目录和替换前备份目录。\n- `no_restart`\n    - 类型：`bool`\n    - 默认值：`false`\n    - 与 CLI `--no-restart` 语义一致；设为 `true` 时，升级成功后不触发自动重启。\n- `timeout`\n    - 限制升级过程的总等待时间。\n- `socks5`\n    - 升级下载时使用的 SOCKS5 代理。\n- `insecure_skip_verify`\n    - 升级下载时跳过 HTTPS 证书校验。",
   },
   cron: {
     jobs: "- 类型：`array`；必填：是；默认值：无\n- 作用：定义一个或多个后台任务。\n- 运行影响：\n  - 数组不能为空。\n  - 每个任务独立维护自己的调度状态和重叠保护。",

--- a/webui/lib/plugin-definitions/executor.ts
+++ b/webui/lib/plugin-definitions/executor.ts
@@ -1510,6 +1510,13 @@ export const executorPluginDefinitions: PluginKindDefinition[] = [
         default: "auto",
       },
       {
+        key: "github_token",
+        description:
+          "GitHub 个人访问令牌，用于提高 API 速率限制或访问私有仓库。",
+        label: "GitHub Token",
+        type: "text",
+      },
+      {
         key: "cache_dir",
         description: "下载缓存目录。",
         label: "下载缓存目录",
@@ -1540,7 +1547,7 @@ export const executorPluginDefinitions: PluginKindDefinition[] = [
       {
         key: "no_restart",
         description:
-          "与 CLI --no-restart 语义一致，启用后升级成功也不会触发自动重启。",
+          "启用后升级成功也不会触发自动重启。",
         label: "跳过自动重启",
         type: "switch",
         default: false,

--- a/webui/lib/plugin-definitions/executor.ts
+++ b/webui/lib/plugin-definitions/executor.ts
@@ -1538,15 +1538,12 @@ export const executorPluginDefinitions: PluginKindDefinition[] = [
         default: false,
       },
       {
-        key: "restart",
+        key: "no_restart",
         description:
-          "设置为 service 时，升级成功替换二进制文件后应用会主动退出并返回错误码，以便 systemd 自动重启。",
-        label: "重启策略",
-        type: "select",
-        options: [
-          { label: "None", value: "none" },
-          { label: "Service", value: "service" },
-        ],
+          "与 CLI --no-restart 语义一致，启用后升级成功也不会触发自动重启。",
+        label: "跳过自动重启",
+        type: "switch",
+        default: false,
       },
       {
         key: "timeout",


### PR DESCRIPTION
- Align the upgrade executor restart option with the CLI --no-restart flag.
- Remove the old restart mode enum and use a shared no_restart boolean.
- Update WebUI plugin metadata and Chinese/English plugin docs.

BREAKING CHANGE: upgrade executor configs must use no_restart instead of restart.