### PR TITLE
fix(upstream): close zombie connections reliably across H2/H3/DoQ

### DIFF
--- a/src/network/upstream/pool/conn_h2.rs
+++ b/src/network/upstream/pool/conn_h2.rs
@@ -178,10 +178,13 @@ impl ConnectionBuilder<H2Connection> for H2ConnectionBuilder {
         )
         .await?;
 
-        let (sender, connection) = h2::client::Builder::new()
-            .handshake(tls_stream)
-            .await
-            .map_err(|e| DnsError::protocol(format!("H2 handshake error: {}", e)))?;
+        let (sender, connection) = timeout(
+            self.timeout,
+            h2::client::Builder::new().handshake(tls_stream),
+        )
+        .await
+        .map_err(|_| DnsError::protocol("H2 handshake timeout"))?
+        .map_err(|e| DnsError::protocol(format!("H2 handshake error: {}", e)))?;
 
         let h2_conn = Arc::new(H2Connection {
             id: conn_id,

--- a/src/network/upstream/pool/conn_h3.rs
+++ b/src/network/upstream/pool/conn_h3.rs
@@ -10,7 +10,7 @@ use bytes::{BufMut, Bytes};
 use futures::future::poll_fn;
 use h3::client::{RequestStream, SendRequest};
 use h3_quinn::{BidiStream, OpenStreams};
-use http::Version;
+use http::{Request, Version};
 use tokio::select;
 use tokio::sync::Notify;
 use tokio::time::timeout;
@@ -91,16 +91,34 @@ impl H3Connection {
         let mut body_bytes = wire_buffer_pool().acquire();
         request.append_to_with_id(0, &mut body_bytes)?;
 
-        let request = build_dns_get_request(
+        let http_request = build_dns_get_request(
             self.request_uri.clone(),
             body_bytes.as_slice(),
             Version::HTTP_3,
         );
 
+        // Cover send_request + finish + recv under a single timeout so that a
+        // zombie QUIC connection (server stops responding but never sends
+        // CONNECTION_CLOSE) cannot leave a live-looking connection in the pool
+        // forever. Previously only recv() was timed out; send_request().await
+        // could block indefinitely on a zombie, which the outer Upstream::query
+        // timeout would cancel without calling self.close(), permanently stalling
+        // the pool (max_size = 1 for BootstrapUpstream).
+        match timeout(self.timeout, self.do_request(http_request, raw_id)).await {
+            Ok(result) => result,
+            Err(_) => {
+                self.close();
+                warn!(conn_id = self.id, raw_id, "H3 request timeout");
+                Err(DnsError::protocol("dns query timeout"))
+            }
+        }
+    }
+
+    async fn do_request(&self, http_request: Request<()>, raw_id: u16) -> Result<Message> {
         let mut request_stream = self
             .sender
             .clone()
-            .send_request(request)
+            .send_request(http_request)
             .await
             .map_err(|e| {
                 self.close();
@@ -112,24 +130,19 @@ impl H3Connection {
             DnsError::protocol(format!("H3 received a stream error: {err}"))
         })?;
 
-        match timeout(self.timeout, recv(request_stream)).await {
-            Ok(Ok(bytes)) => {
+        match recv(request_stream).await {
+            Ok(bytes) => {
                 let mut resp = Message::from_bytes(&bytes)?;
                 resp.set_id(raw_id);
                 trace!(conn_id = self.id, raw_id, "Received H3 response");
                 Ok(resp)
             }
-            Ok(Err(H3RecvError::Transport(e))) => {
+            Err(H3RecvError::Transport(e)) => {
                 self.close();
                 warn!(conn_id = self.id, raw_id, ?e, "H3 request error");
                 Err(e)
             }
-            Ok(Err(H3RecvError::HttpStatus(e))) => Err(e),
-            Err(_) => {
-                self.close();
-                warn!(conn_id = self.id, raw_id, "H3 request timeout");
-                Err(DnsError::protocol("dns query timeout"))
-            }
+            Err(H3RecvError::HttpStatus(e)) => Err(e),
         }
     }
 }

--- a/src/network/upstream/pool/conn_quic.rs
+++ b/src/network/upstream/pool/conn_quic.rs
@@ -92,6 +92,9 @@ impl Connection for QuicConnection {
                 )));
             }
             Err(_) => {
+                // Timeout opening a stream indicates the connection is in a
+                // bad/zombie state; close it so the pool can replace it.
+                self.close();
                 return Err(DnsError::protocol(
                     "Timeout opening QUIC bidirectional stream",
                 ));
@@ -129,15 +132,23 @@ impl Connection for QuicConnection {
                         conn_id = self.id,
                         query_id = raw_id,
                         error = ?e,
-                        "Failed to convert Message to DnsResponse"
+                        "Failed to read DNS response from QUIC stream"
                     );
                     Err(DnsError::protocol(format!(
-                        "Failed to convert Message: {}",
+                        "Failed to read QUIC DNS response: {}",
                         e
                     )))
                 }
             },
             Err(_) => {
+                // Close the connection on read timeout, not just the stream.
+                // If the QUIC transport is alive but the server isn't responding
+                // at the DNS layer (server ACKs our packets so loss detection
+                // won't fire), read timeouts repeat indefinitely and last_used
+                // stays fresh, keeping a useless connection in the pool forever.
+                // Closing forces the pool to create a fresh connection on the
+                // next query. This matches H3's behavior on recv timeout.
+                self.close();
                 warn!(
                     conn_id = self.id,
                     query_id = raw_id,
@@ -249,6 +260,10 @@ impl ConnectionBuilder<QuicConnection> for QuicConnectionBuilder {
         tokio::spawn(async move {
             select! {
                 _ = _conn.transport.closed() => {
+                    // Mark the QuicConnection as unavailable so the pool removes
+                    // it on the next query or maintenance cycle instead of
+                    // continuing to try open_bi() on a dead transport.
+                    _conn.close();
                     debug!(
                         conn_id,
                         "QUIC connection closed by remote peer or network error"

--- a/src/network/upstream/utils.rs
+++ b/src/network/upstream/utils.rs
@@ -33,7 +33,7 @@ use http::{HeaderValue, Method, Request, Response, Version, header};
 #[cfg(any(feature = "upstream-doq", feature = "upstream-doh3"))]
 use quinn::crypto::rustls::QuicClientConfig;
 #[cfg(any(feature = "upstream-doq", feature = "upstream-doh3"))]
-use quinn::{ClientConfig, Endpoint, EndpointConfig, TokioRuntime};
+use quinn::{ClientConfig, Endpoint, EndpointConfig, TokioRuntime, TransportConfig, VarInt};
 #[cfg(feature = "_tls-client")]
 use rustls::pki_types::ServerName;
 use socket2::{Domain, Protocol, Socket, Type};
@@ -153,7 +153,17 @@ pub(crate) async fn connect_quic(
     };
     client_config.alpn_protocols = alpn;
 
-    let client_config = ClientConfig::new(Arc::new(QuicClientConfig::try_from(client_config)?));
+    // Set QUIC idle timeout to 3× the query timeout. Without this, zombie
+    // connections (server stops responding but never sends CONNECTION_CLOSE)
+    // are never detected by the QUIC layer, and send_request() / open_bi()
+    // block forever. With idle timeout, the QUIC stack closes the connection
+    // and the H3/DoQ driver task calls conn.close(), letting the pool replace it.
+    let idle_ms = (conn_timeout.as_millis() * 3).min(u32::MAX as u128) as u32;
+    let mut transport = TransportConfig::default();
+    transport.max_idle_timeout(Some(VarInt::from_u32(idle_ms).into()));
+
+    let mut client_config = ClientConfig::new(Arc::new(QuicClientConfig::try_from(client_config)?));
+    client_config.transport_config(Arc::new(transport));
 
     endpoint.set_default_client_config(client_config);
 


### PR DESCRIPTION
H3: wrap all I/O (send_request+finish+recv) in a single timeout instead of only recv(), so self.close() is called when send_request blocks on a zombie QUIC connection. This was the root cause of issue #160 recurring without a network outage — the outer Upstream::query timeout cancelled the future without closing the connection, permanently stalling the max_size=1 BootstrapUpstream pool.

H2: add timeout to the TLS handshake, which previously had no time bound.

DoQ: call self.close() on open_bi() timeout, on read_message() timeout (handles half-alive servers that ACK QUIC packets but ignore DNS queries, bypassing loss detection), and in the monitoring task's transport.closed() arm so the pool removes the connection on the next maintenance cycle.

QUIC: configure TransportConfig max_idle_timeout to 3× query timeout so the QUIC stack can detect zombie connections at the transport layer as a final backstop.