### PR TITLE
feat(upgrade): add HTTP upgrade API and WebUI update notification

### DIFF
--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -37,6 +37,7 @@ mod route;
 mod server;
 #[cfg(feature = "webui")]
 mod static_files;
+#[cfg(feature = "plugin-upgrade")]
 mod upgrade;
 
 use std::sync::Arc;
@@ -71,6 +72,7 @@ pub fn register_builtin_routes() -> Result<()> {
         metrics::register_builtin_routes(&register)?;
         logs::register_log_routes(&register)?;
         build::register_builtin_routes(&register)?;
+        #[cfg(feature = "plugin-upgrade")]
         upgrade::register_upgrade_routes(&register)?;
     }
     Ok(())

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -37,6 +37,7 @@ mod route;
 mod server;
 #[cfg(feature = "webui")]
 mod static_files;
+mod upgrade;
 
 use std::sync::Arc;
 
@@ -70,6 +71,7 @@ pub fn register_builtin_routes() -> Result<()> {
         metrics::register_builtin_routes(&register)?;
         logs::register_log_routes(&register)?;
         build::register_builtin_routes(&register)?;
+        upgrade::register_upgrade_routes(&register)?;
     }
     Ok(())
 }

--- a/src/api/upgrade.rs
+++ b/src/api/upgrade.rs
@@ -1,0 +1,210 @@
+// SPDX-FileCopyrightText: 2025 Sven Shi
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+//! HTTP handlers for the upgrade check and apply endpoints.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use bytes::Bytes;
+use http::{Request, StatusCode};
+use serde::{Deserialize, Serialize};
+use tokio::sync::Semaphore;
+use tracing::error;
+
+use crate::api::{ApiHandler, ApiRegister, json_error, json_ok, json_response};
+use crate::core::error::Result;
+use crate::upgrade::{UpgradeBundle, UpgradeConfig, UpgradeContext};
+
+#[derive(Debug, Deserialize, Default)]
+struct UpgradeApiBody {
+    repository: Option<String>,
+    bundle: Option<String>,
+    socks5: Option<String>,
+    allow_prerelease: Option<bool>,
+    target: Option<String>,
+    github_token: Option<String>,
+}
+
+fn build_upgrade_config(opts: UpgradeApiBody) -> std::result::Result<UpgradeConfig, String> {
+    let mut config = UpgradeConfig::default();
+    if let Some(repo) = opts.repository.filter(|s| !s.trim().is_empty()) {
+        config.repository = repo;
+    }
+    if let Some(bundle_str) = opts.bundle.filter(|s| !s.trim().is_empty()) {
+        config.bundle = UpgradeBundle::from_user_value(&bundle_str).map_err(|e| e.to_string())?;
+    }
+    config.socks5 = opts.socks5.filter(|s| !s.trim().is_empty());
+    if let Some(allow_prerelease) = opts.allow_prerelease {
+        config.allow_prerelease = allow_prerelease;
+    }
+    if let Some(target) = opts.target.filter(|s| !s.trim().is_empty()) {
+        config.target = target;
+    }
+    config.github_token = opts.github_token.filter(|s| !s.trim().is_empty());
+    Ok(config)
+}
+
+fn parse_query_params(query: Option<&str>) -> UpgradeApiBody {
+    let mut body = UpgradeApiBody::default();
+    for (key, value) in url::form_urlencoded::parse(query.unwrap_or_default().as_bytes()) {
+        match key.as_ref() {
+            "repository" => body.repository = Some(value.into_owned()),
+            "bundle" => body.bundle = Some(value.into_owned()),
+            "socks5" => body.socks5 = Some(value.into_owned()),
+            "allow_prerelease" => body.allow_prerelease = value.parse().ok(),
+            "target" => body.target = Some(value.into_owned()),
+            "github_token" => body.github_token = Some(value.into_owned()),
+            _ => {}
+        }
+    }
+    body
+}
+
+#[derive(Debug, Serialize)]
+struct UpgradeCheckResponse {
+    ok: bool,
+    current_version: String,
+    latest_version: String,
+    update_available: bool,
+    asset_name: String,
+    release_url: String,
+}
+
+#[derive(Debug, Serialize)]
+struct UpgradeApplyResponse {
+    ok: bool,
+    action: &'static str,
+    status: &'static str,
+    message: &'static str,
+}
+
+#[derive(Debug, Serialize)]
+struct UpgradeBusyResponse {
+    ok: bool,
+    code: &'static str,
+    message: &'static str,
+}
+
+struct UpgradeCheckHandler;
+
+#[async_trait]
+impl ApiHandler for UpgradeCheckHandler {
+    async fn handle(&self, request: Request<Bytes>) -> crate::api::ApiResponse {
+        let opts = if request.body().is_empty() {
+            parse_query_params(request.uri().query())
+        } else {
+            match serde_json::from_slice::<UpgradeApiBody>(request.body()) {
+                Ok(b) => b,
+                Err(err) => {
+                    return json_error(
+                        StatusCode::BAD_REQUEST,
+                        "invalid_request",
+                        format!("invalid request body: {err}"),
+                    );
+                }
+            }
+        };
+
+        let config = match build_upgrade_config(opts) {
+            Ok(c) => c,
+            Err(err) => {
+                return json_error(StatusCode::BAD_REQUEST, "invalid_upgrade_config", err);
+            }
+        };
+
+        match crate::upgrade::check(&config).await {
+            Ok(check) => json_ok(
+                StatusCode::OK,
+                &UpgradeCheckResponse {
+                    ok: true,
+                    current_version: check.current_version,
+                    latest_version: check.latest_version,
+                    update_available: check.update_available,
+                    asset_name: check.asset_name,
+                    release_url: check.release_url,
+                },
+            ),
+            Err(err) => json_error(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "upgrade_check_failed",
+                err.to_string(),
+            ),
+        }
+    }
+}
+
+struct UpgradeApplyHandler {
+    apply_semaphore: Arc<Semaphore>,
+}
+
+#[async_trait]
+impl ApiHandler for UpgradeApplyHandler {
+    async fn handle(&self, request: Request<Bytes>) -> crate::api::ApiResponse {
+        let opts = if request.body().is_empty() {
+            UpgradeApiBody::default()
+        } else {
+            match serde_json::from_slice::<UpgradeApiBody>(request.body()) {
+                Ok(b) => b,
+                Err(err) => {
+                    return json_error(
+                        StatusCode::BAD_REQUEST,
+                        "invalid_request",
+                        format!("invalid request body: {err}"),
+                    );
+                }
+            }
+        };
+
+        let config = match build_upgrade_config(opts) {
+            Ok(c) => c,
+            Err(err) => {
+                return json_error(StatusCode::BAD_REQUEST, "invalid_upgrade_config", err);
+            }
+        };
+
+        let permit = match self.apply_semaphore.clone().try_acquire_owned() {
+            Ok(p) => p,
+            Err(_) => {
+                return json_response(
+                    StatusCode::CONFLICT,
+                    &UpgradeBusyResponse {
+                        ok: false,
+                        code: "upgrade_in_progress",
+                        message: "an upgrade is already in progress",
+                    },
+                );
+            }
+        };
+
+        tokio::spawn(async move {
+            let _permit = permit;
+            match crate::upgrade::apply(&config, UpgradeContext::Plugin).await {
+                Ok(_) => {}
+                Err(err) => {
+                    error!(error = %err, "upgrade apply failed");
+                }
+            }
+        });
+
+        json_ok(
+            StatusCode::ACCEPTED,
+            &UpgradeApplyResponse {
+                ok: true,
+                action: "upgrade_apply",
+                status: "accepted",
+                message: "upgrade started; server will restart when complete",
+            },
+        )
+    }
+}
+
+pub fn register_upgrade_routes(register: &ApiRegister) -> Result<()> {
+    let apply_semaphore = Arc::new(Semaphore::new(1));
+    register.register_get("/upgrade/check", Arc::new(UpgradeCheckHandler))?;
+    register.register_post(
+        "/upgrade/apply",
+        Arc::new(UpgradeApplyHandler { apply_semaphore }),
+    )?;
+    Ok(())
+}

