### PR TITLE
fix: 400 Bad Request, message: missing Accept header

### DIFF
--- a/src/network/upstream/utils.rs
+++ b/src/network/upstream/utils.rs
@@ -224,6 +224,7 @@ pub fn build_dns_get_request(mut uri: String, buf: &[u8], version: Version) -> R
     http::Request::builder()
         .version(version)
         .header(header::CONTENT_TYPE, DNS_HEADER_VALUE)
+        .header(header::ACCEPT, DNS_HEADER_VALUE)
         .method(Method::GET)
         .uri(uri)
         .body(())


### PR DESCRIPTION
我有一个用 mosdns 启动的 doh 服务，如果用它做上游的话，就会报这个400错误

在本地验证过了，加上 accept header 解决