### PR TITLE
refactor: reduce complexity risk in DNS internals

### DIFF
--- a/crates/zoneparser/src/parser.rs
+++ b/crates/zoneparser/src/parser.rs
@@ -486,6 +486,32 @@ fn parse_record_rdata(
         return Ok(rdata);
     }
 
+    if let Some(rdata) = parse_address_rdata(rr_type, fields)? {
+        return Ok(rdata);
+    }
+    if let Some(rdata) = parse_name_rdata(rr_type, fields, origin)? {
+        return Ok(rdata);
+    }
+    if let Some(rdata) = parse_pair_rdata(rr_type, fields, origin)? {
+        return Ok(rdata);
+    }
+    if let Some(rdata) = parse_text_rdata(rr_type, fields)? {
+        return Ok(rdata);
+    }
+    if let Some(rdata) = parse_soa_rdata(rr_type, fields, origin)? {
+        return Ok(rdata);
+    }
+    if let Some(rdata) = parse_service_rdata(rr_type, fields, origin)? {
+        return Ok(rdata);
+    }
+
+    Err(format!(
+        "record type '{}' requires RFC3597 generic syntax ('\\# <len> <hex>') in zoneparser",
+        <&str>::from(rr_type)
+    ))
+}
+
+fn parse_address_rdata(rr_type: RecordType, fields: &[Token]) -> Result<Option<RData>, String> {
     match rr_type {
         RecordType::A => {
             let field = require_exact_fields(fields, 1, "A")?;
@@ -509,50 +535,96 @@ fn parse_record_rdata(
                 IpAddr::V4(_) => Err("AAAA record requires an IPv6 address".to_string()),
             }
         }
-        RecordType::CNAME => Ok(RData::CNAME(CNAME(parse_name_token(&fields[0], origin)?))),
-        RecordType::NS => Ok(RData::NS(NS(parse_name_token(&fields[0], origin)?))),
-        RecordType::PTR => Ok(RData::PTR(PTR(parse_name_token(&fields[0], origin)?))),
-        RecordType::DNAME => Ok(RData::DNAME(DNAME(parse_name_token(&fields[0], origin)?))),
-        RecordType::ANAME => Ok(RData::ANAME(ANAME(parse_name_token(&fields[0], origin)?))),
-        RecordType::MD => Ok(RData::MD(MD(parse_name_token(&fields[0], origin)?))),
-        RecordType::MF => Ok(RData::MF(MF(parse_name_token(&fields[0], origin)?))),
-        RecordType::MB => Ok(RData::MB(MB(parse_name_token(&fields[0], origin)?))),
-        RecordType::MG => Ok(RData::MG(MG(parse_name_token(&fields[0], origin)?))),
-        RecordType::MR => Ok(RData::MR(MR(parse_name_token(&fields[0], origin)?))),
-        RecordType::NSAPPTR => Ok(RData::NSAPPTR(NSAPPTR(parse_name_token(
-            &fields[0], origin,
-        )?))),
-        RecordType::MX => parse_u16_name_pair(fields, origin, "MX")
-            .map(|value| RData::MX(MX::new(value.0, value.1))),
-        RecordType::RT => parse_u16_name_pair(fields, origin, "RT")
-            .map(|value| RData::RT(RT::new(value.0, value.1))),
-        RecordType::AFSDB => parse_u16_name_pair(fields, origin, "AFSDB")
-            .map(|value| RData::AFSDB(AFSDB::new(value.0, value.1))),
+        _ => return Ok(None),
+    }
+    .map(Some)
+}
+
+fn parse_name_rdata(
+    rr_type: RecordType,
+    fields: &[Token],
+    origin: Option<&Name>,
+) -> Result<Option<RData>, String> {
+    let rdata = match rr_type {
+        RecordType::CNAME => RData::CNAME(CNAME(parse_single_name(fields, origin, "CNAME")?)),
+        RecordType::NS => RData::NS(NS(parse_single_name(fields, origin, "NS")?)),
+        RecordType::PTR => RData::PTR(PTR(parse_single_name(fields, origin, "PTR")?)),
+        RecordType::DNAME => RData::DNAME(DNAME(parse_single_name(fields, origin, "DNAME")?)),
+        RecordType::ANAME => RData::ANAME(ANAME(parse_single_name(fields, origin, "ANAME")?)),
+        RecordType::MD => RData::MD(MD(parse_single_name(fields, origin, "MD")?)),
+        RecordType::MF => RData::MF(MF(parse_single_name(fields, origin, "MF")?)),
+        RecordType::MB => RData::MB(MB(parse_single_name(fields, origin, "MB")?)),
+        RecordType::MG => RData::MG(MG(parse_single_name(fields, origin, "MG")?)),
+        RecordType::MR => RData::MR(MR(parse_single_name(fields, origin, "MR")?)),
+        RecordType::NSAPPTR => {
+            RData::NSAPPTR(NSAPPTR(parse_single_name(fields, origin, "NSAPPTR")?))
+        }
+        _ => return Ok(None),
+    };
+    Ok(Some(rdata))
+}
+
+fn parse_pair_rdata(
+    rr_type: RecordType,
+    fields: &[Token],
+    origin: Option<&Name>,
+) -> Result<Option<RData>, String> {
+    let rdata = match rr_type {
+        RecordType::MX => {
+            let (preference, exchange) = parse_u16_name_pair(fields, origin, "MX")?;
+            RData::MX(MX::new(preference, exchange))
+        }
+        RecordType::RT => {
+            let (preference, host) = parse_u16_name_pair(fields, origin, "RT")?;
+            RData::RT(RT::new(preference, host))
+        }
+        RecordType::AFSDB => {
+            let (subtype, hostname) = parse_u16_name_pair(fields, origin, "AFSDB")?;
+            RData::AFSDB(AFSDB::new(subtype, hostname))
+        }
         RecordType::RP => {
             let fields = require_exact_fields(fields, 2, "RP")?;
-            Ok(RData::RP(RP::new(
+            RData::RP(RP::new(
                 parse_name_token(&fields[0], origin)?,
                 parse_name_token(&fields[1], origin)?,
-            )))
+            ))
         }
         RecordType::MINFO => {
             let fields = require_exact_fields(fields, 2, "MINFO")?;
-            Ok(RData::MINFO(MINFO::new(
+            RData::MINFO(MINFO::new(
                 parse_name_token(&fields[0], origin)?,
                 parse_name_token(&fields[1], origin)?,
-            )))
+            ))
         }
         RecordType::HINFO => {
             let fields = require_exact_fields(fields, 2, "HINFO")?;
-            Ok(RData::HINFO(HINFO::new(
+            RData::HINFO(HINFO::new(
                 fields[0].decode_text_bytes()?.into_boxed_slice(),
                 fields[1].decode_text_bytes()?.into_boxed_slice(),
-            )))
+            ))
         }
+        _ => return Ok(None),
+    };
+    Ok(Some(rdata))
+}
+
+fn parse_text_rdata(rr_type: RecordType, fields: &[Token]) -> Result<Option<RData>, String> {
+    match rr_type {
         RecordType::TXT => parse_txt_like(fields).map(RData::TXT),
         RecordType::SPF => parse_txt_like(fields).map(|value| RData::SPF(SPF(value))),
         RecordType::AVC => parse_txt_like(fields).map(|value| RData::AVC(AVC(value))),
         RecordType::RESINFO => parse_txt_like(fields).map(|value| RData::RESINFO(RESINFO(value))),
+        _ => return Ok(None),
+    }
+    .map(Some)
+}
+
+fn parse_soa_rdata(
+    rr_type: RecordType,
+    fields: &[Token],
+    origin: Option<&Name>,
+) -> Result<Option<RData>, String> {
+    match rr_type {
         RecordType::SOA => {
             let fields = require_exact_fields(fields, 7, "SOA")?;
             Ok(RData::SOA(SOA::new(
@@ -565,6 +637,17 @@ fn parse_record_rdata(
                 parse_u32(&fields[6].raw, "SOA minimum")?,
             )))
         }
+        _ => return Ok(None),
+    }
+    .map(Some)
+}
+
+fn parse_service_rdata(
+    rr_type: RecordType,
+    fields: &[Token],
+    origin: Option<&Name>,
+) -> Result<Option<RData>, String> {
+    match rr_type {
         RecordType::SRV => {
             let fields = require_exact_fields(fields, 4, "SRV")?;
             Ok(RData::SRV(SRV::new(
@@ -593,11 +676,9 @@ fn parse_record_rdata(
                 fields[2].decode_text_bytes()?.into_boxed_slice(),
             )))
         }
-        _ => Err(format!(
-            "record type '{}' requires RFC3597 generic syntax ('\\# <len> <hex>') in zoneparser",
-            <&str>::from(rr_type)
-        )),
+        _ => return Ok(None),
     }
+    .map(Some)
 }
 
 fn try_parse_generic_rdata(rr_type: RecordType, fields: &[Token]) -> Result<Option<RData>, String> {
@@ -656,6 +737,11 @@ fn parse_u16_name_pair(
         parse_u16(&fields[0].raw, &format!("{} preference", kind))?,
         parse_name_token(&fields[1], origin)?,
     ))
+}
+
+fn parse_single_name(fields: &[Token], origin: Option<&Name>, kind: &str) -> Result<Name, String> {
+    let fields = require_exact_fields(fields, 1, kind)?;
+    parse_name_token(&fields[0], origin)
 }
 
 fn require_exact_fields<'a>(
@@ -1451,6 +1537,67 @@ mod tests {
             records[1].data(),
             RData::Unknown { rr_type: 65534, data } if data == &vec![0x01, 0x02, 0x03, 0x04, 0xAB, 0xCD]
         ));
