### PR TITLE
docs(plugin): correct documented default values

### DIFF
--- a/docs/docs/custom-build.mdx
+++ b/docs/docs/custom-build.mdx
@@ -16,7 +16,7 @@ feature 开关。需要小体积 / 特定平台 / 特定插件组合的二进制
 | [本地 `cargo build`](#方式二本地-cargo-build) | 手头有 Rust 环境,只需要一次性产出一个定制二进制 | ✅ |
 | [fork 整个项目](#方式三fork-项目) | 需要持续修改源码 / 长期偏离上游 | ✅ |
 
-<Admonition type="tip" title="默认行为">
+<Admonition type="tip" title="Cargo 默认 feature">
 
 `cargo build` 默认启用 `full` 组合,产出与官方发布物完全等价的二进制。
 只有显式 `--no-default-features` 才进入裁剪模式。

--- a/docs/docs/plugin-reference/executor.mdx
+++ b/docs/docs/plugin-reference/executor.mdx
@@ -308,14 +308,14 @@ import Admonition from "@theme/Admonition";
 
 #### `upstreams[].idle_timeout`
 
-- 类型：`integer`；必填：否；默认值：无
+- 类型：`integer`；必填：否；默认值：`10`
 - 单位：秒
 - 作用：定义连接池空闲连接保留时间。
 - 示例：`idle_timeout: 30`
 
 #### `upstreams[].max_conns`
 
-- 类型：`integer`；必填：否；默认值：实现默认值
+- 类型：`integer`；必填：否；默认值：`64`
 - 作用：定义连接池连接上限。
 - 示例：`max_conns: 256`
 
@@ -334,7 +334,7 @@ import Admonition from "@theme/Admonition";
 
 #### `upstreams[].enable_pipeline`
 
-- 类型：`boolean`；必填：否；默认值：协议默认行为
+- 类型：`boolean`；必填：否；默认值：`false`
 - 作用：控制 TCP 或 DoT 流水线。
 - 示例：`enable_pipeline: true`
 - 说明：也可直接通过 `tcp+pipeline://` 或 `tls+pipeline://` 在 `addr` 中启用。
@@ -479,7 +479,7 @@ import Admonition from "@theme/Admonition";
 
 #### `short_circuit`
 
-- 类型：`boolean`；必填：否；默认值：实现默认行为
+- 类型：`boolean`；必填：否；默认值：`false`
 - 作用：控制缓存命中后是否立即结束后续执行。
 - 说明：
   - 设为 `false` 时，即使 cache 已经写入 response，后续执行链仍会继续。
@@ -487,7 +487,7 @@ import Admonition from "@theme/Admonition";
 
 #### `cache_negative`
 
-- 类型：`boolean`；必填：否；默认值：实现默认行为
+- 类型：`boolean`；必填：否；默认值：`true`
 - 作用：控制是否缓存 NXDOMAIN 与 NODATA。
 
 #### `max_negative_ttl`
@@ -2313,7 +2313,7 @@ old-static.example.com static.example.net
 
 #### `mask4` / `mask6`
 
-- 类型：`integer`；必填：否；默认值：由实现确定
+- 类型：`integer`；必填：否；默认值：`mask4` 为 `24`，`mask6` 为 `48`
 - 作用：兼容写法下分别定义 IPv4 / IPv6 前缀长度。
 
 ### quick setup

--- a/docs/i18n/en/docusaurus-plugin-content-docs/current/custom-build.mdx
+++ b/docs/i18n/en/docusaurus-plugin-content-docs/current/custom-build.mdx
@@ -18,7 +18,7 @@ paths**:
 | [Local `cargo build`](#path-2-local-cargo-build) | One-off custom binary, you already have Rust installed | ✅ |
 | [Fork the whole project](#path-3-fork-the-project) | Long-term source modifications, diverging from upstream | ✅ |
 
-<Admonition type="tip" title="Default behavior">
+<Admonition type="tip" title="Cargo Default Features">
 
 `cargo build` enables the `full` bundle by default and produces a binary
 equivalent to the official release. Only `--no-default-features` enters

--- a/docs/i18n/en/docusaurus-plugin-content-docs/current/plugin-reference/executor.mdx
+++ b/docs/i18n/en/docusaurus-plugin-content-docs/current/plugin-reference/executor.mdx
@@ -267,13 +267,13 @@ Sends DNS queries to upstreams.
 
 #### `upstreams[].idle_timeout`
 
-- Type: `integer`; Required: no
+- Type: `integer`; Required: no; Default: `10`
 - Unit: seconds
 - Purpose: Idle pooled connection lifetime.
 
 #### `upstreams[].max_conns`
 
-- Type: `integer`; Required: no
+- Type: `integer`; Required: no; Default: `64`
 - Purpose: Maximum pooled connections.
 
 #### `upstreams[].insecure_skip_verify`
@@ -288,8 +288,9 @@ Sends DNS queries to upstreams.
 
 #### `upstreams[].enable_pipeline`
 
-- Type: `boolean`; Required: no
+- Type: `boolean`; Required: no; Default: `false`
 - Purpose: Enable pipelining for TCP or DoT.
+- Notes: `tcp+pipeline://` and `tls+pipeline://` force this on.
 
 #### `upstreams[].enable_http3`
 
@@ -395,7 +396,7 @@ Provides TTL-aware response caching with negative cache support and persistence.
 
 #### `size`
 
-- Type: `integer`; Required: no; Default: implementation default
+- Type: `integer`; Required: no; Default: `1024`
 - Purpose: Cache capacity.
 
 #### `lazy_cache_ttl`
@@ -415,7 +416,7 @@ Provides TTL-aware response caching with negative cache support and persistence.
 
 #### `dump_interval`
 
-- Type: `duration`; Required: no
+- Type: `duration`; Required: no; Default: `600s`
 - Purpose: Periodic dump interval.
 
 #### `short_circuit`
@@ -428,17 +429,17 @@ Provides TTL-aware response caching with negative cache support and persistence.
 
 #### `cache_negative`
 
-- Type: `boolean`; Required: no; Default: `false`
+- Type: `boolean`; Required: no; Default: `true`
 - Purpose: Cache negative responses.
 
 #### `max_negative_ttl`
 
-- Type: `duration`; Required: no
+- Type: `duration`; Required: no; Default: `300s`
 - Purpose: Cap negative-cache TTL.
 
 #### `negative_ttl_without_soa`
 
-- Type: `duration`; Required: no
+- Type: `duration`; Required: no; Default: `60s`
 - Purpose: Fallback TTL for negative answers without SOA.
 
 #### `max_positive_ttl`
@@ -448,7 +449,7 @@ Provides TTL-aware response caching with negative cache support and persistence.
 
 #### `ecs_in_key`
 
-- Type: `boolean`; Required: no
+- Type: `boolean`; Required: no; Default: `false`
 - Purpose: Include ECS information in the cache key.
 
 ### quick setup
@@ -2216,7 +2217,7 @@ Compatibility form:
 
 #### `mask4` / `mask6`
 
-- Type: `integer`; Required: no; Default: implementation-defined
+- Type: `integer`; Required: no; Default: `24` for `mask4`, `48` for `mask6`
 - Purpose: In the compatibility form, defines the prefix length for IPv4 / IPv6 respectively.
 
 ### quick setup


### PR DESCRIPTION
- Replace implementation-defined placeholders with concrete defaults for forward, cache, and nftset.
- Clarify that the custom-build note describes Cargo default features, not runtime behavior.
- Keep Chinese and English plugin reference pages aligned.