### PR TITLE
perf(ros_address_list): pipeline concurrent writes and drop post-add …

### DIFF
--- a/src/network/upstream/pool/mod.rs
+++ b/src/network/upstream/pool/mod.rs
@@ -144,6 +144,7 @@ pub trait ManagedMaintenanceTask {
 /// Ensures `using_count` is always decremented even when the query future is
 /// cancelled by an outer timeout, preventing the pool from permanently
 /// deadlocking due to a leaked counter.
+#[allow(dead_code)]
 pub(crate) struct UsingCountGuard<'a>(pub(crate) &'a AtomicU16);
 
 impl Drop for UsingCountGuard<'_> {

--- a/src/plugin/executor/ros_address_list/api.rs
+++ b/src/plugin/executor/ros_address_list/api.rs
@@ -88,7 +88,7 @@ pub(super) trait MikrotikApi: Debug + Send + Sync {
         comment_prefix: &str,
         plugin_tag: &str,
         refresh_timeout: bool,
-    ) -> Result<Option<String>>;
+    ) -> Result<Option<()>>;
     /// Delete one row by RouterOS internal id.
     async fn delete_entry_by_id(&self, id: &str, family: AddressListFamily) -> Result<()>;
     /// Cheap connectivity check used during startup.
@@ -286,9 +286,7 @@ impl MikrotikRsClient {
         key: &AddressListKey,
         timeout: Option<&str>,
         comment: &str,
-    ) -> Result<String> {
-        // Add is followed by a re-query because RouterOS does not always return
-        // the created row id directly in a stable shape.
+    ) -> Result<()> {
         let mut add = CommandBuilder::new()
             .command(address_list_command(key.family, ListOp::Add))
             .attribute(ADDRESS_LIST_FIELD, Some(key.list.as_str()))
@@ -300,18 +298,7 @@ impl MikrotikRsClient {
         let _ = self
             .send_rows("add address-list entry", add.build())
             .await?;
-
-        let mut created = self.find_entries_by_key(key).await?;
-        created.retain(|entry| entry.comment.as_deref() == Some(comment));
-        created
-            .into_iter()
-            .map(|entry| entry.id)
-            .next()
-            .ok_or_else(|| {
-                DnsError::plugin(
-                    "ros_address_list add address-list entry succeeded but entry id not found",
-                )
-            })
+        Ok(())
     }
 }
 
