### PR TITLE
fix(webui): polish plugin delete dialog flow

### DIFF
--- a/webui/components/plugins/plugin-delete-button.tsx
+++ b/webui/components/plugins/plugin-delete-button.tsx
@@ -56,8 +56,8 @@ export function PluginDeleteButton({
   const removeReferencesAndDeletePlugin = useAppStore(
     (s) => s.removeReferencesAndDeletePlugin,
   );
-  const forceDeletePluginInEditor = useAppStore(
-    (s) => s.forceDeletePluginInEditor,
+  const enterEditorForPluginReferences = useAppStore(
+    (s) => s.enterEditorForPluginReferences,
   );
   const isConfigSaving = useAppStore((s) => s.isConfigSaving);
   const isApplying = useAppStore((s) => s.isApplying);
@@ -71,7 +71,7 @@ export function PluginDeleteButton({
   const [loading, setLoading] = useState(false);
 
   const busy = isConfigSaving || isApplying || isRestarting || loading;
-  const disabled = busy || Boolean(configError);
+  const disabled = busy;
 
   const openDialog = async () => {
     setOpen(true);
@@ -111,13 +111,13 @@ export function PluginDeleteButton({
   };
 
   const handleManualFix = () => {
-    forceDeletePluginInEditor(plugin.id);
+    enterEditorForPluginReferences();
     setOpen(false);
     onDeleted?.();
   };
 
   const tooltip = configError
-    ? "配置有错误，需先修复"
+    ? "配置有错误，点击查看原因"
     : busy
       ? "配置操作进行中"
       : "删除";
@@ -146,16 +146,24 @@ export function PluginDeleteButton({
       </Tooltip>
 
       <AlertDialog open={open} onOpenChange={setOpen}>
-        <AlertDialogContent className="max-w-xl">
+        <AlertDialogContent
+          size="wide"
+          onClick={(event) => {
+            if (stopPropagation) event.stopPropagation();
+          }}
+          onPointerDown={(event) => {
+            if (stopPropagation) event.stopPropagation();
+          }}
+        >
           <AlertDialogHeader>
             <AlertDialogTitle>
               {readyPreview && readyPreview.references.length > 0
-                ? "该插件仍被引用"
+                ? `插件 “${plugin.name}” 仍被引用`
                 : "确认删除插件？"}
             </AlertDialogTitle>
             <AlertDialogDescription>
               {readyPreview && readyPreview.references.length > 0
-                ? "删除前需要先处理所有引用，否则配置会产生悬空依赖。"
+                ? "删除前请先替换或修复下列引用，否则配置会产生悬空依赖。"
                 : `确定要删除插件 “${plugin.name}” 吗？此操作会先保存到磁盘，但不会自动应用。`}
             </AlertDialogDescription>
           </AlertDialogHeader>
@@ -174,17 +182,28 @@ export function PluginDeleteButton({
                 {readyPreview.references.map((reference) => (
                   <div
                     key={`${reference.source_tag}:${reference.field}`}
-                    className="rounded-md border bg-background px-3 py-2 text-xs"
+                    className="min-w-0 rounded-md border bg-background px-3 py-2 text-xs"
                   >
-                    <div className="flex flex-wrap items-center gap-1.5">
-                      <span className="font-mono font-medium">
+                    <div className="flex min-w-0 flex-wrap items-center gap-1.5">
+                      <span className="min-w-0 break-all font-mono font-medium">
                         {reference.source_tag}
                       </span>
                       <Badge
                         variant="outline"
                         className="font-mono text-[10px]"
                       >
-                        {reference.expected_kind}
+                        来源{" "}
+                        {reference.sourcePlugin?.pluginKind ??
+                          reference.sourcePlugin?.type ??
+                          "未知"}
+                      </Badge>
+                      <Badge
+                        variant="outline"
+                        className="font-mono text-[10px]"
+                      >
+                        需要{" "}
+                        {reference.expected_plugin_type ??
+                          reference.expected_kind}
                       </Badge>
                       {!reference.removable && (
                         <Badge variant="outline" className="text-[10px]">
@@ -192,11 +211,11 @@ export function PluginDeleteButton({
                         </Badge>
                       )}
                     </div>
-                    <div className="mt-1 font-mono text-muted-foreground">
+                    <div className="mt-1 break-all font-mono text-muted-foreground">
                       {reference.field}
                     </div>
                     {reference.removeBlockedReason && (
-                      <div className="mt-1 text-muted-foreground">
+                      <div className="mt-1 break-words text-muted-foreground">
                         {reference.removeBlockedReason}
                       </div>
                     )}
@@ -216,7 +235,7 @@ export function PluginDeleteButton({
                     loading || readyPreview.replacementCandidates.length === 0
                   }
                 >
-                  <SelectTrigger>
+                  <SelectTrigger className="w-full min-w-0">
                     <SelectValue placeholder="选择兼容的替换插件" />
                   </SelectTrigger>
                   <SelectContent>
@@ -237,17 +256,20 @@ export function PluginDeleteButton({
           ) : null}
 
           {actionError && (
-            <div className="flex items-center gap-2 rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-sm text-destructive">
+            <div className="flex min-w-0 items-center gap-2 rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-sm text-destructive">
               <AlertTriangle className="h-4 w-4" />
-              {actionError}
+              <span className="min-w-0 break-words">{actionError}</span>
             </div>
           )}
 
-          <AlertDialogFooter className="gap-2 sm:gap-2">
-            <AlertDialogCancel disabled={loading}>取消</AlertDialogCancel>
+          <AlertDialogFooter className="gap-2 sm:flex-wrap sm:gap-2">
+            <AlertDialogCancel size="sm" disabled={loading}>
+              取消
+            </AlertDialogCancel>
             {readyPreview && readyPreview.references.length === 0 && (
               <Button
                 variant="destructive"
+                size="sm"
                 disabled={loading}
                 onClick={() => runAction(() => confirmDeletePlugin(plugin.id))}
               >
@@ -258,6 +280,7 @@ export function PluginDeleteButton({
               <>
                 <Button
                   variant="outline"
+                  size="sm"
                   disabled={loading}
                   onClick={handleManualFix}
                 >
@@ -266,6 +289,7 @@ export function PluginDeleteButton({
                 </Button>
                 <Button
                   variant="outline"
+                  size="sm"
                   disabled={loading || !readyPreview.canRemoveReferences}
                   onClick={() =>
                     runAction(() => removeReferencesAndDeletePlugin(plugin.id))
@@ -275,6 +299,7 @@ export function PluginDeleteButton({
                 </Button>
                 <Button
                   variant="destructive"
+                  size="sm"
                   disabled={loading || !replacementTag}
                   onClick={() =>
                     runAction(() =>

--- a/webui/components/plugins/plugin-detail-template.tsx
+++ b/webui/components/plugins/plugin-detail-template.tsx
@@ -396,7 +396,7 @@ export function PluginDetailTemplate({
           if (!open) setPendingRename(null);
         }}
       >
-        <AlertDialogContent className="max-w-lg">
+        <AlertDialogContent size="lg">
           <AlertDialogHeader>
             <AlertDialogTitle>同步更新引用？</AlertDialogTitle>
             <AlertDialogDescription>

--- a/webui/components/ui/alert-dialog.tsx
+++ b/webui/components/ui/alert-dialog.tsx
@@ -49,7 +49,7 @@ function AlertDialogContent({
   size = "default",
   ...props
 }: React.ComponentProps<typeof AlertDialogPrimitive.Content> & {
-  size?: "default" | "sm";
+  size?: "default" | "sm" | "lg" | "wide";
 }) {
   return (
     <AlertDialogPortal>
@@ -58,7 +58,7 @@ function AlertDialogContent({
         data-slot="alert-dialog-content"
         data-size={size}
         className={cn(
-          "group/alert-dialog-content fixed top-1/2 left-1/2 z-50 grid w-full -translate-x-1/2 -translate-y-1/2 gap-4 rounded-xl bg-popover p-4 text-popover-foreground ring-1 ring-foreground/10 duration-100 outline-none data-[size=default]:max-w-xs data-[size=sm]:max-w-xs data-[size=default]:sm:max-w-sm data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+          "group/alert-dialog-content fixed top-1/2 left-1/2 z-50 grid w-full max-w-xs -translate-x-1/2 -translate-y-1/2 gap-4 rounded-xl bg-popover p-4 text-popover-foreground ring-1 ring-foreground/10 duration-100 outline-none data-[size=default]:sm:max-w-sm data-[size=lg]:max-w-[calc(100vw-2rem)] data-[size=lg]:sm:max-w-lg data-[size=wide]:max-w-[calc(100vw-2rem)] data-[size=wide]:sm:max-w-xl data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
           className,
         )}
         {...props}
@@ -75,7 +75,7 @@ function AlertDialogHeader({
     <div
       data-slot="alert-dialog-header"
       className={cn(
-        "grid grid-rows-[auto_1fr] place-items-center gap-1.5 text-center has-data-[slot=alert-dialog-media]:grid-rows-[auto_auto_1fr] has-data-[slot=alert-dialog-media]:gap-x-4 sm:group-data-[size=default]/alert-dialog-content:place-items-start sm:group-data-[size=default]/alert-dialog-content:text-left sm:group-data-[size=default]/alert-dialog-content:has-data-[slot=alert-dialog-media]:grid-rows-[auto_1fr]",
+        "grid grid-rows-[auto_1fr] place-items-center gap-1.5 text-center has-data-[slot=alert-dialog-media]:grid-rows-[auto_auto_1fr] has-data-[slot=alert-dialog-media]:gap-x-4 sm:group-data-[size=default]/alert-dialog-content:place-items-start sm:group-data-[size=default]/alert-dialog-content:text-left sm:group-data-[size=default]/alert-dialog-content:has-data-[slot=alert-dialog-media]:grid-rows-[auto_1fr] sm:group-data-[size=lg]/alert-dialog-content:place-items-start sm:group-data-[size=lg]/alert-dialog-content:text-left sm:group-data-[size=lg]/alert-dialog-content:has-data-[slot=alert-dialog-media]:grid-rows-[auto_1fr] sm:group-data-[size=wide]/alert-dialog-content:place-items-start sm:group-data-[size=wide]/alert-dialog-content:text-left sm:group-data-[size=wide]/alert-dialog-content:has-data-[slot=alert-dialog-media]:grid-rows-[auto_1fr]",
         className,
       )}
       {...props}
@@ -107,7 +107,7 @@ function AlertDialogMedia({
     <div
       data-slot="alert-dialog-media"
       className={cn(
-        "mb-2 inline-flex size-10 items-center justify-center rounded-md bg-muted sm:group-data-[size=default]/alert-dialog-content:row-span-2 *:[svg:not([class*='size-'])]:size-6",
+        "mb-2 inline-flex size-10 items-center justify-center rounded-md bg-muted sm:group-data-[size=default]/alert-dialog-content:row-span-2 sm:group-data-[size=lg]/alert-dialog-content:row-span-2 sm:group-data-[size=wide]/alert-dialog-content:row-span-2 *:[svg:not([class*='size-'])]:size-6",
         className,
       )}
       {...props}
@@ -123,7 +123,7 @@ function AlertDialogTitle({
     <AlertDialogPrimitive.Title
       data-slot="alert-dialog-title"
       className={cn(
-        "font-heading text-base font-medium sm:group-data-[size=default]/alert-dialog-content:group-has-data-[slot=alert-dialog-media]/alert-dialog-content:col-start-2",
+        "font-heading text-base font-medium sm:group-data-[size=default]/alert-dialog-content:group-has-data-[slot=alert-dialog-media]/alert-dialog-content:col-start-2 sm:group-data-[size=lg]/alert-dialog-content:group-has-data-[slot=alert-dialog-media]/alert-dialog-content:col-start-2 sm:group-data-[size=wide]/alert-dialog-content:group-has-data-[slot=alert-dialog-media]/alert-dialog-content:col-start-2",
         className,
       )}
       {...props}

--- a/webui/lib/store.ts
+++ b/webui/lib/store.ts
@@ -140,7 +140,7 @@ interface AppState {
   confirmDeletePlugin: (id: string) => Promise<void>;
   replaceAndDeletePlugin: (id: string, replacementTag: string) => Promise<void>;
   removeReferencesAndDeletePlugin: (id: string) => Promise<void>;
-  forceDeletePluginInEditor: (id: string) => void;
+  enterEditorForPluginReferences: () => void;
   addPlugin: (
     plugin: Omit<PluginInstance, "id" | "createdAt" | "updatedAt" | "metrics">,
   ) => void;
@@ -665,17 +665,7 @@ export const useAppStore = create<AppState>((set, get) => ({
     await get().saveConfig();
   },
 
-  forceDeletePluginInEditor: (id) => {
-    set((state) => ({
-      ...deletePluginFromState(state, id),
-      editorMode: true,
-    }));
-    void get()
-      .validateCurrentConfig()
-      .catch(() => {
-        // The editor and header expose the dangling-reference validation error.
-      });
-  },
+  enterEditorForPluginReferences: () => set({ editorMode: true }),
 
   addPlugin: (plugin) =>
     set((state) =>


### PR DESCRIPTION
- Make referenced-plugin delete dialogs wider and clearer for dependency handling.
- Prevent delete dialog actions from bubbling into plugin cards and opening details.
- Keep manual editor repair from removing plugins before the user edits config.
- Allow delete dialogs to show config errors instead of leaving a disabled icon.