### PR TITLE
fix(upstream): prevent connection pool deadlock after network outage

### DIFF
--- a/src/network/upstream/pool/conn_h2.rs
+++ b/src/network/upstream/pool/conn_h2.rs
@@ -15,6 +15,7 @@ use tokio::sync::Notify;
 use tokio::time::timeout;
 use tracing::{debug, trace, warn};
 
+use super::UsingCountGuard;
 use crate::core::app_clock::AppClock;
 use crate::core::error::{DnsError, Result};
 use crate::network::buffer_pool::wire_buffer_pool;
@@ -58,12 +59,12 @@ impl Connection for H2Connection {
             return Err(DnsError::protocol("DoH connection closed"));
         }
         self.using_count.fetch_add(1, Ordering::Relaxed);
+        // Guard ensures using_count is decremented even if this future is
+        // cancelled by an outer timeout (cancel-safety).
+        let _guard = UsingCountGuard(&self.using_count);
         self.last_used
             .store(AppClock::elapsed_millis(), Ordering::Relaxed);
-
-        let result = self.query_inner(request).await;
-        self.using_count.fetch_sub(1, Ordering::Relaxed);
-        result
+        self.query_inner(request).await
     }
 
     fn using_count(&self) -> u16 {

--- a/src/network/upstream/pool/conn_h3.rs
+++ b/src/network/upstream/pool/conn_h3.rs
@@ -16,6 +16,7 @@ use tokio::sync::Notify;
 use tokio::time::timeout;
 use tracing::{debug, trace, warn};
 
+use super::UsingCountGuard;
 use crate::core::app_clock::AppClock;
 use crate::core::error::{DnsError, Result};
 use crate::network::buffer_pool::wire_buffer_pool;
@@ -63,12 +64,12 @@ impl Connection for H3Connection {
             return Err(DnsError::protocol("H3 connection closed"));
         }
         self.using_count.fetch_add(1, Ordering::Relaxed);
+        // Guard ensures using_count is decremented even if this future is
+        // cancelled by an outer timeout (cancel-safety).
+        let _guard = UsingCountGuard(&self.using_count);
         self.last_used
             .store(AppClock::elapsed_millis(), Ordering::Relaxed);
-
-        let result = self.query_inner(request).await;
-        self.using_count.fetch_sub(1, Ordering::Relaxed);
-        result
+        self.query_inner(request).await
     }
 
     fn using_count(&self) -> u16 {

--- a/src/network/upstream/pool/conn_quic.rs
+++ b/src/network/upstream/pool/conn_quic.rs
@@ -11,6 +11,7 @@ use tokio::sync::Notify;
 use tokio::time::timeout;
 use tracing::{debug, trace, warn};
 
+use super::UsingCountGuard;
 use crate::core::app_clock::AppClock;
 use crate::core::error::{DnsError, Result};
 use crate::network::transport::quic_transport::QuicTransport;
@@ -76,12 +77,14 @@ impl Connection for QuicConnection {
             return Err(DnsError::protocol("Cannot query on closed QUIC connection"));
         }
         self.using_count.fetch_add(1, Ordering::Relaxed);
+        // Guard ensures using_count is decremented even if this future is
+        // cancelled by an outer timeout (cancel-safety).
+        let _guard = UsingCountGuard(&self.using_count);
 
         // Open a new bidirectional stream (reader/writer) via connection wrapper
         let (mut reader, mut writer) = match timeout(self.timeout, self.transport.open_bi()).await {
             Ok(Ok((reader, writer))) => (reader, writer),
             Ok(Err(e)) => {
-                self.using_count.fetch_sub(1, Ordering::Relaxed);
                 self.close();
                 return Err(DnsError::protocol(format!(
                     "Failed to open QUIC bidirectional stream: {}",
@@ -89,7 +92,6 @@ impl Connection for QuicConnection {
                 )));
             }
             Err(_) => {
-                self.using_count.fetch_sub(1, Ordering::Relaxed);
                 return Err(DnsError::protocol(
                     "Timeout opening QUIC bidirectional stream",
                 ));
@@ -98,7 +100,6 @@ impl Connection for QuicConnection {
 
         let raw_id = request.id();
         if let Err(e) = writer.write_message(&request).await {
-            self.using_count.fetch_sub(1, Ordering::Relaxed);
             return Err(DnsError::protocol(format!(
                 "Failed to write DNS query to QUIC stream: {}",
                 e
@@ -149,7 +150,6 @@ impl Connection for QuicConnection {
 
         self.last_used
             .store(AppClock::elapsed_millis(), Ordering::Relaxed);
-        self.using_count.fetch_sub(1, Ordering::Relaxed);
         result
     }
 

--- a/src/network/upstream/pool/mod.rs
+++ b/src/network/upstream/pool/mod.rs
@@ -35,7 +35,7 @@
 //! - Connection reuse to amortize handshake costs
 
 use std::fmt::Debug;
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicU16, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex, Weak};
 use std::time::Duration;
 
@@ -137,6 +137,19 @@ pub trait ConnectionPool<C: Connection>: Send + Sync + Debug + 'static {
 pub trait ManagedMaintenanceTask {
     fn maintenance_task_id(&self) -> &Mutex<Option<u64>>;
     fn maintenance_task_name(&self) -> String;
+}
+
+/// RAII guard that decrements a connection's in-flight query counter on drop.
+///
+/// Ensures `using_count` is always decremented even when the query future is
+/// cancelled by an outer timeout, preventing the pool from permanently
+/// deadlocking due to a leaked counter.
+pub(crate) struct UsingCountGuard<'a>(pub(crate) &'a AtomicU16);
+
+impl Drop for UsingCountGuard<'_> {
+    fn drop(&mut self) {
+        self.0.fetch_sub(1, Ordering::Relaxed);
+    }
 }
 
 /// Maintenance interval for pool cleanup


### PR DESCRIPTION
When an outer `Upstream::query` timeout cancelled an in-flight H2, H3, or QUIC query future, `using_count` was incremented but the matching decrement was never reached, leaking the counter on every timeout.

After 64 such leaks (equal to `max_load`), the affected connection appeared fully loaded while maintenance kept it alive because `using_count > 0` implied active queries. With `connections.len == max_size == 1`, no new connection could be created, permanently deadlocking the pool until OxiDNS was restarted — the root cause of the network-never-recovers-after-router-reboot report.

- Add `UsingCountGuard` (RAII, Drop-based) to `pool/mod.rs` as the single shared implementation
- Apply the guard in `H2Connection`, `H3Connection`, and `QuicConnection` so `using_count` is decremented on both normal return and cancellation
- Remove the now-redundant manual `fetch_sub` calls scattered across `QuicConnection::query` error paths

TCP and UDP connections were already cancel-safe via `RequestGuard` from `RequestMap` and are unaffected.

Fixed #160