### PR TITLE
Improve query recorder SQLite read scalability

### DIFF
--- a/docs/docs/plugin-reference/executor.mdx
+++ b/docs/docs/plugin-reference/executor.mdx
@@ -1655,6 +1655,8 @@ old-static.example.com static.example.net
     retention_days: 7
     # 定时清理周期，单位小时；最小 1
     cleanup_interval_hours: 1
+    # SQLite 读取侧最大并发数；最小 1
+    reader_concurrency: 2
 ```
 
 ### 配置项
@@ -1696,6 +1698,12 @@ old-static.example.com static.example.net
 - 最小值：`1`
 - 作用：定义过期清理任务的执行周期。
 
+#### `reader_concurrency`
+
+- 类型：`integer`；必填：否；默认值：`2`
+- 最小值：`1`
+- 作用：限制 WebUI / API 统计与历史查询同时运行的 SQLite reader 数量，避免突发读取在大库上占用过多阻塞线程和内存。
+
 ### 行为说明
 
 - 这是纯 executor 观察器，不会修改 `server` 收口逻辑。
@@ -1703,10 +1711,12 @@ old-static.example.com static.example.net
 - `next` 返回后立即提交记录；成功时记录当前 response，失败时记录 `error` 和空 response。
 - request / response 不保存 wire 数据，而是把问题区、RR、EDNS 等字段拆成 JSON 文本列。
 - `client_ip` 字段来自 OxiDNS 看到的传输层来源地址；如果前面有 systemd-resolved、dnsmasq、AdGuardHome、dae、clash 等本机转发链路，记录中可能只看到 `127.0.0.1`。
-- 每个 recorder 只使用两张表：
+- 每个 recorder 使用同一前缀下的版本化表：
   - `qr_<safe_tag>_<fnv64hex>_v1_records`
   - `qr_<safe_tag>_<fnv64hex>_v1_steps`
-- `records` 主表只保存固定字段集合；`steps` 表保存 `sequence` 路径事件，用于执行路径分析和命中率统计。
+  - `qr_<safe_tag>_<fnv64hex>_v1_questions`
+  - `qr_<safe_tag>_<fnv64hex>_v1_meta`
+- `records` 主表只保存固定字段集合；`steps` 表保存 `sequence` 路径事件，用于执行路径分析和命中率统计；`questions` 表是从 `questions_json` 派生的索引表，用于加速 qname/qtype 查询；`meta` 表记录已完成的派生表迁移。
 - 每个 recorder 独占自己的有界队列、SQLite 连接、后台写线程、内存 tail 和 SSE 广播器。
 - 默认假定不同 recorder 使用不同 `path`；v1 不做跨 recorder 写线程复用或路径协调。
 

--- a/docs/i18n/en/docusaurus-plugin-content-docs/current/plugin-reference/executor.mdx
+++ b/docs/i18n/en/docusaurus-plugin-content-docs/current/plugin-reference/executor.mdx
@@ -1576,6 +1576,8 @@ Persists the entry request, the post-`next` response, and `sequence` execution-p
     retention_days: 7
     # Cleanup interval in hours; minimum 1
     cleanup_interval_hours: 1
+    # Maximum concurrent SQLite readers; minimum 1
+    reader_concurrency: 2
 ```
 
 ### Configuration Details
@@ -1615,6 +1617,11 @@ Persists the entry request, the post-`next` response, and `sequence` execution-p
 - Type: `integer`; Required: no; Default: `1`; Minimum: `1`
 - Purpose: Cleanup task cadence.
 
+#### `reader_concurrency`
+
+- Type: `integer`; Required: no; Default: `2`; Minimum: `1`
+- Purpose: Limits concurrent SQLite readers used by WebUI / API history and stats queries, so read bursts on large recorder databases do not occupy too many blocking threads or too much memory.
+
 ### Behavior
 
 - This is a pure executor observer and does not change server finalization logic.
@@ -1622,10 +1629,12 @@ Persists the entry request, the post-`next` response, and `sequence` execution-p
 - Successful runs store the current response. Failed runs store `error` and an empty response shape.
 - Request and response payloads are not stored as wire blobs. Question, RR, and EDNS fields are extracted into JSON text columns.
 - The `client_ip` field comes from the transport source address seen by OxiDNS; if a local forwarding chain such as systemd-resolved, dnsmasq, AdGuardHome, dae, or clash sits in front, rows may show only `127.0.0.1`.
-- Each recorder uses exactly two tables:
+- Each recorder uses versioned tables under the same prefix:
   - `qr_<safe_tag>_<fnv64hex>_v1_records`
   - `qr_<safe_tag>_<fnv64hex>_v1_steps`
-- `records` contains only the fixed schema fields for structured snapshots. `steps` stores `sequence` path events for path analysis and hit-rate reporting.
+  - `qr_<safe_tag>_<fnv64hex>_v1_questions`
+  - `qr_<safe_tag>_<fnv64hex>_v1_meta`
+- `records` contains only the fixed schema fields for structured snapshots. `steps` stores `sequence` path events for path analysis and hit-rate reporting. `questions` is a derived index table from `questions_json` for faster qname/qtype queries. `meta` records completed derived-table migrations.
 - Every recorder owns its own bounded queue, SQLite connection, writer thread, tail buffer, and SSE broadcaster.
 - v1 assumes different recorders use different `path` values. There is no cross-recorder writer sharing or path coordination.
 

--- a/src/plugin/executor/query_recorder/api.rs
+++ b/src/plugin/executor/query_recorder/api.rs
@@ -23,7 +23,7 @@ use super::store::{
     load_record_detail, load_timeseries, load_top_clients, load_top_qnames, query_records,
 };
 use crate::api::{ApiHandler, json_error, json_ok, simple_response, streaming_response};
-use crate::infra::error::Result;
+use crate::infra::error::{DnsError, Result};
 use crate::register_plugin_api;
 
 const DEFAULT_LIST_LIMIT: usize = 100;
@@ -116,6 +116,28 @@ struct TimeseriesHandler {
     backend: Arc<RecorderBackend>,
 }
 