+    }
+
+    #[test]
+    fn parses_representative_rdata_families_from_inline_zone() {
+        let records = parse_str(
+            r#"
+$ORIGIN example.test.
+@ SOA ns hostmaster 1 2 3 4 5
+www A 192.0.2.1
+v6 AAAA 2001:db8::1
+alias CNAME www
+@ MX 10 mail
+_https._tcp SRV 1 2 443 svc
+@ TXT "hello" world
+@ CAA 0 issue "letsencrypt.org"
+"#,
+            &ParseOptions::default(),
+        )
+        .unwrap();
+
+        assert_eq!(
+            records
+                .iter()
+                .map(|record| record.rr_type())
+                .collect::<Vec<_>>(),
+            vec![
+                RecordType::SOA,
+                RecordType::A,
+                RecordType::AAAA,
+                RecordType::CNAME,
+                RecordType::MX,
+                RecordType::SRV,
+                RecordType::TXT,
+                RecordType::CAA,
+            ]
+        );
+        assert_eq!(txt_chunks(&records[6]), vec!["hello", "world"]);
+    }
+
+    #[test]
+    fn rejects_malformed_rdata_field_counts() {
+        for (zone, expected) in [
+            (
+                "$ORIGIN example.test.\nalias CNAME\n",
+                "CNAME record requires 1 field(s), got 0",
+            ),
+            (
+                "$ORIGIN example.test.\nalias CNAME target extra\n",
+                "CNAME record requires 1 field(s), got 2",
+            ),
+            (
+                "$ORIGIN example.test.\n_https._tcp SRV 1 2 svc\n",
+                "SRV record requires 4 field(s), got 3",
+            ),
+        ] {
+            let err = parse_str(zone, &ParseOptions::default()).unwrap_err();
+            assert!(
+                err.to_string().contains(expected),
+                "expected '{expected}' in '{err}'"
+            );
+        }
     }
 
     #[test]

--- a/src/core/rule_matcher/ip.rs
+++ b/src/core/rule_matcher/ip.rs
@@ -967,6 +967,79 @@ mod tests {
     }
 
     #[test]
+    fn test_compiled_v4_page_inline1_boundaries() {
+        let mut matcher = IpPrefixMatcher::default();
+        matcher.add_rule("10.0.0.10").unwrap();
+        matcher.finalize();
+
+        assert_v4_page_kind(&matcher, Ipv4Addr::new(10, 0, 0, 10), V4_KIND_INLINE1, 1);
+        assert!(matcher.contains_ip(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 10))));
+        assert!(!matcher.contains_ip(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 9))));
+        assert!(!matcher.contains_ip(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 11))));
+    }
+
+    #[test]
+    fn test_compiled_v4_page_inline2_boundaries() {
+        let mut matcher = IpPrefixMatcher::default();
+        matcher.add_rule("10.0.0.10").unwrap();
+        matcher.add_rule("10.0.0.20").unwrap();
+        matcher.finalize();
+
+        assert_v4_page_kind(&matcher, Ipv4Addr::new(10, 0, 0, 10), V4_KIND_INLINE2, 2);
+        assert!(matcher.contains_ip(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 10))));
+        assert!(matcher.contains_ip(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 20))));
+        assert!(!matcher.contains_ip(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 15))));
+    }
+
+    #[test]
+    fn test_compiled_v4_page_inline4_len3_and_len4_boundaries() {
+        let mut three = IpPrefixMatcher::default();
+        three.add_rule("10.0.0.10").unwrap();
+        three.add_rule("10.0.0.20").unwrap();
+        three.add_rule("10.0.0.30").unwrap();
+        three.finalize();
+
+        assert_v4_page_kind(&three, Ipv4Addr::new(10, 0, 0, 10), V4_KIND_INLINE4, 3);
+        assert!(three.contains_ip(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 30))));
+        assert!(!three.contains_ip(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 25))));
+
+        let mut four = IpPrefixMatcher::default();
+        four.add_rule("10.0.1.10").unwrap();
+        four.add_rule("10.0.1.20").unwrap();
+        four.add_rule("10.0.1.30").unwrap();
+        four.add_rule("10.0.1.40").unwrap();
+        four.finalize();
+
+        assert_v4_page_kind(&four, Ipv4Addr::new(10, 0, 1, 10), V4_KIND_INLINE4, 4);
+        assert!(four.contains_ip(IpAddr::V4(Ipv4Addr::new(10, 0, 1, 40))));
+        assert!(!four.contains_ip(IpAddr::V4(Ipv4Addr::new(10, 0, 1, 35))));
+    }
+
+    #[test]
+    fn test_compiled_v4_page_full_and_bitmap_boundaries() {
+        let mut full = IpPrefixMatcher::default();
+        full.add_rule("10.0.0.0/16").unwrap();
+        full.finalize();
+
+        assert_v4_page_kind(&full, Ipv4Addr::new(10, 0, 0, 0), V4_KIND_FULL, 0);
+        assert!(full.contains_ip(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 0))));
+        assert!(full.contains_ip(IpAddr::V4(Ipv4Addr::new(10, 0, 255, 255))));
+        assert!(!full.contains_ip(IpAddr::V4(Ipv4Addr::new(10, 1, 0, 0))));
+
+        let mut bitmap = IpPrefixMatcher::default();
+        for host in [10, 20, 30, 40, 50] {
+            bitmap
+                .add_rule(&format!("10.2.0.{host}"))
+                .expect("host rule must parse");
+        }
+        bitmap.finalize();
+
+        assert_v4_page_kind(&bitmap, Ipv4Addr::new(10, 2, 0, 10), V4_KIND_BITMAP, 0);
+        assert!(bitmap.contains_ip(IpAddr::V4(Ipv4Addr::new(10, 2, 0, 50))));
+        assert!(!bitmap.contains_ip(IpAddr::V4(Ipv4Addr::new(10, 2, 0, 45))));
+    }
+
+    #[test]
     fn test_add_v4_network_matches_textual_rule() {
         let mut bytes = IpPrefixMatcher::default();
         bytes
@@ -1012,5 +1085,18 @@ mod tests {
         assert!(matcher.v6_rules.is_empty());
         assert!(matcher.contains_ip(IpAddr::V4(Ipv4Addr::new(10, 1, 2, 3))));
         assert!(matcher.contains_ip(IpAddr::V6("2001:db8::1".parse().unwrap())));
+    }
+
+    fn assert_v4_page_kind(
+        matcher: &IpPrefixMatcher,
+        ip: Ipv4Addr,
+        expected_kind: u8,
+        expected_len: u8,
+    ) {
+        let page = (u32::from(ip) >> V4_PAGE_BITS) as usize;
+        let compiled = matcher.v4.as_ref().expect("matcher must be compiled");
+        let meta = compiled.pages[page];
+        assert_eq!(meta.kind, expected_kind);
+        assert_eq!(meta.len, expected_len);
     }
 }

--- a/src/plugin/executor/cache/api.rs
+++ b/src/plugin/executor/cache/api.rs
@@ -1,16 +1,15 @@
 // SPDX-FileCopyrightText: 2025 Sven Shi
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-use std::net::IpAddr;
 use std::sync::Arc;
 
 use async_trait::async_trait;
 use base64::Engine;
-use base64::engine::general_purpose::{STANDARD, URL_SAFE_NO_PAD};
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
 use bytes::Bytes;
 use http::{Request, StatusCode};
 use serde::{Deserialize, Serialize};
-use serde_json::{Value, json};
+use serde_json::Value;
 use tracing::{info, warn};
 
 use super::key::{CacheKey, EcsScopeDigest, normalize_domain_key};
@@ -19,7 +18,8 @@ use super::{Cache, CacheItem, CacheMap};
 use crate::api::{ApiHandler, json_error, json_ok, simple_response};
 use crate::core::app_clock::AppClock;
 use crate::core::error::Result;
