### PR TITLE
Serve WebUI HTML without immutable caching

### DIFF
--- a/src/api/static_files.rs
+++ b/src/api/static_files.rs
@@ -206,7 +206,7 @@ fn content_type_for_path(path: &Path) -> &'static str {
 }
 
 fn cache_control_for_path(path: &Path) -> &'static str {
-    if path.file_name().and_then(|name| name.to_str()) == Some("index.html") {
+    if path.extension().and_then(|extension| extension.to_str()) == Some("html") {
         "no-cache"
     } else {
         "public, max-age=31536000, immutable"

--- a/src/api/tests.rs
+++ b/src/api/tests.rs
@@ -701,6 +701,12 @@ async fn test_hyper_serves_webui_static_files_and_spa_fallback() {
         asset.headers().get(http::header::CONTENT_TYPE),
         Some(&HeaderValue::from_static("text/javascript; charset=utf-8"))
     );
+    assert_eq!(
+        asset.headers().get(http::header::CACHE_CONTROL),
+        Some(&HeaderValue::from_static(
+            "public, max-age=31536000, immutable"
+        ))
+    );
 
     let fallback_uri: Uri = format!("http://{addr}/settings")
         .parse()
@@ -729,6 +735,10 @@ async fn test_hyper_serves_webui_static_files_and_spa_fallback() {
         .await
         .expect("logs response");
     assert_eq!(logs.status(), StatusCode::OK);
+    assert_eq!(
+        logs.headers().get(http::header::CACHE_CONTROL),
+        Some(&HeaderValue::from_static("no-cache"))
+    );
     let logs_body = logs
         .into_body()
         .collect()


### PR DESCRIPTION
## Why

The WebUI serves a SPA shell and routed HTML fallbacks. Those HTML responses can reference hashed JavaScript/CSS chunks. If HTML is cached as immutable across an upgrade, a browser can keep an old shell that points to chunks that no longer exist, producing a client-side load failure even though the server is healthy.

Static hashed assets are safe to cache immutably, but HTML entry points should remain revalidatable.

## What changed

- Serve `.html` WebUI responses with `Cache-Control: no-cache`.
- Preserve the existing long-lived immutable caching policy for non-HTML static assets.
- Added test coverage for WebUI static file and SPA fallback cache headers.

## Compatibility

- Asset caching behavior remains optimized for hashed assets.
- HTML entry points become safer across WebUI upgrades and route fallback changes.
- No API or configuration change.

## Validation

- `just check`