### PR TITLE
feat(query_recorder): add history clearing support

### DIFF
--- a/docs/docs/api.md
+++ b/docs/docs/api.md
@@ -512,6 +512,22 @@ GET /api/plugins/reverse_lookup_main?ip=8.8.8.8
 * `404 Not Found`
   * 记录不存在。
 
+#### `DELETE /api/plugins/<tag>/records`
+
+清空当前 recorder 的所有历史查询记录和 `steps` 路径事件。清空操作会先 flush 后台写入队列，随后删除 SQLite 记录表中的所有行，并清空内存 tail。
+
+返回：
+
+* `200 OK`
+  * JSON，形如：
+
+```json
+{
+  "ok": true,
+  "cleared_records": 128
+}
+```
+
 #### `GET /api/plugins/<tag>/stats/plugins`
 
 按路径事件聚合插件命中情况。

--- a/docs/docs/plugin-reference/executor.md
+++ b/docs/docs/plugin-reference/executor.md
@@ -1463,6 +1463,9 @@ old-static.example.com static.example.net
     - `qtype=<type>` / `rcode=<rcode>` / `status=all|error|has_response|no_response`
 - `GET /plugins/<tag>/records/<id>`
   - 返回单条完整记录，并附带 `steps`。
+- `DELETE /plugins/<tag>/records`
+  - 清空当前 recorder 的所有历史记录和 `steps`，并清空内存 tail。
+  - 操作会先 flush 后台写入队列，返回 `cleared_records` 表示删除的主表记录数。
 - `GET /plugins/<tag>/stats/plugins`
   - 返回按 `matcher / executor / builtin` 聚合的命中统计。
   - 支持 `since_ms`、`until_ms`、`kind=matcher|executor|builtin|all` 和 records 的过滤参数。

--- a/docs/i18n/en/docusaurus-plugin-content-docs/current/api.md
+++ b/docs/i18n/en/docusaurus-plugin-content-docs/current/api.md
@@ -512,6 +512,22 @@ Responses:
 * `404 Not Found`
   * The record does not exist.
 
+#### `DELETE /api/plugins/<tag>/records`
+
+Clears all persisted query-history rows and `steps` path events for the current recorder. The operation first flushes the background writer queue, then deletes all rows from the SQLite records table and clears the in-memory tail.
+
+Responses:
+
+* `200 OK`
+  * JSON shaped like:
+
+```json
+{
+  "ok": true,
+  "cleared_records": 128
+}
+```
+
 #### `GET /api/plugins/<tag>/stats/plugins`
 
 Aggregates plugin hit information from recorded path events.

--- a/docs/i18n/en/docusaurus-plugin-content-docs/current/plugin-reference/executor.md
+++ b/docs/i18n/en/docusaurus-plugin-content-docs/current/plugin-reference/executor.md
@@ -1374,6 +1374,9 @@ Persists the entry request, the post-`next` response, and `sequence` execution-p
     - `qtype=<type>` / `rcode=<rcode>` / `status=all|error|has_response|no_response`
 - `GET /plugins/<tag>/records/<id>`
   - Returns one full record plus `steps`.
+- `DELETE /plugins/<tag>/records`
+  - Clears all history rows and `steps` for the current recorder, and clears the in-memory tail.
+  - The operation first flushes the background writer queue and returns `cleared_records` for the number of deleted main-table rows.
 - `GET /plugins/<tag>/stats/plugins`
   - Returns hit stats grouped by `matcher / executor / builtin`.
   - Supports `since_ms`, `until_ms`, `kind=matcher|executor|builtin|all`, and the record filters.

--- a/src/plugin/executor/query_recorder/api.rs
+++ b/src/plugin/executor/query_recorder/api.rs
@@ -49,6 +49,12 @@ struct RecordDetailResponse {
 }
 
 #[derive(Debug, Clone, Serialize)]
