### PR TITLE
fix(upgrade): use POST body for all params and fix apply state lifecycle

### DIFF
--- a/src/api/upgrade.rs
+++ b/src/api/upgrade.rs
@@ -1,7 +1,6 @@
 // SPDX-FileCopyrightText: 2025 Sven Shi
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-#![cfg(feature = "plugin-upgrade")]
 //! HTTP handlers for the upgrade check and apply endpoints.
 
 use std::sync::Arc;
@@ -46,22 +45,6 @@ fn build_upgrade_config(opts: UpgradeApiBody) -> std::result::Result<UpgradeConf
     Ok(config)
 }
 
-fn parse_query_params(query: Option<&str>) -> UpgradeApiBody {
-    let mut body = UpgradeApiBody::default();
-    for (key, value) in url::form_urlencoded::parse(query.unwrap_or_default().as_bytes()) {
-        match key.as_ref() {
-            "repository" => body.repository = Some(value.into_owned()),
-            "bundle" => body.bundle = Some(value.into_owned()),
-            "socks5" => body.socks5 = Some(value.into_owned()),
-            "allow_prerelease" => body.allow_prerelease = value.parse().ok(),
-            "target" => body.target = Some(value.into_owned()),
-            "github_token" => body.github_token = Some(value.into_owned()),
-            _ => {}
-        }
-    }
-    body
-}
-
 #[derive(Debug, Serialize)]
 struct UpgradeCheckResponse {
     ok: bool,
@@ -93,7 +76,7 @@ struct UpgradeCheckHandler;
 impl ApiHandler for UpgradeCheckHandler {
     async fn handle(&self, request: Request<Bytes>) -> crate::api::ApiResponse {
         let opts = if request.body().is_empty() {
-            parse_query_params(request.uri().query())
+            UpgradeApiBody::default()
         } else {
             match serde_json::from_slice::<UpgradeApiBody>(request.body()) {
                 Ok(b) => b,
@@ -202,7 +185,7 @@ impl ApiHandler for UpgradeApplyHandler {
 
 pub fn register_upgrade_routes(register: &ApiRegister) -> Result<()> {
     let apply_semaphore = Arc::new(Semaphore::new(1));
-    register.register_get("/upgrade/check", Arc::new(UpgradeCheckHandler))?;
+    register.register_post("/upgrade/check", Arc::new(UpgradeCheckHandler))?;
     register.register_post(
         "/upgrade/apply",
         Arc::new(UpgradeApplyHandler { apply_semaphore }),

--- a/webui/app/(console)/layout.tsx
+++ b/webui/app/(console)/layout.tsx
@@ -43,6 +43,7 @@ export default function ConsoleLayout({
   const isAuthHydrated = useAuthStore((s) => s.isHydrated);
   const pathname = usePathname();
   const checkForUpdates = useUpdateStore((s) => s.checkForUpdates);
+  const resetApplyState = useUpdateStore((s) => s.resetApplyState);
   const upgradeAutoCheck = useUpdateStore((s) => s.upgradeConfig.autoCheck);
   const buildInfo = useAppStore((s) => s.buildInfo);
   const [sidebarOpen, setSidebarOpen] = useState(true);
@@ -81,6 +82,15 @@ export default function ConsoleLayout({
     hasCheckedUpdates.current = true;
     void checkForUpdates(version);
   }, [isConnected, upgradeAutoCheck, health, system, buildInfo, checkForUpdates]);
+
+  // On disconnect: allow auto-check to re-fire on the next reconnect, and
+  // clear any in-progress upgrade state (the server restarted or the apply failed).
+  useEffect(() => {
+    if (!isConnected) {
+      hasCheckedUpdates.current = false;
+      resetApplyState();
+    }
+  }, [isConnected, resetApplyState]);
 
   // On reconnect, drop offline mode so loadConfig's authoritative state wins.
   useEffect(() => {

--- a/webui/app/(console)/settings/page.tsx
+++ b/webui/app/(console)/settings/page.tsx
@@ -4,7 +4,7 @@ import { useEffect, useState } from "react";
 import { AppHeader } from "@/components/shell/app-header";
 import { useAppStore } from "@/lib/store";
 import { useAuthStore } from "@/lib/auth-store";
-import { useUpdateStore, type UpgradeBundle } from "@/lib/update-store";
+import { useUpdateStore, DEFAULT_UPGRADE_CONFIG, type UpgradeBundle } from "@/lib/update-store";
 import { stringifyOxiDnsConfig, type OxiDnsConfig } from "@/lib/oxidns-config";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -173,7 +173,7 @@ export default function SettingsPage() {
 
   const buildUpgradeCliCommand = () => {
     const parts = ["oxidns", "upgrade", "apply"];
-    if (upgradeConfig.repository !== "svenshi/oxidns") {
+    if (upgradeConfig.repository !== DEFAULT_UPGRADE_CONFIG.repository) {
       parts.push("--repository", upgradeConfig.repository);
     }
     if (upgradeConfig.bundle !== "auto") {
@@ -1072,12 +1072,12 @@ export default function SettingsPage() {
                   <Field>
                     <FieldLabel>GitHub 仓库</FieldLabel>
                     <p className="text-xs text-muted-foreground mb-2">
-                      格式 <span className="font-mono">owner/repo</span>，默认 svenshi/oxidns
+                      格式 <span className="font-mono">owner/repo</span>，默认 {DEFAULT_UPGRADE_CONFIG.repository}
                     </p>
                     <Input
                       value={upgradeConfig.repository}
                       onChange={(e) => setUpgradeConfig({ repository: e.target.value })}
-                      placeholder="svenshi/oxidns"
+                      placeholder={DEFAULT_UPGRADE_CONFIG.repository}
                       className="font-mono"
                     />
                   </Field>

--- a/webui/lib/oxidns-api.ts
+++ b/webui/lib/oxidns-api.ts
@@ -917,17 +917,17 @@ export interface UpgradeApplyResponse {
 export async function fetchUpgradeCheck(
   options: UpgradeCheckOptions = {},
 ): Promise<UpgradeCheckResponse> {
-  const params = new URLSearchParams();
-  if (options.repository) params.set("repository", options.repository);
-  if (options.bundle) params.set("bundle", options.bundle);
-  if (options.socks5) params.set("socks5", options.socks5);
-  if (options.allowPrerelease) params.set("allow_prerelease", "true");
-  if (options.target) params.set("target", options.target);
-  if (options.githubToken) params.set("github_token", options.githubToken);
-  const suffix = params.size > 0 ? `?${params.toString()}` : "";
-  const response = await fetch(apiUrl(`/upgrade/check${suffix}`), {
-    method: "GET",
-    headers: apiHeaders(),
+  const body: Record<string, unknown> = {};
+  if (options.repository) body.repository = options.repository;
+  if (options.bundle) body.bundle = options.bundle;
+  if (options.socks5) body.socks5 = options.socks5;
+  if (options.allowPrerelease) body.allow_prerelease = true;
+  if (options.target) body.target = options.target;
+  if (options.githubToken) body.github_token = options.githubToken;
+  const response = await fetch(apiUrl("/upgrade/check"), {
+    method: "POST",
+    headers: { ...apiHeaders(), "Content-Type": "application/json" },
+    body: JSON.stringify(body),
   });
   return readJsonResponse<UpgradeCheckResponse>(response);
 }

--- a/webui/lib/update-store.ts
+++ b/webui/lib/update-store.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import { create } from "zustand";
+import { fetchUpgradeCheck, triggerUpgradeApply } from "./oxidns-api";
 
 const STORAGE_KEY = "oxidns:upgrade-config";
 
@@ -14,7 +15,7 @@ export interface UpgradeConfig {
   autoCheck: boolean;
 }
 
-const DEFAULT_UPGRADE_CONFIG: UpgradeConfig = {
+export const DEFAULT_UPGRADE_CONFIG: UpgradeConfig = {
   repository: "svenshi/oxidns",
   bundle: "auto",
   socks5: "",
@@ -42,6 +43,7 @@ interface UpdateState {
   setUpgradeConfig: (config: Partial<UpgradeConfig>) => void;
   checkForUpdates: (currentVersion: string) => Promise<void>;
   triggerUpgrade: () => Promise<void>;
+  resetApplyState: () => void;
 }
 
 function loadUpgradeConfig(): UpgradeConfig {
@@ -84,7 +86,6 @@ export const useUpdateStore = create<UpdateState>((set, get) => ({
     const { upgradeConfig } = get();
     set({ isChecking: true, checkError: null });
     try {
-      const { fetchUpgradeCheck } = await import("./oxidns-api");
       const result = await fetchUpgradeCheck({
         repository: upgradeConfig.repository,
         bundle: upgradeConfig.bundle,
@@ -115,14 +116,14 @@ export const useUpdateStore = create<UpdateState>((set, get) => ({
     const { upgradeConfig } = get();
     set({ isApplying: true, applyError: null });
     try {
-      const { triggerUpgradeApply } = await import("./oxidns-api");
       await triggerUpgradeApply({
         repository: upgradeConfig.repository,
         bundle: upgradeConfig.bundle,
         socks5: upgradeConfig.socks5 || undefined,
         allowPrerelease: upgradeConfig.allowPrerelease,
       });
-      set({ isApplying: false });
+      // 服务端升级在后台运行，202 到达后服务即将重启。
+      // 保持 isApplying=true 直到连接断开，由 resetApplyState 在断连时重置。
     } catch (error) {
       set({
         applyError: error instanceof Error ? error.message : "启动升级失败",
@@ -130,4 +131,6 @@ export const useUpdateStore = create<UpdateState>((set, get) => ({
       });
     }
   },
+
+  resetApplyState: () => set({ isApplying: false, applyError: null }),
 }));


### PR DESCRIPTION
- Change /upgrade/check from GET to POST so all fields (including github_token) are transmitted in the JSON body rather than URL query strings where they would be written to server logs
- Remove parse_query_params and the now-redundant #![cfg] inner attribute from upgrade.rs; both endpoints now share the same body-parsing path
- Keep isApplying=true after the 202 response instead of resetting immediately; the server is still running the upgrade in background
- Reset isApplying and re-arm the auto-check ref on disconnect, so a fresh version check fires automatically after the server restarts
- Replace hardcoded "svenshi/oxidns" with DEFAULT_UPGRADE_CONFIG.repository in the CLI command builder; switch to static imports in update-store