--- a/src/api/upgrade.rs
+++ b/src/api/upgrade.rs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2025 Sven Shi
 // SPDX-License-Identifier: GPL-3.0-or-later
 
+#![cfg(feature = "plugin-upgrade")]
 //! HTTP handlers for the upgrade check and apply endpoints.
 
 use std::sync::Arc;

--- a/src/plugin/executor/query_recorder/tests.rs
+++ b/src/plugin/executor/query_recorder/tests.rs
@@ -762,7 +762,20 @@ async fn seed_demo_records(backend: &std::sync::Arc<super::backend::RecorderBack
         None,
         &[],
     ));
-    tokio::time::sleep(Duration::from_millis(50)).await;
+    // Poll until all 5 records appear in the in-memory tail rather than
+    // sleeping for a fixed duration. A fixed sleep is unreliable on Windows
+    // where SQLite WAL writes and thread scheduling can exceed 50 ms.
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(10);
+    loop {
+        if backend.tail.lock().unwrap().len() >= 5 {
+            break;
+        }
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "seed_demo_records: writer thread did not flush 5 records within 10 s"
+        );
+        tokio::time::sleep(Duration::from_millis(5)).await;
+    }
 }
 
 #[tokio::test]

--- a/webui/app/(console)/layout.tsx
+++ b/webui/app/(console)/layout.tsx
@@ -10,6 +10,7 @@ import { OfflineConfigImport } from "@/components/config/offline-config-import";
 import { ConfigHistorySheet } from "@/components/config/config-history-sheet";
 import { useAppStore } from "@/lib/store";
 import { useAuthStore } from "@/lib/auth-store";