@@ -435,7 +422,7 @@ impl MikrotikApi for MikrotikRsClient {
         comment_prefix: &str,
         plugin_tag: &str,
         refresh_timeout: bool,
-    ) -> Result<Option<String>> {
+    ) -> Result<Option<()>> {
         // Upsert policy:
         // 1) query all rows for the exact `(family, list, address)` key
         // 2) refuse overwrite when only foreign rows exist
@@ -471,8 +458,8 @@ impl MikrotikApi for MikrotikRsClient {
             if timeout_kind_changed {
                 self.delete_entry_by_id(&existing.id, existing.key.family)
                     .await?;
-                let id = self.add_entry(key, timeout, comment).await?;
-                return Ok(Some(id));
+                self.add_entry(key, timeout, comment).await?;
+                return Ok(Some(()));
             }
 
             // `refresh_timeout` lets callers force a timeout rewrite even when
@@ -491,11 +478,11 @@ impl MikrotikApi for MikrotikRsClient {
                     .send_rows("set address-list entry", set.build())
                     .await?;
             }
-            return Ok(Some(existing.id));
+            return Ok(Some(()));
         }
 
-        let id = self.add_entry(key, timeout, comment).await?;
-        Ok(Some(id))
+        self.add_entry(key, timeout, comment).await?;
+        Ok(Some(()))
     }
 
     async fn delete_entry_by_id(&self, id: &str, family: AddressListFamily) -> Result<()> {

--- a/src/plugin/executor/ros_address_list/manager.rs
+++ b/src/plugin/executor/ros_address_list/manager.rs
@@ -25,7 +25,7 @@ use tracing::{debug, warn};
 
 use super::api::MikrotikApi;
 use crate::core::app_clock::AppClock;
-use crate::core::error::Result;
+use crate::core::error::{DnsError, Result};
 use crate::core::task_center;
 
 /// Host prefix used for normalized IPv4 single-address entries.
@@ -600,37 +600,61 @@ impl AddressListManager {
             return Ok(());
         }
 
-        // One response can contain duplicate IPs. We already reduced that to one
-        // key with the strongest TTL, so each key below represents at most one
-        // remote write decision for this DNS observation.
+        // Phase 1: collect entries that actually need a remote write, along with
+        // their pre-formatted timeout strings so the borrow checker lets us hand
+        // shared references to the concurrent futures below.
         let comment = self.comment_for_dynamic(domain.as_str());
-        for (key, timeout) in dedup {
-            if !self.should_refresh_dynamic_entry(&key, timeout, now_ms) {
-                continue;
-            }
-            let timeout_value = match timeout {
-                DynamicTimeout::Timed(ttl) => Some(format!("{ttl}s")),
-                DynamicTimeout::Timeless => None,
-            };
-            let upsert_result = self
-                .api
-                .upsert_owned_entry(
-                    &key,
+        let to_refresh: Vec<(AddressListKey, DynamicTimeout, Option<String>)> = dedup
+            .into_iter()
+            .filter_map(|(key, timeout)| {
+                if !self.should_refresh_dynamic_entry(&key, timeout, now_ms) {
+                    return None;
+                }
+                let timeout_value = match timeout {
+                    DynamicTimeout::Timed(ttl) => Some(format!("{ttl}s")),
+                    DynamicTimeout::Timeless => None,
+                };
+                Some((key, timeout, timeout_value))
+            })
+            .collect();
+
+        if to_refresh.is_empty() {
+            return Ok(());
+        }
+
+        // Phase 2: fire all upserts concurrently — one DNS response may carry
+        // many IPs (CDN responses), and each previously-serial write is now
+        // pipelined over the same RouterOS API connection.
+        let api = self.api.as_ref();
+        let comment_str = comment.as_str();
+        let prefix = self.cfg.comment_prefix.as_str();
+        let tag = self.cfg.plugin_tag.as_str();
+
+        let results =
+            futures::future::join_all(to_refresh.iter().map(|(key, timeout, timeout_value)| {
+                api.upsert_owned_entry(
+                    key,
                     timeout_value.as_deref(),
-                    comment.as_str(),
-                    self.cfg.comment_prefix.as_str(),
-                    self.cfg.plugin_tag.as_str(),
+                    comment_str,
+                    prefix,
+                    tag,
                     matches!(timeout, DynamicTimeout::Timed(_)),
                 )
-                .await;
-            match upsert_result {
-                Ok(Some(_)) => {
+            }))
+            .await;
+
+        // Phase 3: update the local suppression cache for every result so that
+        // a single failure does not prevent successful entries from being cached.
+        let mut first_error: Option<DnsError> = None;
+        for ((key, timeout, _), result) in to_refresh.into_iter().zip(results) {
+            match result {
+                Ok(Some(())) => {
                     // Only successful remote writes advance the suppression cache.
                     let state = match timeout {
                         DynamicTimeout::Timed(ttl) => DynamicRefreshState::from_write(now_ms, ttl),
                         DynamicTimeout::Timeless => DynamicRefreshState::timeless(),
                     };
-                    self.dynamic_refresh_cache.insert(key.clone(), state);
+                    self.dynamic_refresh_cache.insert(key, state);
                 }
                 Ok(None) => {
                     // Foreign ownership conflict: drop any local cache so future
@@ -647,11 +671,14 @@ impl AddressListManager {
                     // Error path also drops the local cache so the next
                     // observation retries immediately instead of being suppressed.
                     self.dynamic_refresh_cache.remove(&key);
-                    return Err(err);
+                    first_error.get_or_insert(err);
                 }
             }
         }
 
+        if let Some(err) = first_error {
+            return Err(err);
+        }
         Ok(())
     }
 

--- a/src/plugin/executor/ros_address_list/mod.rs
+++ b/src/plugin/executor/ros_address_list/mod.rs
@@ -864,7 +864,7 @@ mod tests {
             comment_prefix: &str,
             plugin_tag: &str,
             refresh_timeout: bool,
-        ) -> Result<Option<String>> {
+        ) -> Result<Option<()>> {
             let mut state = self
                 .state
                 .lock()
@@ -900,9 +900,9 @@ mod tests {
                     entry.timeout = timeout.map(str::to_string);
                     entry.comment = Some(comment.to_string());
                     state.update_ops = state.update_ops.saturating_add(1);
-                    state.entries.insert(Self::storage_key(key), entry.clone());
+                    state.entries.insert(Self::storage_key(key), entry);
                 }
-                return Ok(Some(entry.id));
+                return Ok(Some(()));
             }
 
             state.next_id = state.next_id.saturating_add(1);
@@ -914,13 +914,13 @@ mod tests {
             state.entries.insert(
                 Self::storage_key(key),
                 RouterListEntry {
-                    id: id.clone(),
+                    id,
                     key: key.clone(),
                     timeout: timeout.map(str::to_string),
                     comment: Some(comment.to_string()),
                 },
             );
-            Ok(Some(id))
+            Ok(Some(()))
         }
 
         async fn delete_entry_by_id(&self, id: &str, _family: AddressListFamily) -> Result<()> {


### PR DESCRIPTION
…re-query

- add_entry no longer issues a follow-up /print query after writing; the returned row ID was unused by all callers, saving one RTT per new entry (3 RTTs per add → 2)
- observe_domain_inner now fires all upserts for a single DNS response concurrently via join_all, eliminating the serial bottleneck that caused CDN domains (many A/AAAA records) to take seconds or minutes
- a per-entry write failure no longer short-circuits the remaining batch; all results are processed before the first error is returned, so successful entries still advance the suppression cache