### PR TITLE
fix(matcher): preserve commas in domain rule files

### DIFF
--- a/src/plugin/matcher/matcher_utils.rs
+++ b/src/plugin/matcher/matcher_utils.rs
@@ -151,7 +151,7 @@ pub(crate) fn parse_domain_rules_and_set_tags(
     // - '$tag'      => provider tag
     // - '&path'     => external rule file
     let (mut inline_rules, set_tags, files) = split_rule_sources(raw_rules);
-    let file_rules = load_rules_from_files(&files, field)?;
+    let file_rules = load_rule_lines_from_files(&files, field)?;
     inline_rules.extend(file_rules);
 
     let mut domain_rules = DomainRuleMatcher::default();
@@ -300,6 +300,43 @@ pub(crate) fn load_rules_from_files(files: &[String], field: &str) -> DnsResult<
                 continue;
             }
             rules.extend(split_rule_tokens(raw));
+        }
+    }
+    Ok(rules)
+}
+
+pub(crate) fn load_rule_lines_from_files(files: &[String], field: &str) -> DnsResult<Vec<String>> {
+    let mut rules = Vec::new();
+    for path in files {
+        if path.trim().is_empty() {
+            continue;
+        }
+        let file = File::open(path).map_err(|e| {
+            DnsError::plugin(format!("failed to open {} file '{}': {}", field, path, e))
+        })?;
+        let mut reader = BufReader::new(file);
+        let mut line = String::new();
+        let mut line_no = 0usize;
+        loop {
+            line.clear();
+            let n = reader.read_line(&mut line).map_err(|e| {
+                DnsError::plugin(format!(
+                    "failed to read {} file '{}' at line {}: {}",
+                    field,
+                    path,
+                    line_no + 1,
+                    e
+                ))
+            })?;
+            if n == 0 {
+                break;
+            }
+            line_no += 1;
+            let raw = line.trim();
+            if raw.is_empty() || raw.starts_with('#') {
+                continue;
+            }
+            rules.push(raw.to_string());
         }
     }
     Ok(rules)

--- a/tests/plugin_integration.rs
+++ b/tests/plugin_integration.rs
@@ -1990,6 +1990,39 @@ plugins:
     Ok(())
 }
 
+#[tokio::test]
+async fn test_qname_matcher_loads_regex_rule_with_comma_from_file() -> Result<()> {
+    let domain_rules = test_rule_path("domain_set_1.txt");
+    let yaml = format!(
+        r#"
+log:
+  level: info
+plugins:
+  - tag: domain_match
+    type: qname
+    args:
+      - "&{domain_rules}"
+"#
+    );
+
+    let config = parse_config(&yaml)?;
+    let registry = plugin::init(config).await?;
+
+    let matcher = registry
+        .get_plugin("domain_match")
+        .expect("domain matcher should exist")
+        .to_matcher();
+
+    let mut matching_ctx = make_context(registry.clone(), "api12.service.test.");
+    assert!(matcher.is_match(&mut matching_ctx));
+
+    let mut non_matching_ctx = make_context(registry.clone(), "api123.service.test.");
+    assert!(!matcher.is_match(&mut non_matching_ctx));
+
+    registry.destroy().await;
+    Ok(())
+}
+
 #[cfg(feature = "plugin-dynamic-domain")]
 #[tokio::test]
 async fn test_dynamic_domain_set_learns_through_sequence_and_parent_domain_set() -> Result<()> {

--- a/tests/testdata/rules/domain_set_1.txt
+++ b/tests/testdata/rules/domain_set_1.txt
@@ -10,5 +10,5 @@ full:exact-only.test
 # Keyword rule.
 keyword:analytics
 
-# Regular expression rule.
-regexp:^api[0-9]+\.service\.test$
+# Regular expression rule with a comma in the quantifier.
+regexp:^api[0-9]{1,2}\.service\.test$


### PR DESCRIPTION
- Load domain matcher rule files as one rule per line so regex quantifiers like {1,2} are not split at commas.

- Keep token splitting for non-domain rule file loaders and cover the qname file path with an integration regression test.

Fixed #204 