+import { useUpdateStore } from "@/lib/update-store";
 import { AppHeader } from "@/components/shell/app-header";
 import {
   ConnectionRequired,
@@ -41,9 +42,12 @@ export default function ConsoleLayout({
   const attemptAutoConnect = useAuthStore((s) => s.attemptAutoConnect);
   const isAuthHydrated = useAuthStore((s) => s.isHydrated);
   const pathname = usePathname();
+  const checkForUpdates = useUpdateStore((s) => s.checkForUpdates);
+  const upgradeAutoCheck = useUpdateStore((s) => s.upgradeConfig.autoCheck);
   const [sidebarOpen, setSidebarOpen] = useState(true);
   const sidebarStateBeforeEditor = useRef(sidebarOpen);
   const previousEditorMode = useRef(editorMode);
+  const hasCheckedUpdates = useRef(false);
 
   // Once the store has hydrated, eagerly probe the configured backend (default
   // `/api`). Only fall back to the connection prompt if that attempt fails.
@@ -64,6 +68,17 @@ export default function ConsoleLayout({
   useEffect(() => {
     if (isConnected) void loadConfig();
   }, [isConnected, loadConfig]);
+
+  const health = useAppStore((s) => s.health);
+  const system = useAppStore((s) => s.system);
+
+  useEffect(() => {
+    if (!isConnected || hasCheckedUpdates.current || !upgradeAutoCheck) return;
+    const version = system?.version ?? health?.version;
+    if (!version) return;
+    hasCheckedUpdates.current = true;
+    void checkForUpdates(version);
+  }, [isConnected, upgradeAutoCheck, health, system, checkForUpdates]);
 
   // On reconnect, drop offline mode so loadConfig's authoritative state wins.
   useEffect(() => {

--- a/webui/app/(console)/layout.tsx
+++ b/webui/app/(console)/layout.tsx
@@ -44,6 +44,7 @@ export default function ConsoleLayout({
   const pathname = usePathname();
   const checkForUpdates = useUpdateStore((s) => s.checkForUpdates);
   const upgradeAutoCheck = useUpdateStore((s) => s.upgradeConfig.autoCheck);
+  const buildInfo = useAppStore((s) => s.buildInfo);
   const [sidebarOpen, setSidebarOpen] = useState(true);
   const sidebarStateBeforeEditor = useRef(sidebarOpen);
   const previousEditorMode = useRef(editorMode);
@@ -74,11 +75,12 @@ export default function ConsoleLayout({
 
   useEffect(() => {
     if (!isConnected || hasCheckedUpdates.current || !upgradeAutoCheck) return;
+    if (!buildInfo?.enabled_features.includes("plugin-upgrade")) return;
     const version = system?.version ?? health?.version;
     if (!version) return;
     hasCheckedUpdates.current = true;
     void checkForUpdates(version);
-  }, [isConnected, upgradeAutoCheck, health, system, checkForUpdates]);
+  }, [isConnected, upgradeAutoCheck, health, system, buildInfo, checkForUpdates]);
 
   // On reconnect, drop offline mode so loadConfig's authoritative state wins.
   useEffect(() => {

--- a/webui/app/(console)/settings/page.tsx
+++ b/webui/app/(console)/settings/page.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from "react";
 import { AppHeader } from "@/components/shell/app-header";
 import { useAppStore } from "@/lib/store";
 import { useAuthStore } from "@/lib/auth-store";
+import { useUpdateStore, type UpgradeBundle } from "@/lib/update-store";
 import { stringifyOxiDnsConfig, type OxiDnsConfig } from "@/lib/oxidns-config";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -26,8 +27,10 @@ import {
 import { Textarea } from "@/components/ui/textarea";
 import { Switch } from "@/components/ui/switch";
 import {
+  ArrowUpCircle,
   CheckCircle2,
   CircleAlert,
+  Copy,
   Cpu,
   FileCode2,
   Globe,
@@ -47,6 +50,18 @@ export default function SettingsPage() {
   const isConnected = useAuthStore((s) => s.isConnected);
   const isConnecting = useAuthStore((s) => s.isConnecting);
   const connectionError = useAuthStore((s) => s.connectionError);
+
+  const upgradeConfig = useUpdateStore((s) => s.upgradeConfig);
+  const setUpgradeConfig = useUpdateStore((s) => s.setUpgradeConfig);
+  const updateInfo = useUpdateStore((s) => s.updateInfo);
+  const isChecking = useUpdateStore((s) => s.isChecking);
+  const isApplying = useUpdateStore((s) => s.isApplying);
+  const lastCheckedAt = useUpdateStore((s) => s.lastCheckedAt);
+  const checkError = useUpdateStore((s) => s.checkError);
+  const applyError = useUpdateStore((s) => s.applyError);
+  const checkForUpdates = useUpdateStore((s) => s.checkForUpdates);
+  const triggerUpgrade = useUpdateStore((s) => s.triggerUpgrade);
+  const [copiedCmd, setCopiedCmd] = useState(false);
 
   const configModel = useAppStore((s) => s.configModel);
   const configPath = useAppStore((s) => s.configPath);
@@ -136,6 +151,44 @@ export default function SettingsPage() {
 
   const handleSaveConnection = () => {
     setServerConfig({ ...serverConfig, url: backendUrl.trim() });
+  };
+
+  const runtimeVersionForCheck =
+    system?.build
+      ? `${system.build.version}`
+      : (system?.version ?? health?.version ?? "");
+
+  const handleCheckUpdates = () => {
+    if (runtimeVersionForCheck) {
+      void checkForUpdates(runtimeVersionForCheck);
+    }
+  };
+
+  const buildUpgradeCliCommand = () => {
+    const parts = ["oxidns", "upgrade", "apply"];
+    if (upgradeConfig.repository !== "svenshi/oxidns") {
+      parts.push("--repository", upgradeConfig.repository);
+    }
+    if (upgradeConfig.bundle !== "auto") {
+      parts.push("--bundle", upgradeConfig.bundle);
+    }
+    if (upgradeConfig.socks5.trim()) {
+      parts.push("--socks5", upgradeConfig.socks5.trim());
+    }
+    if (upgradeConfig.allowPrerelease) {
+      parts.push("--allow-prerelease");
+    }
+    return parts.join(" ");
+  };
+
+  const handleCopyCommand = async () => {
+    try {
+      await navigator.clipboard.writeText(buildUpgradeCliCommand());
+      setCopiedCmd(true);
+      setTimeout(() => setCopiedCmd(false), 2000);
+    } catch {
+      // ignore
+    }
   };
 
   const handleConnect = async () => {
@@ -897,6 +950,203 @@ export default function SettingsPage() {
                   {isRestarting ? "重启中…" : "保存并重启"}
                 </Button>
               </div>
+            </CardContent>
+          </Card>
+
+          {/* ── 软件升级 ─────────────────────────────────── */}
+          <Card id="upgrade">
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2">
+                <ArrowUpCircle className="h-5 w-5" />
+                软件升级
+              </CardTitle>
+              <CardDescription>
+                检查版本更新并触发后端自升级，升级完成后服务将自动重启
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-6">
+
+              {/* 版本信息 */}
+              <div className="grid gap-4 sm:grid-cols-3">
+                <InfoTile label="当前版本" value={runtimeVersionForCheck || "-"} />
+                <InfoTile
+                  label="最新版本"
+                  value={updateInfo ? updateInfo.latestVersion : (lastCheckedAt ? "-" : "尚未检查")}
+                />
+                <InfoTile
+                  label="上次检查"
+                  value={
+                    lastCheckedAt
+                      ? new Date(lastCheckedAt).toLocaleTimeString()
+                      : "-"
+                  }
+                />
+              </div>
+
+              {updateInfo?.updateAvailable && (
+                <div className="flex items-center justify-between gap-3 rounded-lg border border-primary/30 bg-primary/10 px-3 py-2">
+                  <div className="flex items-center gap-2 text-sm text-primary">
+                    <ArrowUpCircle className="h-4 w-4 shrink-0" />
+                    <span>
+                      发现新版本 <span className="font-semibold">{updateInfo.latestVersion}</span>，当前运行
+                      <span className="font-semibold"> {updateInfo.currentVersion}</span>
+                    </span>
+                  </div>
+                  <a
+                    href={updateInfo.releaseUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="shrink-0 text-xs text-primary underline-offset-2 hover:underline"
+                  >
+                    发布说明
+                  </a>
+                </div>
+              )}
+
+              {updateInfo && !updateInfo.updateAvailable && (
+                <div className="flex items-center gap-2 rounded-lg border border-border px-3 py-2 text-sm text-muted-foreground">
+                  <CheckCircle2 className="h-4 w-4 shrink-0 text-primary" />
+                  已是最新版本 {updateInfo.latestVersion}
+                </div>
+              )}
+
+              {checkError && (
+                <div className="flex items-center gap-2 rounded-lg border border-destructive/30 bg-destructive/10 px-3 py-2 text-sm text-destructive">
+                  <CircleAlert className="h-4 w-4 shrink-0" />
+                  {checkError}
+                </div>
+              )}
+
+              {applyError && (
+                <div className="flex items-center gap-2 rounded-lg border border-destructive/30 bg-destructive/10 px-3 py-2 text-sm text-destructive">
+                  <CircleAlert className="h-4 w-4 shrink-0" />
+                  启动升级失败：{applyError}
+                </div>
+              )}
+
+              <div className="flex flex-wrap gap-2">
+                <Button
+                  variant="outline"
+                  onClick={handleCheckUpdates}
+                  disabled={isChecking || !runtimeVersionForCheck}
+                >
+                  <RefreshCw className={`h-4 w-4 mr-1.5 ${isChecking ? "animate-spin" : ""}`} />
+                  {isChecking ? "检查中…" : "检查更新"}
+                </Button>
+                {updateInfo?.updateAvailable && (
+                  <Button
+                    onClick={() => void triggerUpgrade()}
+                    disabled={isApplying || isRestarting}
+                  >
+                    <ArrowUpCircle className="h-4 w-4 mr-1.5" />
+                    {isApplying ? "升级中…" : "立即升级"}
+                  </Button>
+                )}
+              </div>
+
+              {/* 升级配置 */}
+              <div className="space-y-4">
+                <p className="text-sm font-medium">升级配置</p>
+                <div className="grid gap-4 sm:grid-cols-2">
+                  <Field>
+                    <FieldLabel>GitHub 仓库</FieldLabel>
+                    <p className="text-xs text-muted-foreground mb-2">
+                      格式 <span className="font-mono">owner/repo</span>，默认 svenshi/oxidns
+                    </p>
+                    <Input
+                      value={upgradeConfig.repository}
+                      onChange={(e) => setUpgradeConfig({ repository: e.target.value })}
+                      placeholder="svenshi/oxidns"
+                      className="font-mono"
+                    />
+                  </Field>
+                  <Field>
+                    <FieldLabel>Bundle 类型</FieldLabel>
+                    <p className="text-xs text-muted-foreground mb-2">
+                      auto 自动匹配当前编译 bundle
+                    </p>
+                    <Select
+                      value={upgradeConfig.bundle}
+                      onValueChange={(v) => setUpgradeConfig({ bundle: v as UpgradeBundle })}
+                    >
+                      <SelectTrigger>
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="auto">auto — 自动</SelectItem>
+                        <SelectItem value="full">full — 完整版</SelectItem>
+                        <SelectItem value="standard">standard — 标准版</SelectItem>
+                        <SelectItem value="minimal">minimal — 精简版</SelectItem>
+                      </SelectContent>
+                    </Select>
+                  </Field>
+                  <Field>
+                    <FieldLabel>Socks5 代理</FieldLabel>
+                    <p className="text-xs text-muted-foreground mb-2">
+                      下载时使用的 SOCKS5 代理，留空不使用
+                    </p>
+                    <Input
+                      value={upgradeConfig.socks5}
+                      onChange={(e) => setUpgradeConfig({ socks5: e.target.value })}
+                      placeholder="socks5://127.0.0.1:1080"
+                      className="font-mono"
+                    />
+                  </Field>
+                </div>
+                <div className="flex flex-wrap gap-6">
+                  <div className="flex items-center justify-between gap-4">
+                    <div>
+                      <p className="text-sm font-medium">允许预发布版本</p>
+                      <p className="text-xs text-muted-foreground mt-0.5">
+                        包含 alpha/beta/rc 等预发布标签
+                      </p>
+                    </div>
+                    <Switch
+                      checked={upgradeConfig.allowPrerelease}
+                      onCheckedChange={(v) => setUpgradeConfig({ allowPrerelease: v })}
+                    />
+                  </div>
+                  <div className="flex items-center justify-between gap-4">
+                    <div>
+                      <p className="text-sm font-medium">自动检查更新</p>
+                      <p className="text-xs text-muted-foreground mt-0.5">
+                        每次连接后台时自动查询最新版本
+                      </p>
+                    </div>
+                    <Switch
+                      checked={upgradeConfig.autoCheck}
+                      onCheckedChange={(v) => setUpgradeConfig({ autoCheck: v })}
+                    />
+                  </div>
+                </div>
+              </div>
+
+              {/* CLI 升级命令 */}
+              <div className="space-y-2">
+                <p className="text-sm font-medium">等效 CLI 命令</p>
+                <p className="text-xs text-muted-foreground">
+                  在服务器上以 root 或有权限的用户执行，将自动下载并替换当前二进制文件
+                </p>
+                <div className="flex items-center gap-2 rounded-lg border bg-muted/50 px-3 py-2">
+                  <code className="flex-1 truncate font-mono text-xs">
+                    {buildUpgradeCliCommand()}
+                  </code>
+                  <Button
+                    variant="ghost"
+                    size="icon-sm"
+                    className="shrink-0"
+                    onClick={() => void handleCopyCommand()}
+                  >
+                    {copiedCmd ? (
+                      <CheckCircle2 className="h-4 w-4 text-primary" />
+                    ) : (
+                      <Copy className="h-4 w-4" />
+                    )}
+                    <span className="sr-only">复制命令</span>
+                  </Button>
+                </div>
+              </div>
+
             </CardContent>
           </Card>
 

--- a/webui/app/(console)/settings/page.tsx
+++ b/webui/app/(console)/settings/page.tsx
@@ -70,6 +70,7 @@ export default function SettingsPage() {
   const dependencyGraph = useAppStore((s) => s.dependencyGraph);
   const health = useAppStore((s) => s.health);
   const system = useAppStore((s) => s.system);
+  const buildInfo = useAppStore((s) => s.buildInfo);
   const reloadStatus = useAppStore((s) => s.reloadStatus);
   const setYamlConfig = useAppStore((s) => s.setYamlConfig);
   const saveConfig = useAppStore((s) => s.saveConfig);
@@ -157,6 +158,12 @@ export default function SettingsPage() {
     system?.build
       ? `${system.build.version}`
       : (system?.version ?? health?.version ?? "");
+
+  // null = build info not yet loaded; true/false = feature presence known
+  const backendSupportsUpgrade =
+    buildInfo != null
+      ? buildInfo.enabled_features.includes("plugin-upgrade")
+      : null;
 
   const handleCheckUpdates = () => {
     if (runtimeVersionForCheck) {
@@ -961,27 +968,39 @@ export default function SettingsPage() {
                 软件升级
               </CardTitle>
               <CardDescription>
-                检查版本更新并触发后端自升级，升级完成后服务将自动重启
+                {backendSupportsUpgrade === false
+                  ? "当前后端编译时未启用升级插件，在线检查和自动升级不可用；可使用下方 CLI 命令手动升级"
+                  : "检查版本更新并触发后端自升级，升级完成后服务将自动重启"}
               </CardDescription>
             </CardHeader>
             <CardContent className="space-y-6">
 
-              {/* 版本信息 */}
-              <div className="grid gap-4 sm:grid-cols-3">
-                <InfoTile label="当前版本" value={runtimeVersionForCheck || "-"} />
-                <InfoTile
-                  label="最新版本"
-                  value={updateInfo ? updateInfo.latestVersion : (lastCheckedAt ? "-" : "尚未检查")}
-                />
-                <InfoTile
-                  label="上次检查"
-                  value={
-                    lastCheckedAt
-                      ? new Date(lastCheckedAt).toLocaleTimeString()
-                      : "-"
-                  }
-                />
-              </div>
+              {/* 后端不支持升级时的提示 */}
+              {backendSupportsUpgrade === false && (
+                <div className="flex items-center gap-2 rounded-lg border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-sm text-amber-700 dark:text-amber-400">
+                  <CircleAlert className="h-4 w-4 shrink-0" />
+                  后端未编译 <span className="mx-1 font-mono font-semibold">plugin-upgrade</span> 特性，在线升级功能不可用
+                </div>
+              )}
+
+              {/* 版本信息（仅在后端支持时展示检查结果） */}
+              {backendSupportsUpgrade !== false && (
+                <div className="grid gap-4 sm:grid-cols-3">
+                  <InfoTile label="当前版本" value={runtimeVersionForCheck || "-"} />
+                  <InfoTile
+                    label="最新版本"
+                    value={updateInfo ? updateInfo.latestVersion : (lastCheckedAt ? "-" : "尚未检查")}
+                  />
+                  <InfoTile
+                    label="上次检查"
+                    value={
+                      lastCheckedAt
+                        ? new Date(lastCheckedAt).toLocaleTimeString()
+                        : "-"
+                    }
+                  />
+                </div>
+              )}
 
               {updateInfo?.updateAvailable && (
                 <div className="flex items-center justify-between gap-3 rounded-lg border border-primary/30 bg-primary/10 px-3 py-2">
@@ -1024,25 +1043,27 @@ export default function SettingsPage() {
                 </div>
               )}
 
-              <div className="flex flex-wrap gap-2">
-                <Button
-                  variant="outline"
-                  onClick={handleCheckUpdates}
-                  disabled={isChecking || !runtimeVersionForCheck}
-                >
-                  <RefreshCw className={`h-4 w-4 mr-1.5 ${isChecking ? "animate-spin" : ""}`} />
-                  {isChecking ? "检查中…" : "检查更新"}
-                </Button>
-                {updateInfo?.updateAvailable && (
+              {backendSupportsUpgrade !== false && (
+                <div className="flex flex-wrap gap-2">
                   <Button
-                    onClick={() => void triggerUpgrade()}
-                    disabled={isApplying || isRestarting}
+                    variant="outline"
+                    onClick={handleCheckUpdates}
+                    disabled={isChecking || !runtimeVersionForCheck || backendSupportsUpgrade === null}
                   >
-                    <ArrowUpCircle className="h-4 w-4 mr-1.5" />
-                    {isApplying ? "升级中…" : "立即升级"}
+                    <RefreshCw className={`h-4 w-4 mr-1.5 ${isChecking ? "animate-spin" : ""}`} />
+                    {isChecking ? "检查中…" : "检查更新"}
                   </Button>
-                )}
-              </div>
+                  {updateInfo?.updateAvailable && (
+                    <Button
+                      onClick={() => void triggerUpgrade()}
+                      disabled={isApplying || isRestarting}
+                    >
+                      <ArrowUpCircle className="h-4 w-4 mr-1.5" />
+                      {isApplying ? "升级中…" : "立即升级"}
+                    </Button>
+                  )}
+                </div>
+              )}
 
               {/* 升级配置 */}
               <div className="space-y-4">

--- a/webui/components/shell/app-header.tsx
+++ b/webui/components/shell/app-header.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import Link from "next/link";
+import { useRouter } from "next/navigation";
 import { SidebarTrigger } from "@/components/ui/sidebar";
 import {
   Breadcrumb,
@@ -11,9 +12,11 @@ import {
   BreadcrumbSeparator,
 } from "@/components/ui/breadcrumb";
 import { Button } from "@/components/ui/button";
-import { Moon, Sun, Code2, LayoutDashboard } from "lucide-react";
+import { Moon, Sun, Code2, LayoutDashboard, ArrowUpCircle } from "lucide-react";
 import { useTheme } from "next-themes";
 import { useAppStore } from "@/lib/store";
+import { useAuthStore } from "@/lib/auth-store";
+import { useUpdateStore } from "@/lib/update-store";
 import { ConfigSyncControl } from "@/components/config/config-sync-status";
 import {
   Tooltip,
@@ -28,8 +31,11 @@ interface AppHeaderProps {
 
 export function AppHeader({ title, breadcrumbs = [] }: AppHeaderProps) {
   const { theme, setTheme } = useTheme();
+  const router = useRouter();
   const editorMode = useAppStore((s) => s.editorMode);
   const setEditorMode = useAppStore((s) => s.setEditorMode);
+  const isConnected = useAuthStore((s) => s.isConnected);
+  const updateInfo = useUpdateStore((s) => s.updateInfo);
   const showNavigation = !editorMode;
 
   return (
@@ -75,6 +81,29 @@ export function AppHeader({ title, breadcrumbs = [] }: AppHeaderProps) {
 
       <div className="ml-auto flex items-center gap-2">
         <ConfigSyncControl />
+        {isConnected && (
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                variant="ghost"
+                size="icon-sm"
+                className="relative rounded-md text-muted-foreground hover:text-foreground"
+                onClick={() => router.push("/settings#upgrade")}
+              >
+                <ArrowUpCircle className="h-4 w-4" />
+                {updateInfo?.updateAvailable && (
+                  <span className="absolute right-0.5 top-0.5 h-2 w-2 rounded-full bg-destructive" />
+                )}
+                <span className="sr-only">软件升级</span>
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>
+              {updateInfo?.updateAvailable
+                ? `有新版本 ${updateInfo.latestVersion} 可用`
+                : "软件升级设置"}
+            </TooltipContent>
+          </Tooltip>
+        )}
         <div className="flex items-center rounded-lg border border-border/60 bg-background/80 p-0.5 shadow-sm">
           <Tooltip>
             <TooltipTrigger asChild>

--- a/webui/components/shell/app-header.tsx
+++ b/webui/components/shell/app-header.tsx
@@ -36,6 +36,9 @@ export function AppHeader({ title, breadcrumbs = [] }: AppHeaderProps) {
   const setEditorMode = useAppStore((s) => s.setEditorMode);
   const isConnected = useAuthStore((s) => s.isConnected);
   const updateInfo = useUpdateStore((s) => s.updateInfo);
+  const buildInfo = useAppStore((s) => s.buildInfo);
+  const backendSupportsUpgrade =
+    buildInfo != null ? buildInfo.enabled_features.includes("plugin-upgrade") : null;
   const showNavigation = !editorMode;
 
   return (
@@ -91,14 +94,14 @@ export function AppHeader({ title, breadcrumbs = [] }: AppHeaderProps) {
                 onClick={() => router.push("/settings#upgrade")}
               >
                 <ArrowUpCircle className="h-4 w-4" />
-                {updateInfo?.updateAvailable && (
+                {backendSupportsUpgrade && updateInfo?.updateAvailable && (
                   <span className="absolute right-0.5 top-0.5 h-2 w-2 rounded-full bg-destructive" />
                 )}
                 <span className="sr-only">软件升级</span>
               </Button>
             </TooltipTrigger>
             <TooltipContent>
-              {updateInfo?.updateAvailable
+              {backendSupportsUpgrade && updateInfo?.updateAvailable
                 ? `有新版本 ${updateInfo.latestVersion} 可用`
                 : "软件升级设置"}
             </TooltipContent>

--- a/webui/lib/oxidns-api.ts
+++ b/webui/lib/oxidns-api.ts
@@ -887,6 +887,69 @@ export async function fetchPrometheusMetrics(): Promise<string> {
   return response.text();
 }
 
+// --- Upgrade API ---
+
+export interface UpgradeCheckOptions {
+  repository?: string;
+  bundle?: string;
+  socks5?: string;
+  allowPrerelease?: boolean;
+  target?: string;
+  githubToken?: string;
+}
+
+export interface UpgradeCheckResponse {
+  ok: boolean;
+  current_version: string;
+  latest_version: string;
+  update_available: boolean;
+  asset_name: string;
+  release_url: string;
+}
+
+export interface UpgradeApplyResponse {
+  ok: boolean;
+  action: string;
+  status: string;
+  message: string;
+}
+
+export async function fetchUpgradeCheck(
+  options: UpgradeCheckOptions = {},
+): Promise<UpgradeCheckResponse> {
+  const params = new URLSearchParams();
+  if (options.repository) params.set("repository", options.repository);
+  if (options.bundle) params.set("bundle", options.bundle);
+  if (options.socks5) params.set("socks5", options.socks5);
+  if (options.allowPrerelease) params.set("allow_prerelease", "true");
+  if (options.target) params.set("target", options.target);
+  if (options.githubToken) params.set("github_token", options.githubToken);
+  const suffix = params.size > 0 ? `?${params.toString()}` : "";
+  const response = await fetch(apiUrl(`/upgrade/check${suffix}`), {
+    method: "GET",
+    headers: apiHeaders(),
+  });
+  return readJsonResponse<UpgradeCheckResponse>(response);
+}
+
+export async function triggerUpgradeApply(
+  options: UpgradeCheckOptions = {},
+): Promise<UpgradeApplyResponse> {
+  const body: Record<string, unknown> = {};
+  if (options.repository) body.repository = options.repository;
+  if (options.bundle) body.bundle = options.bundle;
+  if (options.socks5) body.socks5 = options.socks5;
+  if (options.allowPrerelease) body.allow_prerelease = true;
+  if (options.target) body.target = options.target;
+  if (options.githubToken) body.github_token = options.githubToken;
+  const response = await fetch(apiUrl("/upgrade/apply"), {
+    method: "POST",
+    headers: { ...apiHeaders(), "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  return readJsonResponse<UpgradeApplyResponse>(response);
+}
+
 export function apiUrl(path: string) {
   const baseUrl = useAuthStore.getState().serverConfig.url.trim();
   return `${baseUrl.replace(/\/$/, "")}${path}`;

--- a/webui/lib/update-store.ts
+++ b/webui/lib/update-store.ts
@@ -1,0 +1,133 @@
+"use client";
+
+import { create } from "zustand";
+
+const STORAGE_KEY = "oxidns:upgrade-config";
+
+export type UpgradeBundle = "auto" | "full" | "minimal" | "standard";
+
+export interface UpgradeConfig {
+  repository: string;
+  bundle: UpgradeBundle;
+  socks5: string;
+  allowPrerelease: boolean;
+  autoCheck: boolean;
+}
+
+const DEFAULT_UPGRADE_CONFIG: UpgradeConfig = {
+  repository: "svenshi/oxidns",
+  bundle: "auto",
+  socks5: "",
+  allowPrerelease: false,
+  autoCheck: true,
+};
+
+export interface UpdateInfo {
+  currentVersion: string;
+  latestVersion: string;
+  updateAvailable: boolean;
+  assetName: string;
+  releaseUrl: string;
+}
+
+interface UpdateState {
+  upgradeConfig: UpgradeConfig;
+  updateInfo: UpdateInfo | null;
+  isChecking: boolean;
+  isApplying: boolean;
+  lastCheckedAt: number | null;
+  checkError: string | null;
+  applyError: string | null;
+
+  setUpgradeConfig: (config: Partial<UpgradeConfig>) => void;
+  checkForUpdates: (currentVersion: string) => Promise<void>;
+  triggerUpgrade: () => Promise<void>;
+}
+
+function loadUpgradeConfig(): UpgradeConfig {
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (stored) {
+      return { ...DEFAULT_UPGRADE_CONFIG, ...(JSON.parse(stored) as Partial<UpgradeConfig>) };
+    }
+  } catch {
+    // ignore
+  }
+  return { ...DEFAULT_UPGRADE_CONFIG };
+}
+
+function saveUpgradeConfig(config: UpgradeConfig): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(config));
+  } catch {
+    // ignore
+  }
+}
+
+export const useUpdateStore = create<UpdateState>((set, get) => ({
+  upgradeConfig:
+    typeof window !== "undefined" ? loadUpgradeConfig() : { ...DEFAULT_UPGRADE_CONFIG },
+  updateInfo: null,
+  isChecking: false,
+  isApplying: false,
+  lastCheckedAt: null,
+  checkError: null,
+  applyError: null,
+
+  setUpgradeConfig: (partial) => {
+    const next = { ...get().upgradeConfig, ...partial };
+    saveUpgradeConfig(next);
+    set({ upgradeConfig: next });
+  },
+
+  checkForUpdates: async (currentVersion: string) => {
+    const { upgradeConfig } = get();
+    set({ isChecking: true, checkError: null });
+    try {
+      const { fetchUpgradeCheck } = await import("./oxidns-api");
+      const result = await fetchUpgradeCheck({
+        repository: upgradeConfig.repository,
+        bundle: upgradeConfig.bundle,
+        socks5: upgradeConfig.socks5 || undefined,
+        allowPrerelease: upgradeConfig.allowPrerelease,
+      });
+      set({
+        updateInfo: {
+          currentVersion,
+          latestVersion: result.latest_version,
+          updateAvailable: result.update_available,
+          assetName: result.asset_name,
+          releaseUrl: result.release_url,
+        },
+        lastCheckedAt: Date.now(),
+        isChecking: false,
+      });
+    } catch (error) {
+      set({
+        checkError: error instanceof Error ? error.message : "检查更新失败",
+        isChecking: false,
+        lastCheckedAt: Date.now(),
+      });
+    }
+  },
+
+  triggerUpgrade: async () => {
+    const { upgradeConfig } = get();
+    set({ isApplying: true, applyError: null });
+    try {
+      const { triggerUpgradeApply } = await import("./oxidns-api");
+      await triggerUpgradeApply({
+        repository: upgradeConfig.repository,
+        bundle: upgradeConfig.bundle,
+        socks5: upgradeConfig.socks5 || undefined,
+        allowPrerelease: upgradeConfig.allowPrerelease,
+      });
+      set({ isApplying: false });
+    } catch (error) {
+      set({
+        applyError: error instanceof Error ? error.message : "启动升级失败",
+        isApplying: false,
+      });
+    }
+  },
+}));


### PR DESCRIPTION
- Add GET /upgrade/check and POST /upgrade/apply API endpoints backed by the existing upgrade engine; apply runs in a background task and restarts the server on success, a semaphore prevents concurrent runs.
- Add update-store (Zustand) to track version check state and persist upgrade config (repository, bundle, socks5, allow_prerelease, auto_check) across sessions via localStorage.
- Show an ArrowUpCircle indicator in the app header when connected; a red dot appears when a newer release is detected, clicking navigates to the upgrade settings section.
- Auto-check fires once per page load after backend connection when auto_check is enabled; users can also trigger a manual check.
- Add a "软件升级" card in settings with version comparison tiles, upgrade config fields (repo, bundle, socks5 proxy, prerelease and auto-check toggles), a one-click upgrade button, and a dynamically generated equivalent CLI command with copy support.