-use crate::proto::{DNSClass, RData, Record, RecordType};
+use crate::plugin::executor::rdata_json::{RDataPayloadMode, rdata_payload};
+use crate::proto::{DNSClass, Record, RecordType};
 use crate::register_plugin_api;
 
 pub(super) fn register(
@@ -476,7 +476,8 @@ fn elapsed_to_unix_ms(elapsed_ms: u64, now_ms: u64, now_unix_ms: u64) -> u64 {
 }
 
 fn cache_record_json(record: &Record) -> CacheRecordJson {
-    let (payload_kind, payload_text, payload) = cache_rdata_payload(record.data());
+    let (payload_kind, payload_text, payload) =
+        rdata_payload(record.data(), RDataPayloadMode::Cache);
     CacheRecordJson {
         name: record.name().to_fqdn(),
         class: dns_class_name(record.class()),
@@ -486,129 +487,6 @@ fn cache_record_json(record: &Record) -> CacheRecordJson {
         payload_text,
         payload,
     }
-}
-
-fn cache_rdata_payload(rdata: &RData) -> (String, String, Value) {
-    match rdata {
-        RData::A(value) => ip_payload("A", IpAddr::V4(value.0)),
-        RData::AAAA(value) => ip_payload("AAAA", IpAddr::V6(value.0)),
-        RData::CNAME(value) => name_payload("CNAME", "target", &value.0),
-        RData::NS(value) => name_payload("NS", "target", &value.0),
-        RData::PTR(value) => name_payload("PTR", "target", &value.0),
-        RData::DNAME(value) => name_payload("DNAME", "target", &value.0),
-        RData::MX(value) => (
-            "MX".to_string(),
-            format!("{} {}", value.preference(), value.exchange().to_fqdn()),
-            json!({
-                "preference": value.preference(),
-                "exchange": value.exchange().to_fqdn(),
-            }),
-        ),
-        RData::SRV(value) => (
-            "SRV".to_string(),
-            format!(
-                "{} {} {} {}",
-                value.priority(),
-                value.weight(),
-                value.port(),
-                value.target().to_fqdn(),
-            ),
-            json!({
-                "priority": value.priority(),
-                "weight": value.weight(),
-                "port": value.port(),
-                "target": value.target().to_fqdn(),
-            }),
-        ),
-        RData::SOA(value) => (
-            "SOA".to_string(),
-            format!("{} {}", value.mname().to_fqdn(), value.rname().to_fqdn()),
-            json!({
-                "mname": value.mname().to_fqdn(),
-                "rname": value.rname().to_fqdn(),
-                "serial": value.serial(),
-                "refresh": value.refresh(),
-                "retry": value.retry(),
-                "expire": value.expire(),
-                "minimum": value.minimum(),
-            }),
-        ),
-        RData::TXT(value) => txt_payload("TXT", value),
-        RData::SVCB(value) => svcb_payload("SVCB", value),
-        RData::HTTPS(value) => svcb_payload("HTTPS", &value.0),
-        RData::NULL(value) => (
-            "NULL".to_string(),
-            "NULL".to_string(),
-            json!({ "data_base64": STANDARD.encode(value.data()) }),
-        ),
-        RData::Unknown { rr_type, data } => (
-            format!("TYPE{rr_type}"),
-            format!("TYPE{rr_type}"),
-            json!({
-                "unknown_rr_type": rr_type,
-                "data_base64": STANDARD.encode(data),
-            }),
-        ),
-        other => (
-            record_type_name(other.rr_type()),
-            format!("{other:?}"),
-            json!({ "display": format!("{other:?}") }),
-        ),
-    }
-}
-
-fn ip_payload(kind: &str, ip: IpAddr) -> (String, String, Value) {
-    let ip = ip.to_string();
-    (kind.to_string(), ip.clone(), json!({ "ip": ip }))
-}
-
-fn name_payload(kind: &str, field: &str, name: &crate::proto::Name) -> (String, String, Value) {
-    let target = name.to_fqdn();
-    (kind.to_string(), target.clone(), json!({ field: target }))
-}
-
-fn txt_payload(kind: &str, value: &crate::proto::TXT) -> (String, String, Value) {
-    let mut strings = Vec::new();
-    let mut parts = Vec::new();
-    let mut all_utf8 = true;
-    for part in value.txt_data() {
-        match std::str::from_utf8(part) {
-            Ok(text) => {
-                strings.push(text.to_string());
-                parts.push(json!({ "text": text }));
-            }
-            Err(_) => {
-                all_utf8 = false;
-                parts.push(json!({ "data_base64": STANDARD.encode(part) }));
-            }
-        }
-    }
-
-    let payload = if all_utf8 {
-        json!({ "strings": strings })
-    } else {
-        json!({ "parts": parts })
-    };
-
-    let payload_text = if strings.is_empty() {
-        kind.to_string()
-    } else {
-        strings.join(" ")
-    };
-
-    (kind.to_string(), payload_text, payload)
-}
-
-fn svcb_payload(kind: &str, value: &crate::proto::SVCB) -> (String, String, Value) {
-    (
-        kind.to_string(),
-        value.target().to_fqdn(),
-        json!({
-            "priority": value.priority(),
-            "target": value.target().to_fqdn(),
-            "params": value.params().len(),
-        }),
-    )
 }
 
 fn dns_class_name(class: DNSClass) -> String {

--- a/src/plugin/executor/mod.rs
+++ b/src/plugin/executor/mod.rs
@@ -61,6 +61,7 @@ pub mod nftset;
 #[cfg(feature = "plugin-query-recorder")]
 pub mod query_recorder;
 pub mod query_summary;
+#[cfg(feature = "api")]
 pub(crate) mod rdata_json;
 pub mod redirect;
 pub mod reload;

--- a/src/plugin/executor/mod.rs
+++ b/src/plugin/executor/mod.rs
@@ -61,6 +61,7 @@ pub mod nftset;
 #[cfg(feature = "plugin-query-recorder")]
 pub mod query_recorder;
 pub mod query_summary;
+pub(crate) mod rdata_json;
 pub mod redirect;
 pub mod reload;
 pub mod reload_provider;

--- a/src/plugin/executor/query_recorder/capture.rs
+++ b/src/plugin/executor/query_recorder/capture.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2025 Sven Shi
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-use std::net::{IpAddr, SocketAddr};
+use std::net::SocketAddr;
 use std::sync::Arc;
 
 use base64::Engine;
@@ -12,11 +12,9 @@ use super::model::{
     EdnsJson, EdnsOptionJson, PendingRecord, QuestionJson, RecordJson, RecordRow, StepJson,
 };
 use crate::core::context::{ExecutionPath, ExecutionPathEvent};
-use crate::proto::rdata::{
-    self, CAA, ClientSubnet, DNSKEY, DS, Edns, EdnsCode, EdnsExtendedDnsError, EdnsOption, NSEC,
-    NSEC3, NSEC3PARAM, RRSIG, SOA, SSHFP, SVCB, TLSA, TXT, URI,
-};
-use crate::proto::{DNSClass, Message, Opcode, Question, RData, Rcode, Record, RecordType};
+use crate::plugin::executor::rdata_json::{RDataPayloadMode, rdata_payload};
+use crate::proto::rdata::{ClientSubnet, Edns, EdnsCode, EdnsExtendedDnsError, EdnsOption};
+use crate::proto::{DNSClass, Message, Opcode, Question, Rcode, Record, RecordType};
 
 impl PendingRecord {
     #[allow(clippy::too_many_arguments)]
@@ -157,7 +155,8 @@ fn step_json((event_index, event): (usize, &Arc<ExecutionPathEvent>)) -> StepJso
 }
 
 fn record_json(record: &Record) -> RecordJson {
-    let (payload_kind, payload_text, payload) = rdata_payload(record.data());
+    let (payload_kind, payload_text, payload) =
+        rdata_payload(record.data(), RDataPayloadMode::Recorder);
     RecordJson {
         name: record.name().to_fqdn(),
         class: dns_class_name(record.class()),
@@ -292,325 +291,6 @@ fn extended_dns_error_json(value: &EdnsExtendedDnsError) -> Value {
     })
 }
 
-fn rdata_payload(rdata: &RData) -> (String, String, Value) {
-    match rdata {
-        RData::A(value) => ip_payload("A", IpAddr::V4(value.0)),
-        RData::AAAA(value) => ip_payload("AAAA", IpAddr::V6(value.0)),
-        RData::CNAME(value) => name_payload("CNAME", "target", &value.0),
-        RData::NS(value) => name_payload("NS", "target", &value.0),
-        RData::PTR(value) => name_payload("PTR", "target", &value.0),
-        RData::DNAME(value) => name_payload("DNAME", "target", &value.0),
-        RData::MD(value) => name_payload("MD", "target", &value.0),
-        RData::MF(value) => name_payload("MF", "target", &value.0),
-        RData::MB(value) => name_payload("MB", "target", &value.0),
-        RData::MG(value) => name_payload("MG", "target", &value.0),
-        RData::MR(value) => name_payload("MR", "target", &value.0),
-        RData::ANAME(value) => name_payload("ANAME", "target", &value.0),
-        RData::NSAPPTR(value) => name_payload("NSAPPTR", "target", &value.0),
-        RData::MX(value) => (
-            "MX".to_string(),
-            format!("{} {}", value.preference(), value.exchange().to_fqdn()),
-            json!({
-                "preference": value.preference(),
-                "exchange": value.exchange().to_fqdn(),
-            }),
-        ),
-        RData::KX(value) => (
-            "KX".to_string(),
-            format!("{} {}", value.preference(), value.exchanger().to_fqdn()),
-            json!({
-                "preference": value.preference(),
-                "exchange": value.exchanger().to_fqdn(),
-            }),
-        ),
-        RData::SRV(value) => (
-            "SRV".to_string(),
-            format!(
-                "{} {} {} {}",
-                value.priority(),
-                value.weight(),
-                value.port(),
-                value.target().to_fqdn()
-            ),
-            json!({
-                "priority": value.priority(),
-                "weight": value.weight(),
-                "port": value.port(),
-                "target": value.target().to_fqdn(),
-            }),
-        ),
-        RData::SOA(value) => soa_payload(value),
-        RData::TXT(value) => txt_payload("TXT", value),
-        RData::SPF(value) => txt_payload("SPF", &value.0),
-        RData::CAA(value) => caa_payload(value),
-        RData::URI(value) => uri_payload(value),
-        RData::SVCB(value) => svcb_payload("SVCB", value),
-        RData::HTTPS(value) => svcb_payload("HTTPS", &value.0),
-        RData::RRSIG(value) => rrsig_payload("RRSIG", value),
-        RData::SIG(value) => rrsig_payload("SIG", &value.0),
-        RData::NSEC(value) => nsec_payload(value),
-        RData::NSEC3(value) => nsec3_payload(value),
-        RData::NSEC3PARAM(value) => nsec3param_payload(value),
-        RData::DNSKEY(value) => dnskey_payload("DNSKEY", value),
-        RData::CDNSKEY(value) => dnskey_payload("CDNSKEY", &value.0),
-        RData::DS(value) => ds_payload("DS", value),
-        RData::CDS(value) => ds_payload("CDS", &value.0),
-        RData::DLV(value) => ds_payload("DLV", &value.0),
-        RData::TA(value) => ds_payload("TA", &value.0),
-        RData::TLSA(value) => tlsa_payload("TLSA", value),
-        RData::SMIMEA(value) => tlsa_payload("SMIMEA", &value.0),
-        RData::SSHFP(value) => sshfp_payload(value),
-        RData::OPENPGPKEY(value) => (
-            "OPENPGPKEY".to_string(),
-            "OPENPGPKEY".to_string(),
-            json!({ "public_key_base64": STANDARD.encode(&value.0) }),
-        ),
-        RData::NULL(value) => (
-            "NULL".to_string(),
-            "NULL".to_string(),
-            json!({ "data_base64": STANDARD.encode(value.data()) }),
-        ),
-        RData::OPT(_) => ("OPT".to_string(), "OPT".to_string(), json!({})),
-        RData::Unknown { rr_type, data } => (
-            format!("TYPE{rr_type}"),
-            format!("TYPE{rr_type}"),
-            json!({
-                "unknown_rr_type": rr_type,
-                "data_base64": STANDARD.encode(data),
-            }),
-        ),
-        other => (
-            record_type_name(other.rr_type()),
-            format!("{other:?}"),
-            json!({ "display": format!("{other:?}") }),
-        ),
-    }
-}
-
-fn ip_payload(kind: &str, ip: IpAddr) -> (String, String, Value) {
-    let ip = ip.to_string();
-    (kind.to_string(), ip.clone(), json!({ "ip": ip }))
-}
-
-fn name_payload(kind: &str, field: &str, name: &crate::proto::Name) -> (String, String, Value) {
-    let target = name.to_fqdn();
-    (kind.to_string(), target.clone(), json!({ field: target }))
-}
-
-fn soa_payload(value: &SOA) -> (String, String, Value) {
-    (
-        "SOA".to_string(),
-        format!("{} {}", value.mname().to_fqdn(), value.rname().to_fqdn()),
-        json!({
-            "mname": value.mname().to_fqdn(),
-            "rname": value.rname().to_fqdn(),
-            "serial": value.serial(),
-            "refresh": value.refresh(),
-            "retry": value.retry(),
-            "expire": value.expire(),
-            "minimum": value.minimum(),
-        }),
-    )
-}
-
-fn txt_payload(kind: &str, value: &TXT) -> (String, String, Value) {
-    let mut strings = Vec::new();
-    let mut parts = Vec::new();
-    let mut all_utf8 = true;
-    for part in value.txt_data() {
-        match std::str::from_utf8(part) {
-            Ok(text) => {
-                strings.push(text.to_string());
-                parts.push(json!({ "text": text }));
-            }
-            Err(_) => {
-                all_utf8 = false;
-                let encoded = STANDARD.encode(part);
-                parts.push(json!({ "data_base64": encoded }));
-            }
-        }
-    }
-
-    let payload = if all_utf8 {
-        json!({ "strings": strings })
-    } else {
-        json!({ "parts": parts })
-    };
-
-    let payload_text = if strings.is_empty() {
-        kind.to_string()
-    } else {
-        strings.join(" ")
-    };
-
-    (kind.to_string(), payload_text, payload)
-}
-
-fn caa_payload(value: &CAA) -> (String, String, Value) {
-    let tag = bytes_to_text_or_base64(value.tag());
-    let caa_value = bytes_to_text_or_base64(value.value());
-    (
-        "CAA".to_string(),
-        format!("{} {}", tag.text, caa_value.text),
-        json!({
-            "flag": value.flag(),
-            "tag": tag.text_value,
-            "tag_base64": tag.base64_value,
-            "value": caa_value.text_value,
-            "value_base64": caa_value.base64_value,
-        }),
-    )
-}
-
-fn uri_payload(value: &URI) -> (String, String, Value) {
-    let target = bytes_to_text_or_base64(value.target());
-    (
-        "URI".to_string(),
-        target.text.clone(),
-        json!({
-            "priority": value.priority(),
-            "weight": value.weight(),
-            "target": target.text_value,
-            "target_base64": target.base64_value,
-        }),
-    )
-}
-
-fn svcb_payload(kind: &str, value: &SVCB) -> (String, String, Value) {
-    let params = value
-        .params()
-        .iter()
-        .map(|param| {
-            json!({
-                "key": param.key(),
-                "name": svcb_param_name(param.key()),
-                "value_base64": STANDARD.encode(param.value()),
-                "parsed": svcb_param_value_json(param.parsed()),
-            })
-        })
-        .collect::<Vec<_>>();
-
-    (
-        kind.to_string(),
-        value.target().to_fqdn(),
-        json!({
-            "priority": value.priority(),
-            "target": value.target().to_fqdn(),
-            "params": params,
-        }),
-    )
-}
-
-fn rrsig_payload(kind: &str, value: &RRSIG) -> (String, String, Value) {
-    (
-        kind.to_string(),
-        value.signer_name().to_fqdn(),
-        json!({
-            "type_covered": format_record_type_from_u16(value.type_covered()),
-            "algorithm": value.algorithm(),
-            "labels": value.labels(),
-            "orig_ttl": value.orig_ttl(),
-            "expiration": value.expiration(),
-            "inception": value.inception(),
-            "key_tag": value.key_tag(),
-            "signer_name": value.signer_name().to_fqdn(),
-            "signature_base64": STANDARD.encode(value.signature()),
-        }),
-    )
-}
-
-fn nsec_payload(value: &NSEC) -> (String, String, Value) {
-    (
-        "NSEC".to_string(),
-        value.next_domain().to_fqdn(),
-        json!({
-            "next_domain": value.next_domain().to_fqdn(),
-            "type_bitmap": value.type_bitmap_types().iter().map(|ty| record_type_name(*ty)).collect::<Vec<_>>(),
-            "type_bitmap_base64": STANDARD.encode(value.type_bitmap()),
-        }),
-    )
-}
-
-fn nsec3_payload(value: &NSEC3) -> (String, String, Value) {
-    (
-        "NSEC3".to_string(),
-        "NSEC3".to_string(),
-        json!({
-            "hash": value.hash(),
-            "flags": value.flags(),
-            "iterations": value.iterations(),
-            "salt_base64": STANDARD.encode(value.salt()),
-            "next_domain_base64": STANDARD.encode(value.next_domain()),
-            "type_bitmap": value.type_bitmap_types().iter().map(|ty| record_type_name(*ty)).collect::<Vec<_>>(),
-            "type_bitmap_base64": STANDARD.encode(value.type_bitmap()),
-        }),
-    )
-}
-
-fn nsec3param_payload(value: &NSEC3PARAM) -> (String, String, Value) {
-    (
-        "NSEC3PARAM".to_string(),
-        "NSEC3PARAM".to_string(),
-        json!({
-            "hash": value.hash(),
-            "flags": value.flags(),
-            "iterations": value.iterations(),
-            "salt_base64": STANDARD.encode(value.salt()),
-        }),
-    )
-}
-
-fn dnskey_payload(kind: &str, value: &DNSKEY) -> (String, String, Value) {
-    (
-        kind.to_string(),
-        kind.to_string(),
-        json!({
-            "flags": value.flags(),
-            "protocol": value.protocol(),
-            "algorithm": value.algorithm(),
-            "public_key_base64": STANDARD.encode(value.public_key()),
-        }),
-    )
-}
-
-fn ds_payload(kind: &str, value: &DS) -> (String, String, Value) {
-    (
-        kind.to_string(),
-        kind.to_string(),
-        json!({
-            "key_tag": value.key_tag(),
-            "algorithm": value.algorithm(),
-            "digest_type": value.digest_type(),
-            "digest_base64": STANDARD.encode(value.digest()),
-        }),
-    )
-}
-
-fn tlsa_payload(kind: &str, value: &TLSA) -> (String, String, Value) {
-    (
-        kind.to_string(),
-        kind.to_string(),
-        json!({
-            "usage": value.usage(),
-            "selector": value.selector(),
-            "matching_type": value.matching_type(),
-            "certificate_base64": STANDARD.encode(value.certificate()),
-        }),
-    )
-}
-
-fn sshfp_payload(value: &SSHFP) -> (String, String, Value) {
-    (
-        "SSHFP".to_string(),
-        "SSHFP".to_string(),
-        json!({
-            "algorithm": value.algorithm(),
-            "fp_type": value.fp_type(),
-            "fingerprint_base64": STANDARD.encode(value.fingerprint()),
-        }),
-    )
-}
-
 fn utf8_or_base64_payload(field: &str, bytes: &[u8]) -> Value {
     match std::str::from_utf8(bytes) {
         Ok(text) => json!({ field: text }),
@@ -622,58 +302,6 @@ fn utf8_or_base64_payload(field: &str, bytes: &[u8]) -> Value {
             );
             Value::Object(map)
         }
-    }
-}
-
-#[derive(Debug)]
-struct TextOrBase64 {
-    text: String,
-    text_value: Option<String>,
-    base64_value: Option<String>,
-}
-
-fn bytes_to_text_or_base64(bytes: &[u8]) -> TextOrBase64 {
-    match std::str::from_utf8(bytes) {
-        Ok(text) => TextOrBase64 {
-            text: text.to_string(),
-            text_value: Some(text.to_string()),
-            base64_value: None,
-        },
-        Err(_) => {
-            let encoded = STANDARD.encode(bytes);
-            TextOrBase64 {
-                text: encoded.clone(),
-                text_value: None,
-                base64_value: Some(encoded),
-            }
-        }
-    }
-}
-
-fn svcb_param_value_json(value: &rdata::SvcParamValue) -> Value {
-    match value {
-        rdata::SvcParamValue::Mandatory(values) => json!({ "mandatory": values }),
-        rdata::SvcParamValue::Alpn(values) => json!({
-            "alpn": values
-                .iter()
-                .map(|value| std::str::from_utf8(value).ok().map(str::to_string).unwrap_or_else(|| STANDARD.encode(value)))
-                .collect::<Vec<_>>()
-        }),
-        rdata::SvcParamValue::NoDefaultAlpn => json!({ "no_default_alpn": true }),
-        rdata::SvcParamValue::Port(port) => json!({ "port": port }),
-        rdata::SvcParamValue::Ipv4Hint(values) => json!({
-            "ipv4_hint": values.iter().map(ToString::to_string).collect::<Vec<_>>()
-        }),
-        rdata::SvcParamValue::Ech(value) => json!({ "ech_base64": STANDARD.encode(value) }),
-        rdata::SvcParamValue::Ipv6Hint(values) => json!({
-            "ipv6_hint": values.iter().map(ToString::to_string).collect::<Vec<_>>()
-        }),
-        rdata::SvcParamValue::DohPath(value) => match std::str::from_utf8(value) {
-            Ok(text) => json!({ "doh_path": text }),
-            Err(_) => json!({ "doh_path_base64": STANDARD.encode(value) }),
-        },
-        rdata::SvcParamValue::Ohttp => json!({ "ohttp": true }),
-        rdata::SvcParamValue::Unknown => json!({ "unknown": true }),
     }
 }
 
@@ -694,10 +322,6 @@ fn dns_class_name(class: DNSClass) -> String {
         DNSClass::OPT(value) => format!("OPT({value})"),
         _ => class.to_string(),
     }
-}
-
-fn format_record_type_from_u16(value: u16) -> String {
-    record_type_name(RecordType::from(value))
 }
 
 fn record_type_name(record_type: RecordType) -> String {
@@ -730,20 +354,5 @@ fn edns_code_name(code: EdnsCode) -> String {
         EdnsCode::ReportChannel => "ReportChannel".to_string(),
         EdnsCode::ZoneVersion => "ZoneVersion".to_string(),
         EdnsCode::Unknown(value) => format!("Unknown({value})"),
-    }
-}
-
-fn svcb_param_name(key: u16) -> &'static str {
-    match key {
-        0 => "mandatory",
-        1 => "alpn",
-        2 => "no-default-alpn",
-        3 => "port",
-        4 => "ipv4hint",
-        5 => "ech",
-        6 => "ipv6hint",
-        7 => "dohpath",
-        8 => "ohttp",
-        _ => "unknown",
     }
 }