+async fn run_reader_query<T, F>(
+    backend: Arc<RecorderBackend>,
+    op: F,
+) -> std::result::Result<T, DnsError>
+where
+    T: Send + 'static,
+    F: FnOnce(Arc<RecorderBackend>) -> std::result::Result<T, DnsError> + Send + 'static,
+{
+    let permit = backend
+        .reader_semaphore
+        .clone()
+        .acquire_owned()
+        .await
+        .map_err(|err| DnsError::runtime(format!("query_recorder reader closed: {err}")))?;
+    tokio::task::spawn_blocking(move || {
+        let _permit = permit;
+        op(backend)
+    })
+    .await
+    .map_err(|err| DnsError::runtime(format!("blocking task failed: {err}")))?
+}
+
 #[async_trait]
 impl ApiHandler for RecordsListHandler {
     async fn handle(&self, request: Request<Bytes>) -> crate::api::ApiResponse {
@@ -125,8 +147,8 @@ impl ApiHandler for RecordsListHandler {
         };
 
         let backend = self.backend.clone();
-        match tokio::task::spawn_blocking(move || query_records(backend, query)).await {
-            Ok(Ok((records, next_cursor))) => json_ok(
+        match run_reader_query(backend, move |backend| query_records(backend, query)).await {
+            Ok((records, next_cursor)) => json_ok(
                 StatusCode::OK,
                 &RecordListResponse {
                     ok: true,
@@ -134,15 +156,10 @@ impl ApiHandler for RecordsListHandler {
                     records,
                 },
             ),
-            Ok(Err(err)) => json_error(
-                StatusCode::INTERNAL_SERVER_ERROR,
-                "query_recorder_records_failed",
-                err.to_string(),
-            ),
             Err(err) => json_error(
                 StatusCode::INTERNAL_SERVER_ERROR,
                 "query_recorder_records_failed",
-                format!("blocking task failed: {err}"),
+                err.to_string(),
             ),
         }
     }
@@ -173,24 +190,21 @@ impl ApiHandler for RecordDetailHandler {
         };
 
         let backend = self.backend.clone();
-        match tokio::task::spawn_blocking(move || load_record_detail(backend, record_id)).await {
-            Ok(Ok(Some(record))) => {
-                json_ok(StatusCode::OK, &RecordDetailResponse { ok: true, record })
-            }
-            Ok(Ok(None)) => json_error(
+        match run_reader_query(backend, move |backend| {
+            load_record_detail(backend, record_id)
+        })
+        .await
+        {
+            Ok(Some(record)) => json_ok(StatusCode::OK, &RecordDetailResponse { ok: true, record }),
+            Ok(None) => json_error(
                 StatusCode::NOT_FOUND,
                 "record_not_found",
                 format!("record {} does not exist", record_id),
             ),
-            Ok(Err(err)) => json_error(
-                StatusCode::INTERNAL_SERVER_ERROR,
-                "query_recorder_record_failed",
-                err.to_string(),
-            ),
             Err(err) => json_error(
                 StatusCode::INTERNAL_SERVER_ERROR,
                 "query_recorder_record_failed",
-                format!("blocking task failed: {err}"),
+                err.to_string(),
             ),
         }
     }
@@ -230,8 +244,8 @@ impl ApiHandler for StatsPluginsHandler {
             Err(err) => return json_error(StatusCode::BAD_REQUEST, "invalid_query", err),
         };
         let backend = self.backend.clone();
-        match tokio::task::spawn_blocking(move || load_plugin_stats(backend, query)).await {
-            Ok(Ok((query_total, stats))) => json_ok(
+        match run_reader_query(backend, move |backend| load_plugin_stats(backend, query)).await {
+            Ok((query_total, stats)) => json_ok(
                 StatusCode::OK,
                 &PluginStatsResponse {
                     ok: true,
@@ -239,15 +253,10 @@ impl ApiHandler for StatsPluginsHandler {
                     stats,
                 },
             ),
-            Ok(Err(err)) => json_error(
-                StatusCode::INTERNAL_SERVER_ERROR,
-                "query_recorder_stats_failed",
-                err.to_string(),
-            ),
             Err(err) => json_error(
                 StatusCode::INTERNAL_SERVER_ERROR,
                 "query_recorder_stats_failed",
-                format!("blocking task failed: {err}"),
+                err.to_string(),
             ),
         }
     }
@@ -342,17 +351,12 @@ impl ApiHandler for TopClientsHandler {
             Err(err) => return json_error(StatusCode::BAD_REQUEST, "invalid_query", err),
         };
         let backend = self.backend.clone();
-        match tokio::task::spawn_blocking(move || load_top_clients(backend, query)).await {
-            Ok(Ok(response)) => json_ok(StatusCode::OK, &response),
-            Ok(Err(err)) => json_error(
-                StatusCode::INTERNAL_SERVER_ERROR,
-                "query_recorder_top_clients_failed",
-                err.to_string(),
-            ),
+        match run_reader_query(backend, move |backend| load_top_clients(backend, query)).await {
+            Ok(response) => json_ok(StatusCode::OK, &response),
             Err(err) => json_error(
                 StatusCode::INTERNAL_SERVER_ERROR,
                 "query_recorder_top_clients_failed",
-                format!("blocking task failed: {err}"),
+                err.to_string(),
             ),
         }
     }
@@ -366,17 +370,12 @@ impl ApiHandler for TopQnamesHandler {
             Err(err) => return json_error(StatusCode::BAD_REQUEST, "invalid_query", err),
         };
         let backend = self.backend.clone();
-        match tokio::task::spawn_blocking(move || load_top_qnames(backend, query)).await {
-            Ok(Ok(response)) => json_ok(StatusCode::OK, &response),
-            Ok(Err(err)) => json_error(
-                StatusCode::INTERNAL_SERVER_ERROR,
-                "query_recorder_top_qnames_failed",
-                err.to_string(),
-            ),
+        match run_reader_query(backend, move |backend| load_top_qnames(backend, query)).await {
+            Ok(response) => json_ok(StatusCode::OK, &response),
             Err(err) => json_error(
                 StatusCode::INTERNAL_SERVER_ERROR,
                 "query_recorder_top_qnames_failed",
-                format!("blocking task failed: {err}"),
+                err.to_string(),
             ),
         }
     }
@@ -390,17 +389,16 @@ impl ApiHandler for QtypeDistributionHandler {
             Err(err) => return json_error(StatusCode::BAD_REQUEST, "invalid_query", err),
         };
         let backend = self.backend.clone();
-        match tokio::task::spawn_blocking(move || load_qtype_distribution(backend, query)).await {
-            Ok(Ok(response)) => json_ok(StatusCode::OK, &response),
-            Ok(Err(err)) => json_error(
-                StatusCode::INTERNAL_SERVER_ERROR,
-                "query_recorder_qtype_failed",
-                err.to_string(),
-            ),
+        match run_reader_query(backend, move |backend| {
+            load_qtype_distribution(backend, query)
+        })
+        .await
+        {
+            Ok(response) => json_ok(StatusCode::OK, &response),
             Err(err) => json_error(
                 StatusCode::INTERNAL_SERVER_ERROR,
                 "query_recorder_qtype_failed",
-                format!("blocking task failed: {err}"),
+                err.to_string(),
             ),
         }
     }
@@ -414,17 +412,16 @@ impl ApiHandler for RcodeDistributionHandler {
             Err(err) => return json_error(StatusCode::BAD_REQUEST, "invalid_query", err),
         };
         let backend = self.backend.clone();
-        match tokio::task::spawn_blocking(move || load_rcode_distribution(backend, query)).await {
-            Ok(Ok(response)) => json_ok(StatusCode::OK, &response),
-            Ok(Err(err)) => json_error(
-                StatusCode::INTERNAL_SERVER_ERROR,
-                "query_recorder_rcode_failed",
-                err.to_string(),
-            ),
+        match run_reader_query(backend, move |backend| {
+            load_rcode_distribution(backend, query)
+        })
+        .await
+        {
+            Ok(response) => json_ok(StatusCode::OK, &response),
             Err(err) => json_error(
                 StatusCode::INTERNAL_SERVER_ERROR,
                 "query_recorder_rcode_failed",
-                format!("blocking task failed: {err}"),
+                err.to_string(),
             ),
         }
     }
@@ -438,17 +435,12 @@ impl ApiHandler for LatencyHandler {
             Err(err) => return json_error(StatusCode::BAD_REQUEST, "invalid_query", err),
         };
         let backend = self.backend.clone();
-        match tokio::task::spawn_blocking(move || load_latency_summary(backend, query)).await {
-            Ok(Ok(response)) => json_ok(StatusCode::OK, &response),
-            Ok(Err(err)) => json_error(
-                StatusCode::INTERNAL_SERVER_ERROR,
-                "query_recorder_latency_failed",
-                err.to_string(),
-            ),
+        match run_reader_query(backend, move |backend| load_latency_summary(backend, query)).await {
+            Ok(response) => json_ok(StatusCode::OK, &response),
             Err(err) => json_error(
                 StatusCode::INTERNAL_SERVER_ERROR,
                 "query_recorder_latency_failed",
-                format!("blocking task failed: {err}"),
+                err.to_string(),
             ),
         }
     }
@@ -462,17 +454,12 @@ impl ApiHandler for TimeseriesHandler {
             Err(err) => return json_error(StatusCode::BAD_REQUEST, "invalid_query", err),
         };
         let backend = self.backend.clone();
-        match tokio::task::spawn_blocking(move || load_timeseries(backend, query)).await {
-            Ok(Ok(response)) => json_ok(StatusCode::OK, &response),
-            Ok(Err(err)) => json_error(
-                StatusCode::INTERNAL_SERVER_ERROR,
-                "query_recorder_timeseries_failed",
-                err.to_string(),
-            ),
+        match run_reader_query(backend, move |backend| load_timeseries(backend, query)).await {
+            Ok(response) => json_ok(StatusCode::OK, &response),
             Err(err) => json_error(
                 StatusCode::INTERNAL_SERVER_ERROR,
                 "query_recorder_timeseries_failed",
-                format!("blocking task failed: {err}"),
+                err.to_string(),
             ),
         }
     }

--- a/src/plugin/executor/query_recorder/backend.rs
+++ b/src/plugin/executor/query_recorder/backend.rs
@@ -9,11 +9,11 @@ use std::sync::{Arc, Mutex};
 use std::thread::{self, JoinHandle};
 use std::time::Duration;
 
-use tokio::sync::broadcast;
+use tokio::sync::{Semaphore, broadcast};
 use tracing::{error, warn};
 
 use super::model::{PendingRecord, RecordDetail, ResolvedRecorderConfig, TableNames};
-use super::store::{create_schema, open_database, run_writer_thread, table_names};
+use super::store::{create_schema, open_writer_database, run_writer_thread, table_names};
 use crate::infra::error::{DnsError, Result};
 
 #[derive(Debug)]
@@ -28,6 +28,7 @@ pub(super) struct RecorderBackend {
     pub(super) memory_tail: usize,
     pub(super) broadcaster: broadcast::Sender<RecordDetail>,
     pub(super) dropped_total: Arc<AtomicU64>,
+    pub(super) reader_semaphore: Arc<Semaphore>,
 }
 
 #[derive(Debug, Clone)]
@@ -79,7 +80,7 @@ impl RecorderBackend {
             })?;
         }
 
-        let mut conn = open_database(&config.path).map_err(|err| {
+        let mut conn = open_writer_database(&config.path).map_err(|err| {
             format!(
                 "failed to open database '{}': {}",
                 config.path.display(),
@@ -103,6 +104,7 @@ impl RecorderBackend {
         )));
         let (broadcaster, _) = broadcast::channel(config.memory_tail.max(16));
         let dropped_total = Arc::new(AtomicU64::new(0));
+        let reader_semaphore = Arc::new(Semaphore::new(config.reader_concurrency));
 
         let writer_tables = tables.clone();
         let writer_stop = stop_requested.clone();
@@ -142,6 +144,7 @@ impl RecorderBackend {
             memory_tail,
             broadcaster,
             dropped_total,
+            reader_semaphore,
         }))
     }
 

--- a/src/plugin/executor/query_recorder/mod.rs
+++ b/src/plugin/executor/query_recorder/mod.rs
@@ -50,6 +50,7 @@ const DEFAULT_FLUSH_INTERVAL_MS: u64 = 200;
 const DEFAULT_MEMORY_TAIL: usize = 1_024;
 const DEFAULT_RETENTION_DAYS: u64 = 7;
 const DEFAULT_CLEANUP_INTERVAL_HOURS: u64 = 1;
+const DEFAULT_READER_CONCURRENCY: usize = 2;
 const ONE_DAY_MS: u64 = 24 * 60 * 60 * 1000;
 
 #[derive(Debug)]
@@ -183,6 +184,9 @@ fn resolve_config(args: Option<YamlValue>) -> Result<ResolvedRecorderConfig> {
     let cleanup_interval_hours = parsed
         .cleanup_interval_hours
         .unwrap_or(DEFAULT_CLEANUP_INTERVAL_HOURS);
+    let reader_concurrency = parsed
+        .reader_concurrency
+        .unwrap_or(DEFAULT_READER_CONCURRENCY);
 
     if queue_size == 0 {
         return Err(DnsError::plugin(
@@ -214,6 +218,11 @@ fn resolve_config(args: Option<YamlValue>) -> Result<ResolvedRecorderConfig> {
             "query_recorder cleanup_interval_hours must be at least 1",
         ));
     }
+    if reader_concurrency == 0 {
+        return Err(DnsError::plugin(
+            "query_recorder reader_concurrency must be greater than 0",
+        ));
+    }
 
     Ok(ResolvedRecorderConfig {
         path: PathBuf::from(path),
@@ -223,6 +232,7 @@ fn resolve_config(args: Option<YamlValue>) -> Result<ResolvedRecorderConfig> {
         memory_tail,
         retention_days,
         cleanup_interval_hours,
+        reader_concurrency,
     })
 }
 

--- a/src/plugin/executor/query_recorder/model.rs
+++ b/src/plugin/executor/query_recorder/model.rs
@@ -18,6 +18,7 @@ pub(super) struct QueryRecorderConfig {
     pub(super) memory_tail: Option<usize>,
     pub(super) retention_days: Option<u64>,
     pub(super) cleanup_interval_hours: Option<u64>,
+    pub(super) reader_concurrency: Option<usize>,
 }
 
 #[derive(Debug, Clone)]
@@ -29,6 +30,7 @@ pub(super) struct ResolvedRecorderConfig {
     pub(super) memory_tail: usize,
     pub(super) retention_days: u64,
     pub(super) cleanup_interval_hours: u64,
+    pub(super) reader_concurrency: usize,
 }
 
 #[derive(Debug, Clone)]

--- a/src/plugin/executor/query_recorder/model.rs
+++ b/src/plugin/executor/query_recorder/model.rs
@@ -37,6 +37,7 @@ pub(super) struct ResolvedRecorderConfig {
 pub(super) struct TableNames {
     pub(super) records: String,
     pub(super) steps: String,
+    pub(super) questions: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]

--- a/src/plugin/executor/query_recorder/model.rs
+++ b/src/plugin/executor/query_recorder/model.rs
@@ -38,6 +38,7 @@ pub(super) struct TableNames {
     pub(super) records: String,
     pub(super) steps: String,
     pub(super) questions: String,
+    pub(super) meta: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]

--- a/src/plugin/executor/query_recorder/store.rs
+++ b/src/plugin/executor/query_recorder/store.rs
@@ -56,29 +56,40 @@ const RECORD_ROW_COLUMNS: [&str; 27] = [
     "resp_edns_json",
 ];
 
-pub(super) fn open_database(path: &Path) -> rusqlite::Result<Connection> {
+pub(super) fn open_writer_database(path: &Path) -> rusqlite::Result<Connection> {
     let conn = Connection::open(path)?;
-    // Tuned for a workload of "one writer + bursty readers".
+    // Tuned for the dedicated writer thread. Keep WAL and incremental vacuum
+    // behavior, but avoid giving the single writer the same large read cache
+    // and mmap footprint that used to be applied to every reader.
     // - auto_vacuum must be selected before WAL or schema creation for a fresh
     //   database; otherwise SQLite keeps the default NONE mode until a manual
     //   VACUUM rewrites the file.
-    // - WAL + synchronous=NORMAL is the standard high-throughput combo for the
-    //   writer thread and keeps readers non-blocking.
-    // - temp_store=MEMORY keeps the implicit temp tables that GROUP BY / ORDER BY /
-    //   DISTINCT create off the disk on every aggregation query.
-    // - cache_size=-32768 = 32 MiB per connection (negative means KiB). The stats
-    //   endpoints repeatedly hit the same recent rows, so the cache amortizes
-    //   cleanly across read connections.
-    // - mmap_size lets SQLite memory-map the DB pages, which is a noticeable
-    //   speedup for read-heavy SELECTs once the OS page cache is warm.
+    // - WAL + synchronous=NORMAL keeps the writer fast and readers non-blocking.
     conn.execute_batch(
         "PRAGMA auto_vacuum=INCREMENTAL;
          PRAGMA journal_mode=WAL;
          PRAGMA synchronous=NORMAL;
          PRAGMA foreign_keys=ON;
-         PRAGMA temp_store=MEMORY;
-         PRAGMA cache_size=-32768;
-         PRAGMA mmap_size=134217728;",
+         PRAGMA temp_store=DEFAULT;
+         PRAGMA cache_size=-4096;
+         PRAGMA mmap_size=0;",
+    )?;
+    Ok(conn)
+}
+
+pub(super) fn open_reader_database(path: &Path) -> rusqlite::Result<Connection> {
+    let conn = Connection::open(path)?;
+    // Reader connections back WebUI list/stat/detail endpoints. They should
+    // not reserve a large per-connection cache or mmap window, because several
+    // dashboard requests can run at once against a large recorder database.
+    conn.execute_batch(
+        "PRAGMA journal_mode=WAL;
+         PRAGMA synchronous=NORMAL;
+         PRAGMA foreign_keys=ON;
+         PRAGMA query_only=ON;
+         PRAGMA temp_store=FILE;
+         PRAGMA cache_size=-4096;
+         PRAGMA mmap_size=0;",
     )?;
     Ok(conn)
 }
@@ -496,7 +507,7 @@ pub(super) fn query_records(
     backend: Arc<RecorderBackend>,
     query: ListQuery,
 ) -> std::result::Result<(Vec<RecordRow>, Option<String>), DnsError> {
-    let conn = open_database(&backend.path)?;
+    let conn = open_reader_database(&backend.path)?;
     let (mut clauses, mut params) = record_filter_clauses(
         "r",
         &backend.tables,
@@ -553,7 +564,7 @@ pub(super) fn load_record_detail(
     backend: Arc<RecorderBackend>,
     record_id: i64,
 ) -> std::result::Result<Option<RecordDetail>, DnsError> {
-    let conn = open_database(&backend.path)?;
+    let conn = open_reader_database(&backend.path)?;
     let row_columns = record_row_select_columns(None);
     let record_sql = format!(
         "SELECT
@@ -614,7 +625,7 @@ pub(super) fn load_plugin_stats(
     backend: Arc<RecorderBackend>,
     query: PluginsStatsQuery,
 ) -> std::result::Result<(u64, Vec<PluginStatsRow>), DnsError> {
-    let conn = open_database(&backend.path)?;
+    let conn = open_reader_database(&backend.path)?;
     let (clauses, mut params) = record_filter_clauses(
         "r",
         &backend.tables,
@@ -724,7 +735,7 @@ pub(super) fn load_top_clients(
     backend: Arc<RecorderBackend>,
     query: TopQuery,
 ) -> std::result::Result<TopBucketsResponse, DnsError> {
-    let conn = open_database(&backend.path)?;
+    let conn = open_reader_database(&backend.path)?;
     let (clauses, mut params) = record_filter_clauses(
         "r",
         &backend.tables,
@@ -784,7 +795,7 @@ pub(super) fn load_top_qnames(
     backend: Arc<RecorderBackend>,
     query: TopQuery,
 ) -> std::result::Result<TopBucketsResponse, DnsError> {
-    let conn = open_database(&backend.path)?;
+    let conn = open_reader_database(&backend.path)?;
     let (clauses, mut params) = record_filter_clauses(
         "r",
         &backend.tables,
@@ -848,7 +859,7 @@ pub(super) fn load_qtype_distribution(
     backend: Arc<RecorderBackend>,
     query: DistributionQuery,
 ) -> std::result::Result<DistributionResponse, DnsError> {
-    let conn = open_database(&backend.path)?;
+    let conn = open_reader_database(&backend.path)?;
     let (clauses, mut params) = record_filter_clauses(
         "r",
         &backend.tables,
@@ -910,7 +921,7 @@ pub(super) fn load_rcode_distribution(
     backend: Arc<RecorderBackend>,
     query: DistributionQuery,
 ) -> std::result::Result<DistributionResponse, DnsError> {
-    let conn = open_database(&backend.path)?;
+    let conn = open_reader_database(&backend.path)?;
     let (clauses, mut params) = record_filter_clauses(
         "r",
         &backend.tables,
@@ -976,7 +987,7 @@ pub(super) fn load_latency_summary(
     backend: Arc<RecorderBackend>,
     query: LatencyQuery,
 ) -> std::result::Result<LatencySummary, DnsError> {
-    let conn = open_database(&backend.path)?;
+    let conn = open_reader_database(&backend.path)?;
     let (clauses, mut params) = record_filter_clauses(
         "r",
         &backend.tables,
@@ -1075,7 +1086,7 @@ pub(super) fn load_timeseries(
     backend: Arc<RecorderBackend>,
     query: TimeseriesQuery,
 ) -> std::result::Result<TimeseriesResponse, DnsError> {
-    let conn = open_database(&backend.path)?;
+    let conn = open_reader_database(&backend.path)?;
     let (clauses, mut params) = record_filter_clauses(
         "r",
         &backend.tables,

--- a/src/plugin/executor/query_recorder/store.rs
+++ b/src/plugin/executor/query_recorder/store.rs
@@ -101,6 +101,7 @@ pub(super) fn table_names(tag: &str) -> TableNames {
     TableNames {
         records: format!("{prefix}_records"),
         steps: format!("{prefix}_steps"),
+        questions: format!("{prefix}_questions"),
     }
 }
 
@@ -182,10 +183,22 @@ pub(crate) fn create_schema(conn: &mut Connection, tables: &TableNames) -> rusql
             PRIMARY KEY (record_id, event_index),
             FOREIGN KEY(record_id) REFERENCES {records}(id) ON DELETE CASCADE
         );
+        CREATE TABLE IF NOT EXISTS {questions} (
+            record_id INTEGER NOT NULL,
+            question_index INTEGER NOT NULL,
+            name_lc TEXT NOT NULL,
+            qtype TEXT NOT NULL,
+            qclass TEXT NOT NULL,
+            PRIMARY KEY (record_id, question_index),
+            FOREIGN KEY(record_id) REFERENCES {records}(id) ON DELETE CASCADE
+        );
         CREATE INDEX IF NOT EXISTS {records}_created_at_idx ON {records}(created_at_ms DESC);
         CREATE INDEX IF NOT EXISTS {records}_request_id_idx ON {records}(request_id);
         CREATE INDEX IF NOT EXISTS {records}_client_ip_idx ON {records}(client_ip);
         CREATE INDEX IF NOT EXISTS {records}_rcode_idx ON {records}(rcode);
+        CREATE INDEX IF NOT EXISTS {questions}_record_id_idx ON {questions}(record_id);
+        CREATE INDEX IF NOT EXISTS {questions}_name_idx ON {questions}(name_lc, record_id);
+        CREATE INDEX IF NOT EXISTS {questions}_qtype_idx ON {questions}(qtype, record_id);
         CREATE INDEX IF NOT EXISTS {steps}_kind_tag_outcome_idx ON {steps}(kind, tag, outcome);
         CREATE INDEX IF NOT EXISTS {steps}_record_id_idx ON {steps}(record_id);
         -- Covering index for the matcher_tag EXISTS subquery used by /records
@@ -202,8 +215,48 @@ pub(crate) fn create_schema(conn: &mut Connection, tables: &TableNames) -> rusql
         CREATE INDEX IF NOT EXISTS {steps}_record_kind_idx
             ON {steps}(record_id, kind);",
         records = tables.records,
+        questions = tables.questions,
         steps = tables.steps,
-    ))
+    ))?;
+    backfill_questions(conn, tables)
+}
+
+fn backfill_questions(conn: &Connection, tables: &TableNames) -> rusqlite::Result<()> {
+    conn.execute(
+        &format!(
+            "WITH missing_records AS (
+                SELECT r.id, r.questions_json
+                FROM {records} r
+                WHERE NOT EXISTS (
+                    SELECT 1
+                    FROM {questions} existing
+                    WHERE existing.record_id = r.id
+                )
+             )
+             INSERT OR IGNORE INTO {questions} (
+                record_id,
+                question_index,
+                name_lc,
+                qtype,
+                qclass
+             )
+             SELECT
+                missing_records.id,
+                CAST(q.key AS INTEGER),
+                LOWER(json_extract(q.value, '$.name')),
+                UPPER(json_extract(q.value, '$.qtype')),
+                json_extract(q.value, '$.qclass')
+             FROM missing_records
+             JOIN json_each(missing_records.questions_json) AS q
+             WHERE json_extract(q.value, '$.name') IS NOT NULL
+               AND json_extract(q.value, '$.qtype') IS NOT NULL
+               AND json_extract(q.value, '$.qclass') IS NOT NULL",
+            records = tables.records,
+            questions = tables.questions,
+        ),
+        [],
+    )?;
+    Ok(())
 }
 
 pub(super) fn run_writer_thread(
@@ -414,6 +467,28 @@ fn insert_record(
         ],
     )?;
     let record_id = tx.last_insert_rowid();
+
+    for (question_index, question) in record.questions_json.iter().enumerate() {
+        tx.execute(
+            &format!(
+                "INSERT OR IGNORE INTO {} (
+                    record_id,
+                    question_index,
+                    name_lc,
+                    qtype,
+                    qclass
+                ) VALUES (?1, ?2, ?3, ?4, ?5)",
+                tables.questions
+            ),
+            params![
+                record_id,
+                question_index as i64,
+                question.name.to_ascii_lowercase(),
+                question.qtype.to_ascii_uppercase(),
+                question.qclass.as_str(),
+            ],
+        )?;
+    }
 
     for step in &steps {
         tx.execute(
@@ -809,7 +884,7 @@ pub(super) fn load_top_qnames(
 
     let sql = format!(
         "WITH sample_records AS (
-            SELECT r.id, r.questions_json
+            SELECT r.id
             FROM {records} r
             WHERE {where_sql}
             ORDER BY r.created_at_ms DESC, r.id DESC
@@ -820,15 +895,16 @@ pub(super) fn load_top_qnames(
          )
          SELECT
             totals.sample_size,
-            LOWER(json_extract(q.value, '$.name')) AS qname,
-            COUNT(*) AS count
+            q.name_lc AS qname,
+            COUNT(q.name_lc) AS count
          FROM totals
          LEFT JOIN sample_records ON 1 = 1
-         LEFT JOIN json_each(sample_records.questions_json) AS q ON 1 = 1
+         LEFT JOIN {questions} q ON q.record_id = sample_records.id
          GROUP BY totals.sample_size, qname
          ORDER BY count DESC, qname ASC
          LIMIT ?",
         records = backend.tables.records,
+        questions = backend.tables.questions,
     );
 
     let mut stmt = conn.prepare(&sql)?;
@@ -872,7 +948,7 @@ pub(super) fn load_qtype_distribution(
 
     let sql = format!(
         "WITH sample_records AS (
-            SELECT r.id, r.questions_json
+            SELECT r.id
             FROM {records} r
             WHERE {where_sql}
             ORDER BY r.created_at_ms DESC, r.id DESC
@@ -883,14 +959,15 @@ pub(super) fn load_qtype_distribution(
          )
          SELECT
             totals.sample_size,
-            UPPER(json_extract(q.value, '$.qtype')) AS qtype,
-            COUNT(*) AS count
+            q.qtype,
+            COUNT(q.qtype) AS count
          FROM totals
          LEFT JOIN sample_records ON 1 = 1
-         LEFT JOIN json_each(sample_records.questions_json) AS q ON 1 = 1
+         LEFT JOIN {questions} q ON q.record_id = sample_records.id
          GROUP BY totals.sample_size, qtype
          ORDER BY count DESC, qtype ASC",
         records = backend.tables.records,
+        questions = backend.tables.questions,
     );
 
     let mut stmt = conn.prepare(&sql)?;
@@ -1033,23 +1110,25 @@ pub(super) fn load_latency_summary(
     slow_params.push(Value::Integer(limit_to_i64(slow_limit)?));
     let slow_sql = format!(
         "WITH sample_records AS (
-            SELECT r.id, r.elapsed_ms, r.questions_json
+            SELECT r.id, r.elapsed_ms
             FROM {records} r
             WHERE {where_sql}
             ORDER BY r.created_at_ms DESC, r.id DESC
             LIMIT ?
          )
          SELECT
-            LOWER(json_extract(q.value, '$.name')) AS qname,
+            q.name_lc AS qname,
             COUNT(*) AS count,
             AVG(sample_records.elapsed_ms) AS avg_ms,
             MAX(sample_records.elapsed_ms) AS max_ms
-         FROM sample_records, json_each(sample_records.questions_json) AS q
+         FROM sample_records
+         JOIN {questions} q ON q.record_id = sample_records.id
          GROUP BY qname
          HAVING qname IS NOT NULL
          ORDER BY avg_ms DESC, count DESC
          LIMIT ?",
         records = backend.tables.records,
+        questions = backend.tables.questions,
         where_sql = slow_where_sql,
     );
     let mut slow_top: Vec<LatencySlowRow> = Vec::new();
@@ -1291,23 +1370,25 @@ fn record_filter_clauses(
     }
     if let Some(qname) = filter.qname.as_deref() {
         clauses.push(format!(
-            "EXISTS (
-                SELECT 1
-                FROM json_each({alias}.questions_json) AS question
-                WHERE LOWER(json_extract(question.value, '$.name')) LIKE LOWER(?) ESCAPE '\\'
-            )"
+            "{alias}.id IN (
+                SELECT q.record_id
+                FROM {questions} q
+                WHERE q.name_lc LIKE ? ESCAPE '\\'
+            )",
+            questions = tables.questions,
         ));
-        params.push(Value::Text(like_pattern(qname)));
+        params.push(Value::Text(like_pattern(&qname.to_ascii_lowercase())));
     }
     if let Some(qtype) = filter.qtype.as_deref() {
         clauses.push(format!(
-            "EXISTS (
-                SELECT 1
-                FROM json_each({alias}.questions_json) AS question
-                WHERE UPPER(json_extract(question.value, '$.qtype')) = UPPER(?)
-            )"
+            "{alias}.id IN (
+                SELECT q.record_id
+                FROM {questions} q
+                WHERE q.qtype = ?
+            )",
+            questions = tables.questions,
         ));
-        params.push(Value::Text(qtype.to_string()));
+        params.push(Value::Text(qtype.to_ascii_uppercase()));
     }
     if let Some(client_ip) = filter.client_ip.as_deref() {
         clauses.push(format!(
@@ -1467,6 +1548,7 @@ mod tests {
         let tables = TableNames {
             records: "records".to_string(),
             steps: "steps".to_string(),
+            questions: "questions".to_string(),
         };
         create_schema(&mut conn, &tables).unwrap();
 
@@ -1474,6 +1556,15 @@ mod tests {
         let tx = conn.transaction().unwrap();
         let detail = insert_record(&tx, &tables, expected.clone(), Vec::new()).unwrap();
         tx.commit().unwrap();
+
+        let question_count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM questions WHERE record_id = ?1",
+                params![detail.record.id],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(question_count, 1);
 
         let row_columns = record_row_select_columns(None);
         let sql = format!(
@@ -1492,6 +1583,33 @@ mod tests {
             ..expected
         };
         assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_create_schema_backfills_missing_question_index_rows() {
+        let mut conn = Connection::open_in_memory().unwrap();
+        let tables = TableNames {
+            records: "records".to_string(),
+            steps: "steps".to_string(),
+            questions: "questions".to_string(),
+        };
+        create_schema(&mut conn, &tables).unwrap();
+
+        let tx = conn.transaction().unwrap();
+        let detail = insert_record(&tx, &tables, sample_record_row(), Vec::new()).unwrap();
+        tx.commit().unwrap();
+        conn.execute("DELETE FROM questions", []).unwrap();
+
+        create_schema(&mut conn, &tables).unwrap();
+
+        let question: (String, String) = conn
+            .query_row(
+                "SELECT name_lc, qtype FROM questions WHERE record_id = ?1",
+                params![detail.record.id],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(question, ("example.com.".to_string(), "A".to_string()));
     }
 
     fn sample_record_row() -> RecordRow {

--- a/src/plugin/executor/query_recorder/store.rs
+++ b/src/plugin/executor/query_recorder/store.rs
@@ -24,6 +24,7 @@ use super::model::{
 use crate::infra::error::{DnsError, Result};
 
 const SCHEMA_VERSION: &str = "v1";
+const QUESTIONS_BACKFILL_MARKER: &str = "questions_backfilled";
 const CLEANUP_BATCH_SIZE: usize = 1_000;
 const PLUGIN_STATS_SAMPLE_LIMIT: usize = 10_000;
 const RECORD_ROW_COLUMNS: [&str; 27] = [
@@ -102,6 +103,7 @@ pub(super) fn table_names(tag: &str) -> TableNames {
         records: format!("{prefix}_records"),
         steps: format!("{prefix}_steps"),
         questions: format!("{prefix}_questions"),
+        meta: format!("{prefix}_meta"),
     }
 }
 
@@ -192,6 +194,10 @@ pub(crate) fn create_schema(conn: &mut Connection, tables: &TableNames) -> rusql
             PRIMARY KEY (record_id, question_index),
             FOREIGN KEY(record_id) REFERENCES {records}(id) ON DELETE CASCADE
         );
+        CREATE TABLE IF NOT EXISTS {meta} (
+            key TEXT PRIMARY KEY,
+            value TEXT NOT NULL
+        );
         CREATE INDEX IF NOT EXISTS {records}_created_at_idx ON {records}(created_at_ms DESC);
         CREATE INDEX IF NOT EXISTS {records}_request_id_idx ON {records}(request_id);
         CREATE INDEX IF NOT EXISTS {records}_client_ip_idx ON {records}(client_ip);
@@ -216,9 +222,43 @@ pub(crate) fn create_schema(conn: &mut Connection, tables: &TableNames) -> rusql
             ON {steps}(record_id, kind);",
         records = tables.records,
         questions = tables.questions,
+        meta = tables.meta,
         steps = tables.steps,
     ))?;
-    backfill_questions(conn, tables)
+    backfill_questions_once(conn, tables)
+}
+
+fn backfill_questions_once(conn: &Connection, tables: &TableNames) -> rusqlite::Result<()> {
+    if questions_backfill_done(conn, tables)? {
+        return Ok(());
+    }
+
+    backfill_questions(conn, tables)?;
+    mark_questions_backfilled(conn, tables)
+}
+
+fn questions_backfill_done(conn: &Connection, tables: &TableNames) -> rusqlite::Result<bool> {
+    conn.query_row(
+        &format!(
+            "SELECT 1 FROM {} WHERE key = ?1 AND value = ?2",
+            tables.meta
+        ),
+        params![QUESTIONS_BACKFILL_MARKER, "true"],
+        |_| Ok(()),
+    )
+    .optional()
+    .map(|row| row.is_some())
+}
+
+fn mark_questions_backfilled(conn: &Connection, tables: &TableNames) -> rusqlite::Result<()> {
+    conn.execute(
+        &format!(
+            "INSERT OR REPLACE INTO {} (key, value) VALUES (?1, ?2)",
+            tables.meta
+        ),
+        params![QUESTIONS_BACKFILL_MARKER, "true"],
+    )?;
+    Ok(())
 }
 
 fn backfill_questions(conn: &Connection, tables: &TableNames) -> rusqlite::Result<()> {
@@ -1549,6 +1589,7 @@ mod tests {
             records: "records".to_string(),
             steps: "steps".to_string(),
             questions: "questions".to_string(),
+            meta: "meta".to_string(),
         };
         create_schema(&mut conn, &tables).unwrap();
 
@@ -1592,6 +1633,7 @@ mod tests {
             records: "records".to_string(),
             steps: "steps".to_string(),
             questions: "questions".to_string(),
+            meta: "meta".to_string(),
         };
         create_schema(&mut conn, &tables).unwrap();
 
@@ -1599,6 +1641,11 @@ mod tests {
         let detail = insert_record(&tx, &tables, sample_record_row(), Vec::new()).unwrap();
         tx.commit().unwrap();
         conn.execute("DELETE FROM questions", []).unwrap();
+        conn.execute(
+            "DELETE FROM meta WHERE key = ?1",
+            params![QUESTIONS_BACKFILL_MARKER],
+        )
+        .unwrap();
 
         create_schema(&mut conn, &tables).unwrap();
 
@@ -1610,6 +1657,30 @@ mod tests {
             )
             .unwrap();
         assert_eq!(question, ("example.com.".to_string(), "A".to_string()));
+    }
+
+    #[test]
+    fn test_create_schema_skips_question_backfill_after_marker() {
+        let mut conn = Connection::open_in_memory().unwrap();
+        let tables = TableNames {
+            records: "records".to_string(),
+            steps: "steps".to_string(),
+            questions: "questions".to_string(),
+            meta: "meta".to_string(),
+        };
+        create_schema(&mut conn, &tables).unwrap();
+
+        let tx = conn.transaction().unwrap();
+        insert_record(&tx, &tables, sample_record_row(), Vec::new()).unwrap();
+        tx.commit().unwrap();
+        conn.execute("DELETE FROM questions", []).unwrap();
+
+        create_schema(&mut conn, &tables).unwrap();
+
+        let question_count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM questions", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(question_count, 0);
     }
 
     fn sample_record_row() -> RecordRow {

--- a/src/plugin/executor/query_recorder/tests.rs
+++ b/src/plugin/executor/query_recorder/tests.rs
@@ -118,6 +118,7 @@ fn test_table_names_include_tag_hash_and_version() {
     assert!(tables.records.starts_with("qr_recorder_main_"));
     assert!(tables.records.ends_with("_v1_records"));
     assert!(tables.steps.ends_with("_v1_steps"));
+    assert!(tables.questions.ends_with("_v1_questions"));
 }
 
 #[test]

--- a/src/plugin/executor/query_recorder/tests.rs
+++ b/src/plugin/executor/query_recorder/tests.rs
@@ -13,8 +13,8 @@ use super::model::{
 };
 use super::store::{
     create_schema, load_latency_summary, load_plugin_stats, load_qtype_distribution,
-    load_rcode_distribution, load_timeseries, load_top_clients, load_top_qnames, open_database,
-    query_records, table_names,
+    load_rcode_distribution, load_timeseries, load_top_clients, load_top_qnames,
+    open_reader_database, open_writer_database, query_records, table_names,
 };
 use super::{QueryRecorder, QueryRecorderFactory, resolve_config};
 use crate::core::context::{DnsContext, ExecutionPathEvent};
@@ -35,6 +35,7 @@ fn recorder_config(path: &str) -> serde_yaml_ng::Value {
         memory_tail: Some(16),
         retention_days: Some(7),
         cleanup_interval_hours: Some(1),
+        reader_concurrency: Some(2),
     })
     .unwrap()
 }
@@ -120,10 +121,10 @@ fn test_table_names_include_tag_hash_and_version() {
 }
 
 #[test]
-fn test_open_database_enables_incremental_auto_vacuum_for_new_database() {
+fn test_open_writer_database_enables_incremental_auto_vacuum_for_new_database() {
     let temp = NamedTempFile::new().unwrap();
     let tables = table_names("rec");
-    let mut conn = open_database(temp.path()).unwrap();
+    let mut conn = open_writer_database(temp.path()).unwrap();
 
     create_schema(&mut conn, &tables).unwrap();
 
@@ -131,6 +132,35 @@ fn test_open_database_enables_incremental_auto_vacuum_for_new_database() {
         .query_row("PRAGMA auto_vacuum", [], |row| row.get(0))
         .unwrap();
     assert_eq!(mode, 2);
+}
+
+#[test]
+fn test_open_reader_database_uses_low_memory_read_pragmas() {
+    let temp = NamedTempFile::new().unwrap();
+    let tables = table_names("rec");
+    {
+        let mut conn = open_writer_database(temp.path()).unwrap();
+        create_schema(&mut conn, &tables).unwrap();
+    }
+
+    let conn = open_reader_database(temp.path()).unwrap();
+    let query_only: i64 = conn
+        .query_row("PRAGMA query_only", [], |row| row.get(0))
+        .unwrap();
+    let cache_size: i64 = conn
+        .query_row("PRAGMA cache_size", [], |row| row.get(0))
+        .unwrap();
+    let mmap_size: i64 = conn
+        .query_row("PRAGMA mmap_size", [], |row| row.get(0))
+        .unwrap();
+    let temp_store: i64 = conn
+        .query_row("PRAGMA temp_store", [], |row| row.get(0))
+        .unwrap();
+
+    assert_eq!(query_only, 1);
+    assert_eq!(cache_size, -4096);
+    assert_eq!(mmap_size, 0);
+    assert_eq!(temp_store, 1);
 }
 
 #[test]
@@ -238,6 +268,7 @@ async fn test_query_recorder_execute_enqueues_record() {
             memory_tail: Some(8),
             retention_days: Some(7),
             cleanup_interval_hours: Some(1),
+            reader_concurrency: Some(2),
         })
         .unwrap(),
     ))
@@ -290,6 +321,7 @@ async fn test_query_recorder_list_cursor_only_when_more_records_exist() {
             memory_tail: Some(8),
             retention_days: Some(7),
             cleanup_interval_hours: Some(1),
+            reader_concurrency: Some(2),
         })
         .unwrap(),
     ))
@@ -381,6 +413,44 @@ async fn test_query_recorder_clear_history_removes_records_and_tail() {
         .unwrap()
         .0;
     assert!(records.is_empty());
+
+    plugin.destroy().await.unwrap();
+}
+
+#[tokio::test]
+async fn test_query_recorder_clear_history_does_not_wait_for_reader_permits() {
+    AppClock::start();
+
+    let temp = NamedTempFile::new().unwrap();
+    let config = resolve_config(Some(recorder_config(&temp.path().display().to_string()))).unwrap();
+    let mut plugin = QueryRecorder::new("rec".to_string(), config);
+    plugin.init_for_test().await.unwrap();
+    let backend = plugin.backend.as_ref().unwrap().clone();
+
+    seed_demo_records(&backend).await;
+    let _reader_a = backend
+        .reader_semaphore
+        .clone()
+        .try_acquire_owned()
+        .expect("first reader permit should be available");
+    let _reader_b = backend
+        .reader_semaphore
+        .clone()
+        .try_acquire_owned()
+        .expect("second reader permit should be available");
+
+    let clear_backend = backend.clone();
+    let clear_result = tokio::time::timeout(
+        std::time::Duration::from_secs(1),
+        tokio::task::spawn_blocking(move || clear_backend.clear_history()),
+    )
+    .await
+    .expect("clear should not wait for reader permits")
+    .unwrap()
+    .unwrap();
+
+    assert_eq!(clear_result.cleared_records, 5);
+    assert!(backend.tail.lock().unwrap().is_empty());
 
     plugin.destroy().await.unwrap();
 }
@@ -811,6 +881,7 @@ async fn test_load_top_clients_allows_limit_above_200() {
             memory_tail: Some(16),
             retention_days: Some(7),
             cleanup_interval_hours: Some(1),
+            reader_concurrency: Some(2),
         })
         .unwrap(),
     ))
@@ -1054,6 +1125,7 @@ fn test_resolve_config_rejects_zero_limits() {
         memory_tail: Some(1),
         retention_days: Some(1),
         cleanup_interval_hours: Some(1),
+        reader_concurrency: Some(2),
     })
     .unwrap();
     assert!(resolve_config(Some(config)).is_err());

--- a/src/plugin/executor/query_recorder/tests.rs
+++ b/src/plugin/executor/query_recorder/tests.rs
@@ -119,6 +119,7 @@ fn test_table_names_include_tag_hash_and_version() {
     assert!(tables.records.ends_with("_v1_records"));
     assert!(tables.steps.ends_with("_v1_steps"));
     assert!(tables.questions.ends_with("_v1_questions"));
+    assert!(tables.meta.ends_with("_v1_meta"));
 }
 
 #[test]

--- a/webui/lib/i18n/locales/en-US/docs.ts
+++ b/webui/lib/i18n/locales/en-US/docs.ts
@@ -258,6 +258,8 @@ export const enUSDocs = {
       "- Type: `integer`; required: no; default value: `7`\n- Minimum value: `1`\n- Function: Define how many days logs are retained; expired data is periodically deleted.",
     cleanup_interval_hours:
       "- Type: `integer`; required: no; default value: `1`\n- Minimum value: `1`\n- Function: Define how often the expired-data cleanup task runs.",
+    reader_concurrency:
+      "- Type: `integer`; required: no; default value: `2`\n- Minimum value: `1`\n- Function: Limit how many SQLite readers may run concurrently for query_recorder API/statistics reads, preventing WebUI or API bursts from occupying too many blocking threads and too much memory.",
   },
   metrics_collector: {
     name: '- Type: `string`; Required: No; Default value: `"default"`\n- Function: Define the name label of the current indicator collector.',

--- a/webui/lib/i18n/locales/en-US/plugin-defined.ts
+++ b/webui/lib/i18n/locales/en-US/plugin-defined.ts
@@ -1139,6 +1139,11 @@ export const enUSPluginDefined = {
           label: "Cleanup interval (hours)",
           description: "Defines how often the expired-data cleanup task runs.",
         },
+        reader_concurrency: {
+          label: "Reader concurrency",
+          description:
+            "Limits how many SQLite readers may run concurrently for query_recorder API/statistics reads, preventing WebUI or API bursts from occupying too many blocking threads and too much memory.",
+        },
       },
     },
     metrics_collector: {

--- a/webui/lib/i18n/locales/zh-CN/docs.ts
+++ b/webui/lib/i18n/locales/zh-CN/docs.ts
@@ -254,6 +254,8 @@ export const zhCNDocs = {
       "- 类型：`integer`；必填：否；默认值：`7`\n- 最小值：`1`\n- 作用：定义日志保留天数；过期数据会被定时实际删除。",
     cleanup_interval_hours:
       "- 类型：`integer`；必填：否；默认值：`1`\n- 最小值：`1`\n- 作用：定义过期清理任务的执行周期。",
+    reader_concurrency:
+      "- 类型：`integer`；必填：否；默认值：`2`\n- 最小值：`1`\n- 作用：限制 query_recorder API/统计读取侧同时运行的 SQLite reader 数量，避免 WebUI 或 API 突发请求占用过多阻塞线程和内存。",
   },
   metrics_collector: {
     name: '- 类型：`string`；必填：否；默认值：`"default"`\n- 作用：定义当前指标收集器的名称标签。',

--- a/webui/lib/i18n/locales/zh-CN/plugin-defined.ts
+++ b/webui/lib/i18n/locales/zh-CN/plugin-defined.ts
@@ -1023,6 +1023,11 @@ export const zhCNPluginDefined = {
           label: "清理周期(小时)",
           description: "定义过期清理任务的执行周期。",
         },
+        reader_concurrency: {
+          label: "读取并发数",
+          description:
+            "限制 query_recorder API/统计读取侧同时运行的 SQLite reader 数量，避免 WebUI 或 API 突发请求占用过多阻塞线程和内存。",
+        },
       },
     },
     metrics_collector: {

--- a/webui/lib/plugin-definitions/executor.ts
+++ b/webui/lib/plugin-definitions/executor.ts
@@ -1112,6 +1112,14 @@ export const executorPluginDefinitions: PluginKindDefinition[] = [
         type: "number",
         default: 1,
       },
+      {
+        key: "reader_concurrency",
+        description:
+          "限制 query_recorder API/统计读取侧同时运行的 SQLite reader 数量，避免 WebUI 或 API 突发请求占用过多阻塞线程和内存。",
+        label: "读取并发数",
+        type: "number",
+        default: 2,
+      },
     ],
   },
   {


### PR DESCRIPTION
## Why

The query recorder is useful for debugging and WebUI inspection, but the recorder database can grow large enough that read-heavy API endpoints become expensive. In particular, qname/qtype filters and top-qname/qtype/latency views repeatedly walked `records.questions_json` through SQLite JSON functions. On larger recorder databases this can increase API latency and transient SQLite memory pressure.

This PR keeps the existing recorder behavior and schema prefixing, but moves the expensive read paths toward indexed relational data and bounds concurrent blocking reader work.

## What changed

- Split recorder database opening into writer and reader paths so the dedicated writer can keep write-oriented PRAGMAs while read-side connections avoid the heavier writer-oriented settings.
- Added a reader semaphore around blocking query-recorder API reads so WebUI/API bursts do not spawn an unbounded number of SQLite reader tasks.
- Added a `questions` index table alongside the existing recorder tables:
  - backfilled from existing `records.questions_json` during schema creation;
  - populated for newly inserted records;
  - indexed by record id, lowercased qname, and qtype.
- Reworked qname/qtype filters and top qname/qtype/latency queries to use the indexed question table instead of repeatedly expanding JSON with `json_each`.
- Kept recorder cleanup/delete operations on the writer path so maintenance work is not blocked behind reader permits.

## Compatibility

- Existing `records` and `steps` tables remain unchanged.
- Existing recorder JSON columns are still written, so current detail APIs and UI behavior continue to work.
- The new question table is derived data and is backfilled automatically for existing recorder rows.

## Validation

- `just check`