+struct RecordsClearResponse {
+    ok: bool,
+    cleared_records: usize,
+}
+
+#[derive(Debug, Clone, Serialize)]
 struct PluginStatsResponse {
     ok: bool,
     query_total: u64,
@@ -64,6 +70,11 @@ struct RecordsListHandler {
 struct RecordDetailHandler {
     backend: Arc<RecorderBackend>,
     path_prefix: String,
+}
+
+#[derive(Debug)]
+struct RecordsClearHandler {
+    backend: Arc<RecorderBackend>,
 }
 
 #[derive(Debug)]
@@ -180,6 +191,32 @@ impl ApiHandler for RecordDetailHandler {
             Err(err) => json_error(
                 StatusCode::INTERNAL_SERVER_ERROR,
                 "query_recorder_record_failed",
+                format!("blocking task failed: {err}"),
+            ),
+        }
+    }
+}
+
+#[async_trait]
+impl ApiHandler for RecordsClearHandler {
+    async fn handle(&self, _request: Request<Bytes>) -> crate::api::ApiResponse {
+        let backend = self.backend.clone();
+        match tokio::task::spawn_blocking(move || backend.clear_history()).await {
+            Ok(Ok(result)) => json_ok(
+                StatusCode::OK,
+                &RecordsClearResponse {
+                    ok: true,
+                    cleared_records: result.cleared_records,
+                },
+            ),
+            Ok(Err(err)) => json_error(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "query_recorder_clear_failed",
+                err,
+            ),
+            Err(err) => json_error(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "query_recorder_clear_failed",
                 format!("blocking task failed: {err}"),
             ),
         }
@@ -748,6 +785,9 @@ pub(super) fn register(backend: &Arc<RecorderBackend>) -> Result<()> {
         &backend.tag,
         |plugin_api|
         GET "/records" => RecordsListHandler {
+            backend: backend.clone(),
+        },
+        DELETE "/records" => RecordsClearHandler {
             backend: backend.clone(),
         },
         GET_PREFIX "/records/" => RecordDetailHandler {

--- a/src/plugin/executor/query_recorder/backend.rs
+++ b/src/plugin/executor/query_recorder/backend.rs
@@ -4,7 +4,7 @@
 use std::collections::VecDeque;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
-use std::sync::mpsc::{SyncSender, sync_channel};
+use std::sync::mpsc::{Sender as ReplySender, SyncSender, sync_channel};
 use std::sync::{Arc, Mutex};
 use std::thread::{self, JoinHandle};
 use std::time::Duration;
@@ -31,9 +31,21 @@ pub(super) struct RecorderBackend {
 }
 
 #[derive(Debug, Clone)]
+pub(super) struct ClearHistoryResult {
+    pub(super) cleared_records: usize,
+}
+
+pub(super) type ClearHistoryReply = std::result::Result<ClearHistoryResult, String>;
+
+#[derive(Debug)]
 pub(super) enum WriterCommand {
     Insert(Box<PendingRecord>),
-    Cleanup { cutoff_ms: i64 },
+    Cleanup {
+        cutoff_ms: i64,
+    },
+    ClearHistory {
+        reply_tx: ReplySender<ClearHistoryReply>,
+    },
 }
 
 #[derive(Debug)]
@@ -141,5 +153,15 @@ impl RecorderBackend {
         if let Err(err) = self.queue_tx.try_send(WriterCommand::Cleanup { cutoff_ms }) {
             warn!("query_recorder cleanup skipped: {}", err);
         }
+    }
+
+    pub(super) fn clear_history(&self) -> ClearHistoryReply {
+        let (reply_tx, reply_rx) = std::sync::mpsc::channel();
+        self.queue_tx
+            .send(WriterCommand::ClearHistory { reply_tx })
+            .map_err(|err| format!("query_recorder clear enqueue failed: {err}"))?;
+        reply_rx
+            .recv()
+            .map_err(|err| format!("query_recorder clear reply failed: {err}"))?
     }
 }

--- a/src/plugin/executor/query_recorder/store.rs
+++ b/src/plugin/executor/query_recorder/store.rs
@@ -13,7 +13,7 @@ use serde::Serialize;
 use serde::de::DeserializeOwned;
 use tokio::sync::broadcast;
 
-use super::backend::{RecorderBackend, WriterCommand, WriterThreadContext};
+use super::backend::{ClearHistoryResult, RecorderBackend, WriterCommand, WriterThreadContext};
 use super::model::{
     DistributionQuery, DistributionResponse, DistributionRow, LatencyHistogramBucket, LatencyQuery,
     LatencySlowRow, LatencySummary, ListCursor, ListQuery, PendingRecord, PluginStatsKind,
@@ -30,6 +30,9 @@ const PLUGIN_STATS_SAMPLE_LIMIT: usize = 10_000;
 pub(super) fn open_database(path: &Path) -> rusqlite::Result<Connection> {
     let conn = Connection::open(path)?;
     // Tuned for a workload of "one writer + bursty readers".
+    // - auto_vacuum must be selected before WAL or schema creation for a fresh
+    //   database; otherwise SQLite keeps the default NONE mode until a manual
+    //   VACUUM rewrites the file.
     // - WAL + synchronous=NORMAL is the standard high-throughput combo for the
     //   writer thread and keeps readers non-blocking.
     // - temp_store=MEMORY keeps the implicit temp tables that GROUP BY / ORDER BY /
@@ -40,10 +43,10 @@ pub(super) fn open_database(path: &Path) -> rusqlite::Result<Connection> {
     // - mmap_size lets SQLite memory-map the DB pages, which is a noticeable
     //   speedup for read-heavy SELECTs once the OS page cache is warm.
     conn.execute_batch(
-        "PRAGMA journal_mode=WAL;
+        "PRAGMA auto_vacuum=INCREMENTAL;
+         PRAGMA journal_mode=WAL;
          PRAGMA synchronous=NORMAL;
          PRAGMA foreign_keys=ON;
-         PRAGMA auto_vacuum=INCREMENTAL;
          PRAGMA temp_store=MEMORY;
          PRAGMA cache_size=-32768;
          PRAGMA mmap_size=134217728;",
@@ -193,6 +196,19 @@ pub(super) fn run_writer_thread(
                     &broadcaster,
                 )?;
                 run_cleanup(&mut conn, &tables, cutoff_ms)?;
+            }
+            Ok(WriterCommand::ClearHistory { reply_tx }) => {
+                let result = flush_pending(
+                    &mut conn,
+                    &tables,
+                    &mut pending,
+                    &tail,
+                    memory_tail,
+                    &broadcaster,
+                )
+                .and_then(|_| run_clear_history(&mut conn, &tables, &tail))
+                .map_err(|err| err.to_string());
+                let _ = reply_tx.send(result);
             }
             Err(RecvTimeoutError::Timeout) => {
                 flush_pending(
@@ -403,6 +419,24 @@ fn run_cleanup(conn: &mut Connection, tables: &TableNames, cutoff_ms: i64) -> ru
         }
     }
     conn.execute_batch("PRAGMA wal_checkpoint(PASSIVE); PRAGMA incremental_vacuum;")
+}
+
+fn run_clear_history(
+    conn: &mut Connection,
+    tables: &TableNames,
+    tail: &Arc<Mutex<VecDeque<RecordDetail>>>,
+) -> Result<ClearHistoryResult> {
+    let tx = conn.transaction()?;
+    let cleared_records = tx.execute(&format!("DELETE FROM {}", tables.records), [])?;
+    tx.commit()?;
+    conn.execute_batch("PRAGMA wal_checkpoint(TRUNCATE); PRAGMA incremental_vacuum;")?;
+
+    let mut tail_guard = tail
+        .lock()
+        .map_err(|_| "query_recorder tail buffer lock poisoned".to_string())?;
+    tail_guard.clear();
+
+    Ok(ClearHistoryResult { cleared_records })
 }
 
 pub(super) fn query_records(

--- a/src/plugin/executor/query_recorder/tests.rs
+++ b/src/plugin/executor/query_recorder/tests.rs
@@ -12,8 +12,9 @@ use super::model::{
     TopQuery,
 };
 use super::store::{
-    load_latency_summary, load_plugin_stats, load_qtype_distribution, load_rcode_distribution,
-    load_timeseries, load_top_clients, load_top_qnames, query_records, table_names,
+    create_schema, load_latency_summary, load_plugin_stats, load_qtype_distribution,
+    load_rcode_distribution, load_timeseries, load_top_clients, load_top_qnames, open_database,
+    query_records, table_names,
 };
 use super::{QueryRecorder, QueryRecorderFactory, resolve_config};
 use crate::core::app_clock::AppClock;
@@ -108,6 +109,20 @@ fn test_table_names_include_tag_hash_and_version() {
     assert!(tables.records.starts_with("qr_recorder_main_"));
     assert!(tables.records.ends_with("_v1_records"));
     assert!(tables.steps.ends_with("_v1_steps"));
+}
+
+#[test]
+fn test_open_database_enables_incremental_auto_vacuum_for_new_database() {
+    let temp = NamedTempFile::new().unwrap();
+    let tables = table_names("rec");
+    let mut conn = open_database(temp.path()).unwrap();
+
+    create_schema(&mut conn, &tables).unwrap();
+
+    let mode: i64 = conn
+        .query_row("PRAGMA auto_vacuum", [], |row| row.get(0))
+        .unwrap();
+    assert_eq!(mode, 2);
 }
 
 #[test]
@@ -329,6 +344,35 @@ async fn test_query_recorder_list_cursor_only_when_more_records_exist() {
 
     assert_eq!(second_page.len(), 1);
     assert!(second_cursor.is_none());
+
+    plugin.destroy().await.unwrap();
+}
+
+#[tokio::test]
+async fn test_query_recorder_clear_history_removes_records_and_tail() {
+    AppClock::start();
+
+    let temp = NamedTempFile::new().unwrap();
+    let config = resolve_config(Some(recorder_config(&temp.path().display().to_string()))).unwrap();
+    let mut plugin = QueryRecorder::new("rec".to_string(), config);
+    plugin.init_for_test().await.unwrap();
+    let backend = plugin.backend.as_ref().unwrap().clone();
+
+    seed_demo_records(&backend).await;
+    assert!(!backend.tail.lock().unwrap().is_empty());
+
+    let clear_backend = backend.clone();
+    let clear_result = tokio::task::spawn_blocking(move || clear_backend.clear_history())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(clear_result.cleared_records, 5);
+    assert!(backend.tail.lock().unwrap().is_empty());
+
+    let records = query_records(backend, list_query(QueryRecordFilter::default()))
+        .unwrap()
+        .0;
+    assert!(records.is_empty());
 
     plugin.destroy().await.unwrap();
 }

--- a/webui/components/plugins/kinds/query-recorder.tsx
+++ b/webui/components/plugins/kinds/query-recorder.tsx
@@ -13,6 +13,7 @@ import {
   RefreshCw,
   ServerCrash,
   Timer,
+  Trash2,
   TrendingUp,
   Users,
   X,
@@ -36,6 +37,18 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogMedia,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
 import {
   Popover,
   PopoverContent,
@@ -61,6 +74,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import {
   apiHeaders,
   apiUrl,
+  clearQueryRecorderHistory,
   fetchQueryRecordDetail,
   fetchQueryRecorderLatency,
   fetchQueryRecorderPluginStats,
@@ -193,9 +207,11 @@ function QueryRecordsPanel({ tag }: { tag: string }) {
   const [appliedFilters, setAppliedFilters] = useState<QueryRecordFilters>({});
   const [loading, setLoading] = useState(false);
   const [statsLoading, setStatsLoading] = useState(false);
+  const [clearing, setClearing] = useState(false);
   const [streaming, setStreaming] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [statsError, setStatsError] = useState<string | null>(null);
+  const [lastClearCount, setLastClearCount] = useState<number | null>(null);
   // SSE controller (existing behavior).
   const abortRef = useRef<AbortController | null>(null);
   // Cancel the previous /records load when a new one starts (e.g. rapid
@@ -318,6 +334,29 @@ function QueryRecordsPanel({ tag }: { tag: string }) {
     }
   };
 
+  const handleClearHistory = async () => {
+    recordsAbortRef.current?.abort();
+    statsAbortRef.current?.abort();
+    setClearing(true);
+    setError(null);
+    setStatsError(null);
+    setLastClearCount(null);
+    try {
+      const response = await clearQueryRecorderHistory(tag);
+      setRecords([]);
+      setNextCursor(undefined);
+      setSelected(null);
+      setMatcherStats([]);
+      setStatsQueryTotal(0);
+      setLastClearCount(response.cleared_records);
+      await refresh(appliedFilters);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "清空查询历史失败");
+    } finally {
+      setClearing(false);
+    }
+  };
+
   const toggleStream = async () => {
     if (streaming) {
       abortRef.current?.abort();
@@ -419,6 +458,17 @@ function QueryRecordsPanel({ tag }: { tag: string }) {
                   正在加载…
                 </span>
               )}
+              {clearing && (
+                <span className="inline-flex items-center gap-1 rounded-full border border-destructive/30 bg-destructive/10 px-2 py-0.5 text-destructive">
+                  <Loader2 className="h-3 w-3 animate-spin" />
+                  正在清空…
+                </span>
+              )}
+              {lastClearCount !== null && !clearing && (
+                <span className="rounded-full border border-destructive/30 bg-destructive/10 px-2 py-0.5 text-destructive">
+                  已清空 {lastClearCount} 条
+                </span>
+              )}
               {streaming && (
                 <span className="rounded-full border border-primary/30 bg-primary/10 px-2 py-0.5 text-primary">
                   实时接收中
@@ -430,7 +480,7 @@ function QueryRecordsPanel({ tag }: { tag: string }) {
             <Button
               variant="outline"
               size="sm"
-              disabled={loading}
+              disabled={loading || clearing}
               onClick={() => void refresh(appliedFilters)}
             >
               <RefreshCw className="h-4 w-4" />
@@ -439,11 +489,47 @@ function QueryRecordsPanel({ tag }: { tag: string }) {
             <Button
               variant={streaming ? "secondary" : "outline"}
               size="sm"
+              disabled={clearing}
               onClick={() => void toggleStream()}
             >
               <Radio className="h-4 w-4" />
               {streaming ? "停止实时" : "实时"}
             </Button>
+            <AlertDialog>
+              <AlertDialogTrigger asChild>
+                <Button variant="outline" size="sm" disabled={clearing}>
+                  {clearing ? (
+                    <Loader2 className="h-4 w-4 animate-spin" />
+                  ) : (
+                    <Trash2 className="h-4 w-4" />
+                  )}
+                  清空历史
+                </Button>
+              </AlertDialogTrigger>
+              <AlertDialogContent>
+                <AlertDialogHeader>
+                  <AlertDialogMedia className="bg-destructive/10 text-destructive">
+                    <Trash2 className="h-5 w-5" />
+                  </AlertDialogMedia>
+                  <AlertDialogTitle>清空查询历史？</AlertDialogTitle>
+                  <AlertDialogDescription>
+                    将删除插件 &ldquo;{tag}&rdquo;
+                    已持久化的所有查询记录和执行路径事件，并清空内存
+                    tail。此操作无法撤销。
+                  </AlertDialogDescription>
+                </AlertDialogHeader>
+                <AlertDialogFooter>
+                  <AlertDialogCancel disabled={clearing}>取消</AlertDialogCancel>
+                  <AlertDialogAction
+                    variant="destructive"
+                    disabled={clearing}
+                    onClick={() => void handleClearHistory()}
+                  >
+                    清空历史
+                  </AlertDialogAction>
+                </AlertDialogFooter>
+              </AlertDialogContent>
+            </AlertDialog>
           </div>
         </CardHeader>
         <CardContent className="p-4 pt-0">

--- a/webui/lib/oxidns-api.ts
+++ b/webui/lib/oxidns-api.ts
@@ -259,6 +259,11 @@ export interface QueryRecordDetailResponse {
   record: QueryRecordDetail;
 }
 
+export interface QueryRecorderClearResponse {
+  ok: boolean;
+  cleared_records: number;
+}
+
 export type QueryRecordStatusFilter =
   | "all"
   | "error"
@@ -581,6 +586,16 @@ export async function fetchQueryRecordDetail(
     { method: "GET", headers: apiHeaders() },
   );
   return readJsonResponse<QueryRecordDetailResponse>(response);
+}
+
+export async function clearQueryRecorderHistory(
+  tag: string,
+): Promise<QueryRecorderClearResponse> {
+  const response = await fetch(
+    apiUrl(`/plugins/${encodeURIComponent(tag)}/records`),
+    { method: "DELETE", headers: apiHeaders() },
+  );
+  return readJsonResponse<QueryRecorderClearResponse>(response);
 }
 
 export async function fetchQueryRecorderTopClients(


### PR DESCRIPTION
- Add a DELETE records API that flushes pending writes, clears persisted history, and resets the in-memory tail.
- Wire the WebUI query recorder panel to clear history with a destructive confirmation flow.
- Fix new recorder databases to enable incremental auto-vacuum before WAL setup.
- Document the new API in Chinese and English plugin/API docs.