--- a/src/plugin/executor/query_recorder/store.rs
+++ b/src/plugin/executor/query_recorder/store.rs
@@ -26,6 +26,35 @@ use crate::core::error::{DnsError, Result};
 const SCHEMA_VERSION: &str = "v1";
 const CLEANUP_BATCH_SIZE: usize = 1_000;
 const PLUGIN_STATS_SAMPLE_LIMIT: usize = 10_000;
+const RECORD_ROW_COLUMNS: [&str; 27] = [
+    "id",
+    "created_at_ms",
+    "elapsed_ms",
+    "request_id",
+    "client_ip",
+    "questions_json",
+    "req_rd",
+    "req_cd",
+    "req_ad",
+    "req_opcode",
+    "req_edns_json",
+    "error",
+    "has_response",
+    "rcode",
+    "resp_aa",
+    "resp_tc",
+    "resp_ra",
+    "resp_ad",
+    "resp_cd",
+    "answer_count",
+    "authority_count",
+    "additional_count",
+    "answers_json",
+    "authorities_json",
+    "additionals_json",
+    "signature_json",
+    "resp_edns_json",
+];
 
 pub(super) fn open_database(path: &Path) -> rusqlite::Result<Connection> {
     let conn = Connection::open(path)?;
@@ -62,6 +91,17 @@ pub(super) fn table_names(tag: &str) -> TableNames {
         records: format!("{prefix}_records"),
         steps: format!("{prefix}_steps"),
     }
+}
+
+fn record_row_select_columns(alias: Option<&str>) -> String {
+    RECORD_ROW_COLUMNS
+        .iter()
+        .map(|column| match alias {
+            Some(alias) => format!("{alias}.{column}"),
+            None => (*column).to_string(),
+        })
+        .collect::<Vec<_>>()
+        .join(",\n            ")
 }
 
 fn sanitize_tag(tag: &str) -> String {
@@ -473,35 +513,10 @@ pub(super) fn query_records(
     let where_sql = join_clauses(&clauses);
     params.push(Value::Integer(query.limit.saturating_add(1) as i64));
 
+    let row_columns = record_row_select_columns(Some("r"));
     let sql = format!(
         "SELECT
-            r.id,
-            r.created_at_ms,
-            r.elapsed_ms,
-            r.request_id,
-            r.client_ip,
-            r.questions_json,
-            r.req_rd,
-            r.req_cd,
-            r.req_ad,
-            r.req_opcode,
-            r.req_edns_json,
-            r.error,
-            r.has_response,
-            r.rcode,
-            r.resp_aa,
-            r.resp_tc,
-            r.resp_ra,
-            r.resp_ad,
-            r.resp_cd,
-            r.answer_count,
-            r.authority_count,
-            r.additional_count,
-            r.answers_json,
-            r.authorities_json,
-            r.additionals_json,
-            r.signature_json,
-            r.resp_edns_json
+            {row_columns}
          FROM {records} r
          WHERE {where_sql}
          ORDER BY r.created_at_ms DESC, r.id DESC
@@ -539,35 +554,10 @@ pub(super) fn load_record_detail(
     record_id: i64,
 ) -> std::result::Result<Option<RecordDetail>, DnsError> {
     let conn = open_database(&backend.path)?;
+    let row_columns = record_row_select_columns(None);
     let record_sql = format!(
         "SELECT
-            id,
-            created_at_ms,
-            elapsed_ms,
-            request_id,
-            client_ip,
-            questions_json,
-            req_rd,
-            req_cd,
-            req_ad,
-            req_opcode,
-            req_edns_json,
-            error,
-            has_response,
-            rcode,
-            resp_aa,
-            resp_tc,
-            resp_ra,
-            resp_ad,
-            resp_cd,
-            answer_count,
-            authority_count,
-            additional_count,
-            answers_json,
-            authorities_json,
-            additionals_json,
-            signature_json,
-            resp_edns_json
+            {row_columns}
          FROM {records}
          WHERE id = ?1",
         records = backend.tables.records
@@ -1450,4 +1440,110 @@ fn non_negative_u16(value: i64) -> rusqlite::Result<u16> {
 
 fn non_negative_usize(value: i64) -> rusqlite::Result<usize> {
     usize::try_from(value).map_err(|_| rusqlite::Error::IntegralValueOutOfRange(0, value))
+}
+
+#[cfg(test)]
+mod tests {
+    use rusqlite::{Connection, params};
+    use serde_json::json;
+
+    use super::super::model::{EdnsJson, EdnsOptionJson, QuestionJson, RecordJson};
+    use super::*;
+
+    #[test]
+    fn test_read_record_row_matches_insert_and_select_column_order() {
+        let mut conn = Connection::open_in_memory().unwrap();
+        let tables = TableNames {
+            records: "records".to_string(),
+            steps: "steps".to_string(),
+        };
+        create_schema(&mut conn, &tables).unwrap();
+
+        let expected = sample_record_row();
+        let tx = conn.transaction().unwrap();
+        let detail = insert_record(&tx, &tables, expected.clone(), Vec::new()).unwrap();
+        tx.commit().unwrap();
+
+        let row_columns = record_row_select_columns(None);
+        let sql = format!(
+            "SELECT
+                {row_columns}
+             FROM {}
+             WHERE id = ?1",
+            tables.records
+        );
+        let actual = conn
+            .query_row(&sql, params![detail.record.id], read_record_row)
+            .unwrap();
+
+        let expected = RecordRow {
+            id: detail.record.id,
+            ..expected
+        };
+        assert_eq!(actual, expected);
+    }
+
+    fn sample_record_row() -> RecordRow {
+        let question = QuestionJson {
+            name: "example.com.".to_string(),
+            qtype: "A".to_string(),
+            qclass: "IN".to_string(),
+        };
+        let answer = RecordJson {
+            name: "example.com.".to_string(),
+            class: "IN".to_string(),
+            ttl: 300,
+            rr_type: "A".to_string(),
+            payload_kind: "A".to_string(),
+            payload_text: "192.0.2.10".to_string(),
+            payload: json!({ "ip": "192.0.2.10" }),
+        };
+        let edns = EdnsJson {
+            udp_payload_size: 1232,
+            ext_rcode: 0,
+            version: 0,
+            dnssec_ok: true,
+            z: 0,
+            options: vec![EdnsOptionJson {
+                code: 8,
+                name: "Subnet".to_string(),
+                payload_kind: "Subnet".to_string(),
+                payload: json!({
+                    "addr": "192.0.2.0",
+                    "source_prefix": 24,
+                    "scope_prefix": 0,
+                }),
+            }],
+        };
+
+        RecordRow {
+            id: 0,
+            created_at_ms: 1_700_000_000_123,
+            elapsed_ms: 37,
+            request_id: 42,
+            client_ip: "127.0.0.1".to_string(),
+            questions_json: vec![question],
+            req_rd: true,
+            req_cd: false,
+            req_ad: true,
+            req_opcode: "Query".to_string(),
+            req_edns_json: Some(edns.clone()),
+            error: None,
+            has_response: true,
+            rcode: Some("NoError".to_string()),
+            resp_aa: Some(false),
+            resp_tc: Some(false),
+            resp_ra: Some(true),
+            resp_ad: Some(false),
+            resp_cd: Some(false),
+            answer_count: 1,
+            authority_count: 0,
+            additional_count: 0,
+            answers_json: vec![answer],
+            authorities_json: Vec::new(),
+            additionals_json: Vec::new(),
+            signature_json: Vec::new(),
+            resp_edns_json: Some(edns),
+        }
+    }
 }

--- a/src/plugin/executor/rdata_json.rs
+++ b/src/plugin/executor/rdata_json.rs
@@ -1,0 +1,510 @@
+// SPDX-FileCopyrightText: 2025 Sven Shi
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+//! Shared RDATA presentation helpers for executor management APIs.
+
+use std::net::IpAddr;
+
+use base64::Engine;
+use base64::engine::general_purpose::STANDARD;
+use serde_json::{Value, json};
+
+use crate::proto::rdata::{
+    self, CAA, DNSKEY, DS, NSEC, NSEC3, NSEC3PARAM, RRSIG, SOA, SSHFP, SVCB, TLSA, TXT, URI,
+};
+use crate::proto::{Name, RData, RecordType};
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum RDataPayloadMode {
+    Cache,
+    Recorder,
+}
+
+impl RDataPayloadMode {
+    #[inline]
+    fn is_recorder(self) -> bool {
+        matches!(self, Self::Recorder)
+    }
+}
+
+type Payload = (String, String, Value);
+
+pub(crate) fn rdata_payload(rdata: &RData, mode: RDataPayloadMode) -> (String, String, Value) {
+    if let Some(payload) = shared_payload(rdata, mode) {
+        return payload;
+    }
+    if mode.is_recorder() {
+        if let Some(payload) = recorder_name_payload(rdata) {
+            return payload;
+        }
+        if let Some(payload) = recorder_metadata_payload(rdata) {
+            return payload;
+        }
+        if let Some(payload) = recorder_dnssec_payload(rdata) {
+            return payload;
+        }
+    }
+
+    fallback_payload(rdata)
+}
+
+fn shared_payload(rdata: &RData, mode: RDataPayloadMode) -> Option<Payload> {
+    match rdata {
+        RData::A(value) => ip_payload("A", IpAddr::V4(value.0)),
+        RData::AAAA(value) => ip_payload("AAAA", IpAddr::V6(value.0)),
+        RData::CNAME(value) => name_payload("CNAME", "target", &value.0),
+        RData::NS(value) => name_payload("NS", "target", &value.0),
+        RData::PTR(value) => name_payload("PTR", "target", &value.0),
+        RData::DNAME(value) => name_payload("DNAME", "target", &value.0),
+        RData::MX(value) => (
+            "MX".to_string(),
+            format!("{} {}", value.preference(), value.exchange().to_fqdn()),
+            json!({
+                "preference": value.preference(),
+                "exchange": value.exchange().to_fqdn(),
+            }),
+        ),
+        RData::SRV(value) => (
+            "SRV".to_string(),
+            format!(
+                "{} {} {} {}",
+                value.priority(),
+                value.weight(),
+                value.port(),
+                value.target().to_fqdn()
+            ),
+            json!({
+                "priority": value.priority(),
+                "weight": value.weight(),
+                "port": value.port(),
+                "target": value.target().to_fqdn(),
+            }),
+        ),
+        RData::SOA(value) => soa_payload(value),
+        RData::TXT(value) => txt_payload("TXT", value),
+        RData::SVCB(value) => svcb_payload("SVCB", value, mode),
+        RData::HTTPS(value) => svcb_payload("HTTPS", &value.0, mode),
+        RData::NULL(value) => (
+            "NULL".to_string(),
+            "NULL".to_string(),
+            json!({ "data_base64": STANDARD.encode(value.data()) }),
+        ),
+        RData::OPT(_) if matches!(mode, RDataPayloadMode::Recorder) => {
+            ("OPT".to_string(), "OPT".to_string(), json!({}))
+        }
+        RData::Unknown { rr_type, data } => (
+            format!("TYPE{rr_type}"),
+            format!("TYPE{rr_type}"),
+            json!({
+                "unknown_rr_type": rr_type,
+                "data_base64": STANDARD.encode(data),
+            }),
+        ),
+        _ => return None,
+    }
+    .into()
+}
+
+fn recorder_name_payload(rdata: &RData) -> Option<Payload> {
+    match rdata {
+        RData::MD(value) => name_payload("MD", "target", &value.0),
+        RData::MF(value) => name_payload("MF", "target", &value.0),
+        RData::MB(value) => name_payload("MB", "target", &value.0),
+        RData::MG(value) => name_payload("MG", "target", &value.0),
+        RData::MR(value) => name_payload("MR", "target", &value.0),
+        RData::ANAME(value) => name_payload("ANAME", "target", &value.0),
+        RData::NSAPPTR(value) => name_payload("NSAPPTR", "target", &value.0),
+        _ => return None,
+    }
+    .into()
+}
+
+fn recorder_metadata_payload(rdata: &RData) -> Option<Payload> {
+    match rdata {
+        RData::KX(value) => (
+            "KX".to_string(),
+            format!("{} {}", value.preference(), value.exchanger().to_fqdn()),
+            json!({
+                "preference": value.preference(),
+                "exchange": value.exchanger().to_fqdn(),
+            }),
+        ),
+        RData::SPF(value) => txt_payload("SPF", &value.0),
+        RData::CAA(value) => caa_payload(value),
+        RData::URI(value) => uri_payload(value),
+        _ => return None,
+    }
+    .into()
+}
+
+fn recorder_dnssec_payload(rdata: &RData) -> Option<Payload> {
+    if let Some(payload) = recorder_signature_payload(rdata) {
+        return Some(payload);
+    }
+    if let Some(payload) = recorder_key_payload(rdata) {
+        return Some(payload);
+    }
+    if let Some(payload) = recorder_digest_payload(rdata) {
+        return Some(payload);
+    }
+
+    match rdata {
+        RData::TLSA(value) => tlsa_payload("TLSA", value),
+        RData::SMIMEA(value) => tlsa_payload("SMIMEA", &value.0),
+        RData::SSHFP(value) => sshfp_payload(value),
+        RData::OPENPGPKEY(value) => (
+            "OPENPGPKEY".to_string(),
+            "OPENPGPKEY".to_string(),
+            json!({ "public_key_base64": STANDARD.encode(&value.0) }),
+        ),
+        _ => return None,
+    }
+    .into()
+}
+
+fn recorder_signature_payload(rdata: &RData) -> Option<Payload> {
+    match rdata {
+        RData::RRSIG(value) => rrsig_payload("RRSIG", value),
+        RData::SIG(value) => rrsig_payload("SIG", &value.0),
+        RData::NSEC(value) => nsec_payload(value),
+        RData::NSEC3(value) => nsec3_payload(value),
+        RData::NSEC3PARAM(value) => nsec3param_payload(value),
+        _ => return None,
+    }
+    .into()
+}
+
+fn recorder_key_payload(rdata: &RData) -> Option<Payload> {
+    match rdata {
+        RData::DNSKEY(value) => dnskey_payload("DNSKEY", value),
+        RData::CDNSKEY(value) => dnskey_payload("CDNSKEY", &value.0),
+        _ => return None,
+    }
+    .into()
+}
+
+fn recorder_digest_payload(rdata: &RData) -> Option<Payload> {
+    match rdata {
+        RData::DS(value) => ds_payload("DS", value),
+        RData::CDS(value) => ds_payload("CDS", &value.0),
+        RData::DLV(value) => ds_payload("DLV", &value.0),
+        RData::TA(value) => ds_payload("TA", &value.0),
+        _ => return None,
+    }
+    .into()
+}
+
+fn fallback_payload(rdata: &RData) -> Payload {
+    (
+        record_type_name(rdata.rr_type()),
+        format!("{rdata:?}"),
+        json!({ "display": format!("{rdata:?}") }),
+    )
+}
+
+fn ip_payload(kind: &str, ip: IpAddr) -> (String, String, Value) {
+    let ip = ip.to_string();
+    (kind.to_string(), ip.clone(), json!({ "ip": ip }))
+}
+
+fn name_payload(kind: &str, field: &str, name: &Name) -> (String, String, Value) {
+    let target = name.to_fqdn();
+    (kind.to_string(), target.clone(), json!({ field: target }))
+}
+
+fn soa_payload(value: &SOA) -> (String, String, Value) {
+    (
+        "SOA".to_string(),
+        format!("{} {}", value.mname().to_fqdn(), value.rname().to_fqdn()),
+        json!({
+            "mname": value.mname().to_fqdn(),
+            "rname": value.rname().to_fqdn(),
+            "serial": value.serial(),
+            "refresh": value.refresh(),
+            "retry": value.retry(),
+            "expire": value.expire(),
+            "minimum": value.minimum(),
+        }),
+    )
+}
+
+fn txt_payload(kind: &str, value: &TXT) -> (String, String, Value) {
+    let mut strings = Vec::new();
+    let mut parts = Vec::new();
+    let mut all_utf8 = true;
+    for part in value.txt_data() {
+        match std::str::from_utf8(part) {
+            Ok(text) => {
+                strings.push(text.to_string());
+                parts.push(json!({ "text": text }));
+            }
+            Err(_) => {
+                all_utf8 = false;
+                let encoded = STANDARD.encode(part);
+                parts.push(json!({ "data_base64": encoded }));
+            }
+        }
+    }
+
+    let payload = if all_utf8 {
+        json!({ "strings": strings })
+    } else {
+        json!({ "parts": parts })
+    };
+
+    let payload_text = if strings.is_empty() {
+        kind.to_string()
+    } else {
+        strings.join(" ")
+    };
+
+    (kind.to_string(), payload_text, payload)
+}
+
+fn caa_payload(value: &CAA) -> (String, String, Value) {
+    let tag = bytes_to_text_or_base64(value.tag());
+    let caa_value = bytes_to_text_or_base64(value.value());
+    (
+        "CAA".to_string(),
+        format!("{} {}", tag.text, caa_value.text),
+        json!({
+            "flag": value.flag(),
+            "tag": tag.text_value,
+            "tag_base64": tag.base64_value,
+            "value": caa_value.text_value,
+            "value_base64": caa_value.base64_value,
+        }),
+    )
+}
+
+fn uri_payload(value: &URI) -> (String, String, Value) {
+    let target = bytes_to_text_or_base64(value.target());
+    (
+        "URI".to_string(),
+        target.text.clone(),
+        json!({
+            "priority": value.priority(),
+            "weight": value.weight(),
+            "target": target.text_value,
+            "target_base64": target.base64_value,
+        }),
+    )
+}
+
+fn svcb_payload(kind: &str, value: &SVCB, mode: RDataPayloadMode) -> (String, String, Value) {
+    let params = match mode {
+        RDataPayloadMode::Cache => json!(value.params().len()),
+        RDataPayloadMode::Recorder => json!(
+            value
+                .params()
+                .iter()
+                .map(|param| {
+                    json!({
+                        "key": param.key(),
+                        "name": svcb_param_name(param.key()),
+                        "value_base64": STANDARD.encode(param.value()),
+                        "parsed": svcb_param_value_json(param.parsed()),
+                    })
+                })
+                .collect::<Vec<_>>()
+        ),
+    };
+
+    (
+        kind.to_string(),
+        value.target().to_fqdn(),
+        json!({
+            "priority": value.priority(),
+            "target": value.target().to_fqdn(),
+            "params": params,
+        }),
+    )
+}
+
+fn rrsig_payload(kind: &str, value: &RRSIG) -> (String, String, Value) {
+    (
+        kind.to_string(),
+        value.signer_name().to_fqdn(),
+        json!({
+            "type_covered": format_record_type_from_u16(value.type_covered()),
+            "algorithm": value.algorithm(),
+            "labels": value.labels(),
+            "orig_ttl": value.orig_ttl(),
+            "expiration": value.expiration(),
+            "inception": value.inception(),
+            "key_tag": value.key_tag(),
+            "signer_name": value.signer_name().to_fqdn(),
+            "signature_base64": STANDARD.encode(value.signature()),
+        }),
+    )
+}
+
+fn nsec_payload(value: &NSEC) -> (String, String, Value) {
+    (
+        "NSEC".to_string(),
+        value.next_domain().to_fqdn(),
+        json!({
+            "next_domain": value.next_domain().to_fqdn(),
+            "type_bitmap": value.type_bitmap_types().iter().map(|ty| record_type_name(*ty)).collect::<Vec<_>>(),
+            "type_bitmap_base64": STANDARD.encode(value.type_bitmap()),
+        }),
+    )
+}
+
+fn nsec3_payload(value: &NSEC3) -> (String, String, Value) {
+    (
+        "NSEC3".to_string(),
+        "NSEC3".to_string(),
+        json!({
+            "hash": value.hash(),
+            "flags": value.flags(),
+            "iterations": value.iterations(),
+            "salt_base64": STANDARD.encode(value.salt()),
+            "next_domain_base64": STANDARD.encode(value.next_domain()),
+            "type_bitmap": value.type_bitmap_types().iter().map(|ty| record_type_name(*ty)).collect::<Vec<_>>(),
+            "type_bitmap_base64": STANDARD.encode(value.type_bitmap()),
+        }),
+    )
+}
+
+fn nsec3param_payload(value: &NSEC3PARAM) -> (String, String, Value) {
+    (
+        "NSEC3PARAM".to_string(),
+        "NSEC3PARAM".to_string(),
+        json!({
+            "hash": value.hash(),
+            "flags": value.flags(),
+            "iterations": value.iterations(),
+            "salt_base64": STANDARD.encode(value.salt()),
+        }),
+    )
+}
+
+fn dnskey_payload(kind: &str, value: &DNSKEY) -> (String, String, Value) {
+    (
+        kind.to_string(),
+        kind.to_string(),
+        json!({
+            "flags": value.flags(),
+            "protocol": value.protocol(),
+            "algorithm": value.algorithm(),
+            "public_key_base64": STANDARD.encode(value.public_key()),
+        }),
+    )
+}
+
+fn ds_payload(kind: &str, value: &DS) -> (String, String, Value) {
+    (
+        kind.to_string(),
+        kind.to_string(),
+        json!({
+            "key_tag": value.key_tag(),
+            "algorithm": value.algorithm(),
+            "digest_type": value.digest_type(),
+            "digest_base64": STANDARD.encode(value.digest()),
+        }),
+    )
+}
+
+fn tlsa_payload(kind: &str, value: &TLSA) -> (String, String, Value) {
+    (
+        kind.to_string(),
+        kind.to_string(),
+        json!({
+            "usage": value.usage(),
+            "selector": value.selector(),
+            "matching_type": value.matching_type(),
+            "certificate_base64": STANDARD.encode(value.certificate()),
+        }),
+    )
+}
+
+fn sshfp_payload(value: &SSHFP) -> (String, String, Value) {
+    (
+        "SSHFP".to_string(),
+        "SSHFP".to_string(),
+        json!({
+            "algorithm": value.algorithm(),
+            "fp_type": value.fp_type(),
+            "fingerprint_base64": STANDARD.encode(value.fingerprint()),
+        }),
+    )
+}
+
+#[derive(Debug)]
+struct TextOrBase64 {
+    text: String,
+    text_value: Option<String>,
+    base64_value: Option<String>,
+}
+
+fn bytes_to_text_or_base64(bytes: &[u8]) -> TextOrBase64 {
+    match std::str::from_utf8(bytes) {
+        Ok(text) => TextOrBase64 {
+            text: text.to_string(),
+            text_value: Some(text.to_string()),
+            base64_value: None,
+        },
+        Err(_) => {
+            let encoded = STANDARD.encode(bytes);
+            TextOrBase64 {
+                text: encoded.clone(),
+                text_value: None,
+                base64_value: Some(encoded),
+            }
+        }
+    }
+}
+
+fn svcb_param_value_json(value: &rdata::SvcParamValue) -> Value {
+    match value {
+        rdata::SvcParamValue::Mandatory(values) => json!({ "mandatory": values }),
+        rdata::SvcParamValue::Alpn(values) => json!({
+            "alpn": values
+                .iter()
+                .map(|value| std::str::from_utf8(value).ok().map(str::to_string).unwrap_or_else(|| STANDARD.encode(value)))
+                .collect::<Vec<_>>()
+        }),
+        rdata::SvcParamValue::NoDefaultAlpn => json!({ "no_default_alpn": true }),
+        rdata::SvcParamValue::Port(port) => json!({ "port": port }),
+        rdata::SvcParamValue::Ipv4Hint(values) => json!({
+            "ipv4_hint": values.iter().map(ToString::to_string).collect::<Vec<_>>()
+        }),
+        rdata::SvcParamValue::Ech(value) => json!({ "ech_base64": STANDARD.encode(value) }),
+        rdata::SvcParamValue::Ipv6Hint(values) => json!({
+            "ipv6_hint": values.iter().map(ToString::to_string).collect::<Vec<_>>()
+        }),
+        rdata::SvcParamValue::DohPath(value) => match std::str::from_utf8(value) {
+            Ok(text) => json!({ "doh_path": text }),
+            Err(_) => json!({ "doh_path_base64": STANDARD.encode(value) }),
+        },
+        rdata::SvcParamValue::Ohttp => json!({ "ohttp": true }),
+        rdata::SvcParamValue::Unknown => json!({ "unknown": true }),
+    }
+}
+
+fn format_record_type_from_u16(value: u16) -> String {
+    record_type_name(RecordType::from(value))
+}
+
+fn record_type_name(record_type: RecordType) -> String {
+    match record_type {
+        RecordType::Unknown(value) => format!("TYPE{value}"),
+        _ => record_type.to_string(),
+    }
+}
+
+fn svcb_param_name(key: u16) -> &'static str {
+    match key {
+        0 => "mandatory",
+        1 => "alpn",
+        2 => "no-default-alpn",
+        3 => "port",
+        4 => "ipv4hint",
+        5 => "ech",
+        6 => "ipv6hint",
+        7 => "dohpath",
+        8 => "ohttp",
+        _ => "unknown",
+    }
+}

--- a/src/plugin/executor/sequence/chain.rs
+++ b/src/plugin/executor/sequence/chain.rs
@@ -164,13 +164,13 @@ impl ChainProgram {
     async fn run_executor_instruction(
         self: &Arc<Self>,
         context: &mut DnsContext,
-        instruction: &Instruction,
+        _instruction: &Instruction,
         executor: &Arc<dyn Executor>,
     ) -> Result<InstructionFlow> {
         record_sequence_event!(
             self,
             context,
-            instruction.node_index,
+            _instruction.node_index,
             "executor",
             Some(executor.tag()),
             "entered",
@@ -180,7 +180,7 @@ impl ChainProgram {
                 record_sequence_event!(
                     self,
                     context,
-                    instruction.node_index,
+                    _instruction.node_index,
                     "executor",
                     Some(executor.tag()),
                     "next",
@@ -191,7 +191,7 @@ impl ChainProgram {
                 record_sequence_event!(
                     self,
                     context,
-                    instruction.node_index,
+                    _instruction.node_index,
                     "executor",
                     Some(executor.tag()),
                     exec_step_outcome(step),
@@ -202,7 +202,7 @@ impl ChainProgram {
                 record_sequence_event!(
                     self,
                     context,
-                    instruction.node_index,
+                    _instruction.node_index,
                     "executor",
                     Some(executor.tag()),
                     "error",
@@ -215,14 +215,14 @@ impl ChainProgram {
     async fn run_executor_with_next_instruction(
         self: &Arc<Self>,
         context: &mut DnsContext,
-        instruction: &Instruction,
+        _instruction: &Instruction,
         executor: &Arc<dyn Executor>,
         pc: usize,
     ) -> Result<InstructionFlow> {
         record_sequence_event!(
             self,
             context,
-            instruction.node_index,
+            _instruction.node_index,
             "executor",
             Some(executor.tag()),
             "entered",
@@ -233,7 +233,7 @@ impl ChainProgram {
                 record_sequence_event!(
                     self,
                     context,
-                    instruction.node_index,
+                    _instruction.node_index,
                     "executor",
                     Some(executor.tag()),
                     exec_step_outcome(step),
@@ -244,7 +244,7 @@ impl ChainProgram {
                 record_sequence_event!(
                     self,
                     context,
-                    instruction.node_index,
+                    _instruction.node_index,
                     "executor",
                     Some(executor.tag()),
                     "error",
@@ -257,7 +257,7 @@ impl ChainProgram {
     async fn run_builtin_instruction(
         self: &Arc<Self>,
         context: &mut DnsContext,
-        instruction: &Instruction,
+        _instruction: &Instruction,
         op: &BuiltinOp,
     ) -> Result<InstructionFlow> {
         match op {
@@ -265,7 +265,7 @@ impl ChainProgram {
                 record_sequence_event!(
                     self,
                     context,
-                    instruction.node_index,
+                    _instruction.node_index,
                     "builtin",
                     Some("accept"),
                     "stop",
@@ -276,7 +276,7 @@ impl ChainProgram {
                 record_sequence_event!(
                     self,
                     context,
-                    instruction.node_index,
+                    _instruction.node_index,
                     "builtin",
                     Some("return"),
                     "return",
@@ -288,7 +288,7 @@ impl ChainProgram {
                 record_sequence_event!(
                     self,
                     context,
-                    instruction.node_index,
+                    _instruction.node_index,
                     "builtin",
                     Some("reject"),
                     "stop",
@@ -300,7 +300,7 @@ impl ChainProgram {
                     record_sequence_event!(
                         self,
                         context,
-                        instruction.node_index,
+                        _instruction.node_index,
                         "builtin",
                         Some("jump"),
                         exec_step_outcome(step),
@@ -314,7 +314,7 @@ impl ChainProgram {
                     record_sequence_event!(
                         self,
                         context,
-                        instruction.node_index,
+                        _instruction.node_index,
                         "builtin",
                         Some("jump"),
                         "error",
@@ -327,7 +327,7 @@ impl ChainProgram {
                     record_sequence_event!(
                         self,
                         context,
-                        instruction.node_index,
+                        _instruction.node_index,
                         "builtin",
                         Some("goto"),
                         exec_step_outcome(step),
@@ -338,7 +338,7 @@ impl ChainProgram {
                     record_sequence_event!(
                         self,
                         context,
-                        instruction.node_index,
+                        _instruction.node_index,
                         "builtin",
                         Some("goto"),
                         "error",
@@ -351,7 +351,7 @@ impl ChainProgram {
                 record_sequence_event!(
                     self,
                     context,
-                    instruction.node_index,
+                    _instruction.node_index,
                     "builtin",
                     Some("mark"),
                     "next",

--- a/src/plugin/executor/sequence/chain.rs
+++ b/src/plugin/executor/sequence/chain.rs
@@ -90,6 +90,12 @@ pub struct ChainProgram {
     instructions: Vec<Instruction>,
 }
 
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+enum InstructionFlow {
+    Continue,
+    Complete(ExecStep),
+}
+
 impl ChainProgram {
     fn new(_sequence_tag: String, instructions: Vec<Instruction>) -> Self {
         Self {
@@ -123,194 +129,236 @@ impl ChainProgram {
 
             match &instruction.op {
                 InstructionOp::Executor(executor) => {
-                    record_sequence_event!(
-                        self,
-                        context,
-                        instruction.node_index,
-                        "executor",
-                        Some(executor.tag()),
-                        "entered",
-                    );
-                    match executor.execute(context).await {
-                        Ok(ExecStep::Next) => {
-                            record_sequence_event!(
-                                self,
-                                context,
-                                instruction.node_index,
-                                "executor",
-                                Some(executor.tag()),
-                                "next",
-                            );
-                            pc += 1;
-                        }
-                        Ok(step @ (ExecStep::Stop | ExecStep::Return)) => {
-                            record_sequence_event!(
-                                self,
-                                context,
-                                instruction.node_index,
-                                "executor",
-                                Some(executor.tag()),
-                                exec_step_outcome(step),
-                            );
-                            return Ok(step);
-                        }
-                        Err(err) => {
-                            record_sequence_event!(
-                                self,
-                                context,
-                                instruction.node_index,
-                                "executor",
-                                Some(executor.tag()),
-                                "error",
-                            );
-                            return Err(err);
-                        }
+                    match self
+                        .run_executor_instruction(context, instruction, executor)
+                        .await?
+                    {
+                        InstructionFlow::Continue => pc += 1,
+                        InstructionFlow::Complete(step) => return Ok(step),
                     }
                 }
                 InstructionOp::ExecutorWithNext(executor) => {
-                    record_sequence_event!(
-                        self,
-                        context,
-                        instruction.node_index,
-                        "executor",
-                        Some(executor.tag()),
-                        "entered",
-                    );
-                    let next = ExecutorNext::new(self.clone(), pc + 1);
-                    return match executor.execute_with_next(context, Some(next)).await {
-                        Ok(step) => {
-                            record_sequence_event!(
-                                self,
-                                context,
-                                instruction.node_index,
-                                "executor",
-                                Some(executor.tag()),
-                                exec_step_outcome(step),
-                            );
-                            Ok(step)
-                        }
-                        Err(err) => {
-                            record_sequence_event!(
-                                self,
-                                context,
-                                instruction.node_index,
-                                "executor",
-                                Some(executor.tag()),
-                                "error",
-                            );
-                            Err(err)
-                        }
-                    };
+                    match self
+                        .run_executor_with_next_instruction(context, instruction, executor, pc)
+                        .await?
+                    {
+                        InstructionFlow::Continue => pc += 1,
+                        InstructionFlow::Complete(step) => return Ok(step),
+                    }
                 }
-                InstructionOp::Builtin(op) => match op {
-                    BuiltinOp::Accept => {
-                        record_sequence_event!(
-                            self,
-                            context,
-                            instruction.node_index,
-                            "builtin",
-                            Some("accept"),
-                            "stop",
-                        );
-                        return Ok(ExecStep::Stop);
+                InstructionOp::Builtin(op) => {
+                    match self
+                        .run_builtin_instruction(context, instruction, op)
+                        .await?
+                    {
+                        InstructionFlow::Continue => pc += 1,
+                        InstructionFlow::Complete(step) => return Ok(step),
                     }
-                    BuiltinOp::Return => {
-                        record_sequence_event!(
-                            self,
-                            context,
-                            instruction.node_index,
-                            "builtin",
-                            Some("return"),
-                            "return",
-                        );
-                        return Ok(ExecStep::Return);
-                    }
-                    BuiltinOp::Reject(rcode) => {
-                        context.set_response(context.request().response(*rcode));
-                        record_sequence_event!(
-                            self,
-                            context,
-                            instruction.node_index,
-                            "builtin",
-                            Some("reject"),
-                            "stop",
-                        );
-                        return Ok(ExecStep::Stop);
-                    }
-                    BuiltinOp::Jump(executor) => {
-                        match executor.execute_with_next(context, None).await {
-                            Ok(step) => {
-                                record_sequence_event!(
-                                    self,
-                                    context,
-                                    instruction.node_index,
-                                    "builtin",
-                                    Some("jump"),
-                                    exec_step_outcome(step),
-                                );
-                                match step {
-                                    ExecStep::Stop => return Ok(ExecStep::Stop),
-                                    ExecStep::Next | ExecStep::Return => {
-                                        pc += 1;
-                                    }
-                                }
-                            }
-                            Err(err) => {
-                                record_sequence_event!(
-                                    self,
-                                    context,
-                                    instruction.node_index,
-                                    "builtin",
-                                    Some("jump"),
-                                    "error",
-                                );
-                                return Err(err);
-                            }
-                        }
-                    }
-                    BuiltinOp::Goto(executor) => {
-                        return match executor.execute_with_next(context, None).await {
-                            Ok(step) => {
-                                record_sequence_event!(
-                                    self,
-                                    context,
-                                    instruction.node_index,
-                                    "builtin",
-                                    Some("goto"),
-                                    exec_step_outcome(step),
-                                );
-                                Ok(step)
-                            }
-                            Err(err) => {
-                                record_sequence_event!(
-                                    self,
-                                    context,
-                                    instruction.node_index,
-                                    "builtin",
-                                    Some("goto"),
-                                    "error",
-                                );
-                                Err(err)
-                            }
-                        };
-                    }
-                    BuiltinOp::Mark(marks) => {
-                        context.marks_mut().extend(marks.iter().cloned());
-                        record_sequence_event!(
-                            self,
-                            context,
-                            instruction.node_index,
-                            "builtin",
-                            Some("mark"),
-                            "next",
-                        );
-                        pc += 1;
-                    }
-                },
+                }
             }
         }
 
         Ok(ExecStep::Next)
+    }
+
+    async fn run_executor_instruction(
+        self: &Arc<Self>,
+        context: &mut DnsContext,
+        instruction: &Instruction,
+        executor: &Arc<dyn Executor>,
+    ) -> Result<InstructionFlow> {
+        record_sequence_event!(
+            self,
+            context,
+            instruction.node_index,
+            "executor",
+            Some(executor.tag()),
+            "entered",
+        );
+        match executor.execute(context).await {
+            Ok(ExecStep::Next) => {
+                record_sequence_event!(
+                    self,
+                    context,
+                    instruction.node_index,
+                    "executor",
+                    Some(executor.tag()),
+                    "next",
+                );
+                Ok(InstructionFlow::Continue)
+            }
+            Ok(step @ (ExecStep::Stop | ExecStep::Return)) => {
+                record_sequence_event!(
+                    self,
+                    context,
+                    instruction.node_index,
+                    "executor",
+                    Some(executor.tag()),
+                    exec_step_outcome(step),
+                );
+                Ok(InstructionFlow::Complete(step))
+            }
+            Err(err) => {
+                record_sequence_event!(
+                    self,
+                    context,
+                    instruction.node_index,
+                    "executor",
+                    Some(executor.tag()),
+                    "error",
+                );
+                Err(err)
+            }
+        }
+    }
+
+    async fn run_executor_with_next_instruction(
+        self: &Arc<Self>,
+        context: &mut DnsContext,
+        instruction: &Instruction,
+        executor: &Arc<dyn Executor>,
+        pc: usize,
+    ) -> Result<InstructionFlow> {
+        record_sequence_event!(
+            self,
+            context,
+            instruction.node_index,
+            "executor",
+            Some(executor.tag()),
+            "entered",
+        );
+        let next = ExecutorNext::new(self.clone(), pc + 1);
+        match executor.execute_with_next(context, Some(next)).await {
+            Ok(step) => {
+                record_sequence_event!(
+                    self,
+                    context,
+                    instruction.node_index,
+                    "executor",
+                    Some(executor.tag()),
+                    exec_step_outcome(step),
+                );
+                Ok(InstructionFlow::Complete(step))
+            }
+            Err(err) => {
+                record_sequence_event!(
+                    self,
+                    context,
+                    instruction.node_index,
+                    "executor",
+                    Some(executor.tag()),
+                    "error",
+                );
+                Err(err)
+            }
+        }
+    }
+
+    async fn run_builtin_instruction(
+        self: &Arc<Self>,
+        context: &mut DnsContext,
+        instruction: &Instruction,
+        op: &BuiltinOp,
+    ) -> Result<InstructionFlow> {
+        match op {
+            BuiltinOp::Accept => {
+                record_sequence_event!(
+                    self,
+                    context,
+                    instruction.node_index,
+                    "builtin",
+                    Some("accept"),
+                    "stop",
+                );
+                Ok(InstructionFlow::Complete(ExecStep::Stop))
+            }
+            BuiltinOp::Return => {
+                record_sequence_event!(
+                    self,
+                    context,
+                    instruction.node_index,
+                    "builtin",
+                    Some("return"),
+                    "return",
+                );
+                Ok(InstructionFlow::Complete(ExecStep::Return))
+            }
+            BuiltinOp::Reject(rcode) => {
+                context.set_response(context.request().response(*rcode));
+                record_sequence_event!(
+                    self,
+                    context,
+                    instruction.node_index,
+                    "builtin",
+                    Some("reject"),
+                    "stop",
+                );
+                Ok(InstructionFlow::Complete(ExecStep::Stop))
+            }
+            BuiltinOp::Jump(executor) => match executor.execute_with_next(context, None).await {
+                Ok(step) => {
+                    record_sequence_event!(
+                        self,
+                        context,
+                        instruction.node_index,
+                        "builtin",
+                        Some("jump"),
+                        exec_step_outcome(step),
+                    );
+                    match step {
+                        ExecStep::Stop => Ok(InstructionFlow::Complete(ExecStep::Stop)),
+                        ExecStep::Next | ExecStep::Return => Ok(InstructionFlow::Continue),
+                    }
+                }
+                Err(err) => {
+                    record_sequence_event!(
+                        self,
+                        context,
+                        instruction.node_index,
+                        "builtin",
+                        Some("jump"),
+                        "error",
+                    );
+                    Err(err)
+                }
+            },
+            BuiltinOp::Goto(executor) => match executor.execute_with_next(context, None).await {
+                Ok(step) => {
+                    record_sequence_event!(
+                        self,
+                        context,
+                        instruction.node_index,
+                        "builtin",
+                        Some("goto"),
+                        exec_step_outcome(step),
+                    );
+                    Ok(InstructionFlow::Complete(step))
+                }
+                Err(err) => {
+                    record_sequence_event!(
+                        self,
+                        context,
+                        instruction.node_index,
+                        "builtin",
+                        Some("goto"),
+                        "error",
+                    );
+                    Err(err)
+                }
+            },
+            BuiltinOp::Mark(marks) => {
+                context.marks_mut().extend(marks.iter().cloned());
+                record_sequence_event!(
+                    self,
+                    context,
+                    instruction.node_index,
+                    "builtin",
+                    Some("mark"),
+                    "next",
+                );
+                Ok(InstructionFlow::Continue)
+            }
+        }
     }
 
     fn matches_instruction(&self, context: &mut DnsContext, instruction: &Instruction) -> bool {


### PR DESCRIPTION
- Share RDATA JSON payload rendering across cache and query recorder APIs while preserving mode-specific output.
- Split sequence execution and zone RDATA parsing into smaller internal paths without intended API or wire-format changes.
- Add regression coverage for recorder row column order, malformed zone RDATA counts, representative RR parsing, and IPv4 matcher page boundaries.