### PR TITLE
Fix upgrade check blocks whole program

### DIFF
--- a/src/infra/network/upstream/dial.rs
+++ b/src/infra/network/upstream/dial.rs
@@ -520,21 +520,26 @@ pub(crate) async fn connect_tcp_stream(
     socks5_opt: Option<Socks5Opt>,
 ) -> Result<TcpStream> {
     if remote_ip.is_none() && socks5_opt.is_none() {
-        let mut addrs = tokio::net::lookup_host((server_name.as_str(), port))
-            .await
-            .map_err(|err| {
-                DnsError::protocol(format!(
-                    "Async DNS resolution failed for '{}': {}",
-                    server_name, err
-                ))
-            })?;
-        let addr = addrs.next().ok_or_else(|| {
-            DnsError::protocol(format!(
-                "Async DNS returned no addresses for '{}'",
-                server_name
-            ))
-        })?;
-        return connect_stream(Some(addr.ip()), server_name, port, None, None, None).await;
+        let remote_ip = {
+            let mut addrs = tokio::net::lookup_host((server_name.as_str(), port))
+                .await
+                .map_err(|err| {
+                    DnsError::protocol(format!(
+                        "Async DNS resolution failed for '{}': {}",
+                        server_name, err
+                    ))
+                })?;
+            addrs
+                .next()
+                .map(|addr| addr.ip())
+                .ok_or_else(|| {
+                    DnsError::protocol(format!(
+                        "Async DNS returned no addresses for '{}'",
+                        server_name
+                    ))
+                })?
+        };
+        return connect_stream(Some(remote_ip), server_name, port, None, None, None).await;
     }
 
     connect_stream(remote_ip, server_name, port, None, None, socks5_opt).await

--- a/src/infra/network/upstream/dial.rs
+++ b/src/infra/network/upstream/dial.rs
@@ -519,6 +519,24 @@ pub(crate) async fn connect_tcp_stream(
     port: u16,
     socks5_opt: Option<Socks5Opt>,
 ) -> Result<TcpStream> {
+    if remote_ip.is_none() && socks5_opt.is_none() {
+        let mut addrs = tokio::net::lookup_host((server_name.as_str(), port))
+            .await
+            .map_err(|err| {
+                DnsError::protocol(format!(
+                    "Async DNS resolution failed for '{}': {}",
+                    server_name, err
+                ))
+            })?;
+        let addr = addrs.next().ok_or_else(|| {
+            DnsError::protocol(format!(
+                "Async DNS returned no addresses for '{}'",
+                server_name
+            ))
+        })?;
+        return connect_stream(Some(addr.ip()), server_name, port, None, None, None).await;
+    }
+
     connect_stream(remote_ip, server_name, port, None, None, socks5_opt).await
 }
 


### PR DESCRIPTION
### 问题复现

本机 DNS 指向 127.0.0.1，oxidns 启动在 53 端口

启动之后打开 http://127.0.0.1:9199/plugins ，这时候发现插件列表加载不出来，所有操作无法进行

包括 DNS 查询

> > nslookup qq.com 127.0.0.1
;; connection timed out; no servers could be reached

多次排查发现需要等待30s，应该是某个 http 请求超时了才正常往下走逻辑

点击检查更新按钮之后会出现相同情况，怀疑是检查更新阻塞了全部逻辑

一直找到 connect_tcp_stream()，在 connect_stream 这里打印log显示耗时 11s+

### 解决

rust 代码我不在行，让 codex 找到了之后提交了异步改动。 macOS 和 windows 上实测解决
