### PR TITLE
fix(webui): drop stray-quote-wrap stripping around ${VAR} placeholders

### DIFF
--- a/webui/lib/oxidns-config.ts
+++ b/webui/lib/oxidns-config.ts
@@ -4,48 +4,6 @@ import { parseDocument, stringify, isSeq, isMap } from "yaml";
 import { getPluginKindDefinition } from "@/lib/plugin-definitions";
 import type { PluginInstance, PluginType } from "@/lib/types";
 
-// Matches `${VAR}`, `${VAR:-default}`, `${env:VAR}` placeholders. The backend
-// runs env expansion after YAML parsing, so we no longer need to coerce these
-// strings into a particular scalar style — the YAML parser sees the literal
-// placeholder text, expansion replaces it inside the typed value, and any
-// special characters in the env value never touch the YAML grammar.
-//
-// The one thing we still have to clean up before serialization is the user's
-// muscle-memory wrapping: form fields are plain text, so users who hit prior
-// breakage often type `"${pw}"` or `'${pw}'` trying to "escape" the
-// placeholder. Those quotes become part of the literal value, and the YAML
-// stringifier adds its own wrapper around them — the runtime value then
-// carries a stray pair of quotes. Stripping a single layer of matching ASCII
-// quotes around a body that contains a placeholder removes that footgun.
-const ENV_PLACEHOLDER_RE = /\$\{[^}]+\}/;
-
-function stripStrayQuoteWrap(value: string): string {
-  if (value.length < 2) return value;
-  const first = value[0];
-  if ((first !== '"' && first !== "'") || value[value.length - 1] !== first) {
-    return value;
-  }
-  const inner = value.slice(1, -1);
-  if (inner.includes(first)) return value;
-  if (!ENV_PLACEHOLDER_RE.test(inner)) return value;
-  return inner;
-}
-
-// Walk a JSON-ish value tree and strip the stray-quote wrapping from any
-// string that carries an env-var placeholder.
-function preserveEnvPlaceholders(value: unknown): unknown {
-  if (typeof value === "string") return stripStrayQuoteWrap(value);
-  if (Array.isArray(value)) return value.map(preserveEnvPlaceholders);
-  if (value && typeof value === "object") {
-    const result: Record<string, unknown> = {};
-    for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
-      result[k] = preserveEnvPlaceholders(v);
-    }
-    return result;
-  }
-  return value;
-}
-
 export interface OxiDnsConfig {
   include?: string[];
   runtime?: Record<string, unknown>;
@@ -112,7 +70,7 @@ export function parseOxiDnsYaml(text: string): OxiDnsParseResult {
 }
 
 export function stringifyOxiDnsConfig(config: OxiDnsConfig): string {
-  return stringify(preserveEnvPlaceholders(cleanUndefined(config)), {
+  return stringify(cleanUndefined(config), {
     indent: 2,
     lineWidth: 0,
     nullStr: "null",
@@ -158,12 +116,10 @@ export function serializePluginsPreserving(
     const items = newPlugins.map((p) => {
       const node = p.tag ? oldNodeByTag.get(p.tag) : undefined;
       if (node && isMap(node) && !changedTags.has(p.tag)) return node;
-      return doc.createNode(preserveEnvPlaceholders(cleanUndefined(p)));
+      return doc.createNode(cleanUndefined(p));
     });
 
-    const seq = doc.createNode(
-      newPlugins.map((p) => preserveEnvPlaceholders(cleanUndefined(p))),
-    );
+    const seq = doc.createNode(newPlugins.map((p) => cleanUndefined(p)));
     if (isSeq(seq)) seq.items = items as typeof seq.items;
     doc.set("plugins", seq);
     return doc.toString({ lineWidth: 0 });
@@ -210,7 +166,7 @@ export function configFromPlugins(
 }
 
 export function pluginConfigToYaml(config: unknown): string {
-  return stringify(preserveEnvPlaceholders(cleanUndefined(config ?? {})), {
+  return stringify(cleanUndefined(config ?? {}), {
     indent: 2,
     lineWidth: 0,
     nullStr: "null",


### PR DESCRIPTION
The helper introduced in 631914e5 unconditionally strips one layer of matching ASCII quotes around any string containing a placeholder, but "${qname}" can also be the user's intentional literal content (HTTP request bodies, script arguments, …). YAML scalar style is lost in the parsed JS string, so the walker cannot distinguish stray wrapping from literal characters, and every parse → serialize cycle through stringifyOxiDnsConfig / serializePluginsPreserving / pluginConfigToYaml would silently shorten the value.

The paired backend fix (3396554e) already lets bare ${pw} survive any env value verbatim, so the WebUI no longer needs to second-guess the user's input — values round-trip unchanged.