### PR TITLE
Add explicit reject 0 soa option

### DIFF
--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -427,15 +427,26 @@ api:
 - 如果当前 `sequence` 是被 `jump` 调用的，调用方会从 `jump` 后一条规则继续执行。
 - 如果当前 `sequence` 是顶层入口，它等价于“提前结束当前规则链”。
 
-### `reject [rcode]`
+### `reject [rcode] [soa]`
 
 - 立即基于当前 request 构造一个 DNS 响应，并结束当前 `sequence`。
 - 默认 `rcode` 为 `REFUSED`，所以 `reject` 等价于拒绝请求。
 - 可以显式写十进制数值，例如：
   - `reject 2` => `SERVFAIL`
   - `reject 3` => `NXDOMAIN`
+- `reject 0` 只返回普通 `NOERROR` 响应，不会自动附加 SOA。
+- `reject 0 soa` 返回 NODATA 风格的 `NOERROR` 响应：Answer 为空，Authority 区会加入一个 synthetic SOA，用于让客户端和递归缓存明确这是“该类型无答案”，而不是域名不存在。
+- `soa` 参数只支持和 `rcode 0` 一起使用，不支持 `reject 3 soa` 这类写法。
+- `reject 0 soa` 中 SOA 记录的 class 会跟随当前 question 的 class。
+- synthetic SOA 的 TTL 和 SOA minimum TTL 当前固定为 300 秒，避免负缓存时间过长。
 - 当前参数只支持十进制数字，不支持 `SERVFAIL`、`NXDOMAIN` 这类名字。
 - 调用方不会继续执行后续规则。
+- 典型用法是在不否定域名存在的前提下抑制某类查询，例如：
+
+```yaml
+- matches: "qtype HTTPS"
+  exec: "reject 0 soa"
+```
 
 ### `mark ...`
 

--- a/docs/docs/plugin-reference/executor.mdx
+++ b/docs/docs/plugin-reference/executor.mdx
@@ -105,11 +105,16 @@ import Admonition from "@theme/Admonition";
 - 不会自动生成响应。
 - 若当前 `sequence` 是被 `jump` 调用的，调用方会从下一条规则继续。
 
-#### `reject [rcode]`
+#### `reject [rcode] [soa]`
 
 - 立即生成响应并结束当前 `sequence`。
 - 默认 `rcode` 为 `REFUSED`。
 - 只支持十进制数值，例如 `reject 2`、`reject 3`。
+- `reject 0` 返回普通 `NOERROR` 响应，不会自动附加 SOA。
+- `reject 0 soa` 返回 NODATA 风格的 `NOERROR` 响应：Answer 为空，Authority 区会加入 synthetic SOA。
+- `soa` 参数只支持和 `rcode 0` 一起使用，不支持 `reject 3 soa` 这类写法。
+- `reject 0 soa` 中 SOA 记录的 class 会跟随当前 question 的 class。
+- synthetic SOA 的 TTL 和 SOA minimum TTL 当前固定为 300 秒，避免负缓存时间过长。
 - 会中断后续规则，不再继续执行。
 
 #### `mark ...`

--- a/docs/i18n/en/docusaurus-plugin-content-docs/current/configuration.md
+++ b/docs/i18n/en/docusaurus-plugin-content-docs/current/configuration.md
@@ -426,15 +426,26 @@ Besides calling plugins, `sequence.args[].exec` can also use built-in control fl
 - If the current `sequence` was entered via `jump`, the caller resumes at the rule after `jump`.
 - If the current `sequence` is the top-level entry, this acts like an early exit from the current rule chain.
 
-### `reject [rcode]`
+### `reject [rcode] [soa]`
 
 - Builds a DNS response from the current request immediately and ends the current `sequence`.
 - The default `rcode` is `REFUSED`, so plain `reject` means “reject this request”.
 - A decimal numeric code can be provided explicitly, for example:
   - `reject 2` => `SERVFAIL`
   - `reject 3` => `NXDOMAIN`
+- `reject 0` returns a plain `NOERROR` response and does not add an SOA automatically.
+- `reject 0 soa` returns a NODATA-style `NOERROR` response: the Answer section is empty, and the Authority section includes a synthetic SOA so clients and recursive caches can distinguish “no answer for this type” from “the domain does not exist”.
+- The `soa` parameter is only supported with `rcode 0`; forms such as `reject 3 soa` are not supported.
+- In `reject 0 soa`, the SOA record class follows the current question class.
+- The synthetic SOA TTL and SOA minimum TTL are currently fixed at 300 seconds to avoid long negative caching.
 - The parameter currently accepts decimal integers only, not mnemonic names such as `SERVFAIL`.
 - Callers do not continue with later rules.
+- A typical use is suppressing a query type without denying that the domain exists, for example:
+
+```yaml
+- matches: "qtype HTTPS"
+  exec: "reject 0 soa"
+```
 
 ### `mark ...`
 

--- a/docs/i18n/en/docusaurus-plugin-content-docs/current/plugin-reference/executor.mdx
+++ b/docs/i18n/en/docusaurus-plugin-content-docs/current/plugin-reference/executor.mdx
@@ -97,11 +97,16 @@ Besides plugin calls, `sequence.args[].exec` can also use built-in control flow:
 - Does not build a response.
 - If the current `sequence` was entered by `jump`, the caller continues with the next rule.
 
-#### `reject [rcode]`
+#### `reject [rcode] [soa]`
 
 - Builds a response immediately and ends the current `sequence`.
 - The default `rcode` is `REFUSED`.
 - Only decimal numeric rcodes are accepted, for example `reject 2` or `reject 3`.
+- `reject 0` returns a plain `NOERROR` response and does not add an SOA automatically.
+- `reject 0 soa` returns a NODATA-style `NOERROR` response: the Answer section is empty, and the Authority section includes a synthetic SOA.
+- The `soa` parameter is only supported with `rcode 0`; forms such as `reject 3 soa` are not supported.
+- In `reject 0 soa`, the SOA record class follows the current question class.
+- The synthetic SOA TTL and SOA minimum TTL are currently fixed at 300 seconds to avoid long negative caching.
 - Stops later rules from running.
 
 #### `mark ...`

--- a/src/plugin/executor/sequence/chain.rs
+++ b/src/plugin/executor/sequence/chain.rs
@@ -16,7 +16,7 @@ use crate::plugin::executor::sequence::{
 use crate::plugin::executor::{ExecStep, Executor};
 use crate::plugin::matcher::{Matcher, MatcherRef};
 use crate::plugin::{PluginHolder, PluginInitContext};
-use crate::proto::Rcode;
+use crate::proto::{Message, Name, Question, RData, Rcode, Record, SOA};
 
 #[cfg(feature = "_sequence-step-recording")]
 macro_rules! record_sequence_event {
@@ -40,14 +40,30 @@ enum BuiltinOp {
     /// stop.
     ///
     /// Sequence config currently accepts only decimal numeric rcode values such
-    /// as `reject 2`; mnemonic names like `SERVFAIL` are not parsed here.
-    Reject(Rcode),
+    /// as `reject 2`; mnemonic names like `SERVFAIL` are not parsed here. The
+    /// explicit `reject 0 soa` form returns a NODATA-style NOERROR response
+    /// with an SOA in the authority section.
+    Reject { rcode: Rcode, soa: bool },
     /// Execute another sequence executor, then continue current program.
     Jump(Arc<dyn Executor>),
     /// Execute another sequence executor and stop current program immediately.
     Goto(Arc<dyn Executor>),
     /// Insert marks into context and continue execution.
     Mark(AHashSet<u32>),
+}
+
+const SEQUENCE_REJECT_SOA_TTL: u32 = 300;
+
+lazy_static::lazy_static! {
+    static ref SEQUENCE_REJECT_SOA_RDATA: Arc<RData> = Arc::new(RData::SOA(SOA::new(
+        Name::from_ascii("fake-ns.oxidns.fake.root.").expect("fake SOA mname should parse"),
+        Name::from_ascii("fake-mbox.oxidns.fake.root.").expect("fake SOA rname should parse"),
+        2021110400,
+        1800,
+        900,
+        604800,
+        SEQUENCE_REJECT_SOA_TTL,
+    )));
 }
 
 #[derive(Debug)]
@@ -283,8 +299,13 @@ impl ChainProgram {
                 );
                 Ok(InstructionFlow::Complete(ExecStep::Return))
             }
-            BuiltinOp::Reject(rcode) => {
-                context.set_response(context.request().response(*rcode));
+            BuiltinOp::Reject { rcode, soa } => {
+                let response = if *soa {
+                    build_reject_soa_response(context.request())
+                } else {
+                    context.request().response(*rcode)
+                };
+                context.set_response(response);
                 record_sequence_event!(
                     self,
                     context,
@@ -400,6 +421,23 @@ impl ChainProgram {
             outcome,
         ));
     }
+}
+
+fn build_reject_soa_response(request: &Message) -> Message {
+    let mut response = request.response(Rcode::NoError);
+    if let Some(question) = request.first_question() {
+        add_reject_soa(&mut response, question);
+    }
+    response
+}
+
+fn add_reject_soa(response: &mut Message, question: &Question) {
+    response.add_authority(Record::from_arc_rdata_with_class(
+        question.name().clone(),
+        SEQUENCE_REJECT_SOA_TTL,
+        question.qclass(),
+        SEQUENCE_REJECT_SOA_RDATA.clone(),
+    ));
 }
 
 #[cfg(feature = "_sequence-step-recording")]
@@ -540,19 +578,7 @@ impl<'a> ChainBuilder<'a> {
         match op {
             "accept" => Ok(Some(BuiltinOp::Accept)),
             "return" => Ok(Some(BuiltinOp::Return)),
-            "reject" => {
-                if let Some(code) = arg {
-                    if let Ok(code) = code.parse::<u16>() {
-                        Ok(Some(BuiltinOp::Reject(Rcode::from(code))))
-                    } else {
-                        Err(DnsError::plugin(
-                            "invalid code argument: reject expects a decimal numeric rcode",
-                        ))
-                    }
-                } else {
-                    Ok(Some(BuiltinOp::Reject(Rcode::Refused)))
-                }
-            }
+            "reject" => parse_reject_builtin(arg).map(Some),
             "mark" => Ok(Some(BuiltinOp::Mark(parse_mark_values(arg)?))),
             "jump" => Ok(Some(BuiltinOp::Jump(
                 self.resolve_jump_or_goto_executor("jump", arg, node_index)
@@ -647,6 +673,31 @@ impl<'a> ChainBuilder<'a> {
             }
         }
     }
+}
+
+fn parse_reject_builtin(arg: Option<&str>) -> Result<BuiltinOp> {
+    let Some(raw) = arg else {
+        return Ok(BuiltinOp::Reject {
+            rcode: Rcode::Refused,
+            soa: false,
+        });
+    };
+
+    if raw == "0 soa" {
+        return Ok(BuiltinOp::Reject {
+            rcode: Rcode::NoError,
+            soa: true,
+        });
+    }
+
+    let code = raw.parse::<u16>().map_err(|_| {
+        DnsError::plugin("invalid code argument: reject expects a decimal numeric rcode")
+    })?;
+
+    Ok(BuiltinOp::Reject {
+        rcode: Rcode::from(code),
+        soa: false,
+    })
 }
 
 /// Parse optional `mark` arguments into normalized mark strings.
@@ -931,7 +982,10 @@ mod tests {
         let program = Arc::new(ChainProgram::new(
             "test_sequence".to_string(),
             vec![
-                builtin_instruction(BuiltinOp::Reject(Rcode::ServFail)),
+                builtin_instruction(BuiltinOp::Reject {
+                    rcode: Rcode::ServFail,
+                    soa: false,
+                }),
                 executor_instruction(skipped),
             ],
         ));
@@ -975,7 +1029,10 @@ mod tests {
     async fn test_run_reject_builds_response_from_request_message() {
         let program = Arc::new(ChainProgram::new(
             "test_sequence".to_string(),
-            vec![builtin_instruction(BuiltinOp::Reject(Rcode::ServFail))],
+            vec![builtin_instruction(BuiltinOp::Reject {
+                rcode: Rcode::ServFail,
+                soa: false,
+            })],
         ));
         let mut context = make_context();
 
@@ -984,6 +1041,53 @@ mod tests {
         let response = context.response().expect("reject should build response");
         assert_eq!(response.id(), 42);
         assert_eq!(response.rcode(), Rcode::ServFail);
+    }
+
+    #[tokio::test]
+    async fn test_run_reject_noerror_builds_simple_response() {
+        let program = Arc::new(ChainProgram::new(
+            "test_sequence".to_string(),
+            vec![builtin_instruction(BuiltinOp::Reject {
+                rcode: Rcode::NoError,
+                soa: false,
+            })],
+        ));
+        let mut context = make_context();
+
+        program.run(&mut context).await.unwrap();
+
+        let response = context.response().expect("reject should build response");
+        assert_eq!(response.id(), 42);
+        assert_eq!(response.rcode(), Rcode::NoError);
+        assert!(response.answers().is_empty());
+        assert!(response.authorities().is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_run_reject_noerror_soa_builds_soa_response() {
+        let program = Arc::new(ChainProgram::new(
+            "test_sequence".to_string(),
+            vec![builtin_instruction(BuiltinOp::Reject {
+                rcode: Rcode::NoError,
+                soa: true,
+            })],
+        ));
+        let mut context = make_context();
+
+        program.run(&mut context).await.unwrap();
+
+        let response = context
+            .response()
+            .expect("reject 0 soa should build response");
+        assert_eq!(response.id(), 42);
+        assert_eq!(response.rcode(), Rcode::NoError);
+        assert!(response.answers().is_empty());
+        assert_eq!(response.authorities().len(), 1);
+        assert_eq!(
+            response.authorities()[0].rr_type(),
+            crate::proto::RecordType::SOA
+        );
+        assert_eq!(response.authorities()[0].ttl(), SEQUENCE_REJECT_SOA_TTL);
     }
 
     #[tokio::test]
@@ -998,7 +1102,34 @@ mod tests {
             .await
             .expect("reject without argument should parse");
 
-        assert!(matches!(op, Some(BuiltinOp::Reject(Rcode::Refused))));
+        assert!(matches!(
+            op,
+            Some(BuiltinOp::Reject {
+                rcode: Rcode::Refused,
+                soa: false
+            })
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_parse_builtin_reject_accepts_noerror_soa_option() {
+        let registry = crate::plugin::test_utils::test_registry();
+        let create_context = PluginCreateContext::default();
+        let init_context = PluginInitContext::new(registry, "seq", &create_context);
+        let mut builder = ChainBuilder::new(&init_context, "seq".to_string());
+
+        let op = builder
+            .parse_builtin("reject 0 soa", 0)
+            .await
+            .expect("reject 0 soa should parse");
+
+        assert!(matches!(
+            op,
+            Some(BuiltinOp::Reject {
+                rcode: Rcode::NoError,
+                soa: true
+            })
+        ));
     }
 
     #[tokio::test]

--- a/tests/plugin_integration.rs
+++ b/tests/plugin_integration.rs
@@ -1092,6 +1092,119 @@ plugins:
 }
 
 #[tokio::test]
+async fn test_sequence_reject_zero_returns_simple_noerror_response() -> Result<()> {
+    let yaml = r#"
+log:
+  level: info
+plugins:
+  - tag: seq
+    type: sequence
+    args:
+      - matches: qtype HTTPS
+        exec: reject 0
+      - exec: reject 2
+"#;
+
+    let config = parse_config(yaml)?;
+    let registry = plugin::init(config).await?;
+    let sequence = registry
+        .get_plugin("seq")
+        .expect("sequence plugin should exist")
+        .to_executor();
+    let mut context = make_context_with_qtype(registry.clone(), "apple.com.", RecordType::HTTPS);
+
+    let step = sequence.execute(&mut context).await?;
+
+    assert!(matches!(step, ExecStep::Stop));
+    let response = context.response().expect("reject 0 should set a response");
+    assert_eq!(response.rcode(), Rcode::NoError);
+    assert!(response.answers().is_empty());
+    assert!(response.authorities().is_empty());
+
+    registry.destroy().await;
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_sequence_reject_zero_soa_for_https_qtype_returns_noerror_soa() -> Result<()> {
+    let yaml = r#"
+log:
+  level: info
+plugins:
+  - tag: seq
+    type: sequence
+    args:
+      - matches: qtype HTTPS
+        exec: reject 0 soa
+      - exec: reject 2
+"#;
+
+    let config = parse_config(yaml)?;
+    let registry = plugin::init(config).await?;
+    let sequence = registry
+        .get_plugin("seq")
+        .expect("sequence plugin should exist")
+        .to_executor();
+    let mut context = make_context_with_qtype(registry.clone(), "apple.com.", RecordType::HTTPS);
+
+    let step = sequence.execute(&mut context).await?;
+
+    assert!(matches!(step, ExecStep::Stop));
+    let response = context
+        .response()
+        .expect("reject 0 soa should set a response");
+    assert_eq!(response.rcode(), Rcode::NoError);
+    assert!(response.answers().is_empty());
+    assert_eq!(response.authorities().len(), 1);
+    assert_eq!(response.authorities()[0].rr_type(), RecordType::SOA);
+    assert_eq!(response.authorities()[0].class(), DNSClass::IN);
+
+    registry.destroy().await;
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_sequence_reject_zero_soa_uses_question_class() -> Result<()> {
+    let yaml = r#"
+log:
+  level: info
+plugins:
+  - tag: seq
+    type: sequence
+    args:
+      - exec: reject 0 soa
+"#;
+
+    let config = parse_config(yaml)?;
+    let registry = plugin::init(config).await?;
+    let sequence = registry
+        .get_plugin("seq")
+        .expect("sequence plugin should exist")
+        .to_executor();
+    let mut request = Message::new();
+    request.add_question(Question::new(
+        Name::from_ascii("version.bind.").expect("query name should be valid"),
+        RecordType::TXT,
+        DNSClass::CH,
+    ));
+    let mut context = DnsContext::new(SocketAddr::from((Ipv4Addr::LOCALHOST, 5300)), request);
+
+    let step = sequence.execute(&mut context).await?;
+
+    assert!(matches!(step, ExecStep::Stop));
+    let response = context
+        .response()
+        .expect("reject 0 soa should set a response");
+    assert_eq!(response.rcode(), Rcode::NoError);
+    assert_eq!(response.authorities().len(), 1);
+    assert_eq!(response.authorities()[0].class(), DNSClass::CH);
+    assert_eq!(response.authorities()[0].rr_type(), RecordType::SOA);
+
+    registry.destroy().await;
+    Ok(())
+}
+
+#[tokio::test]
 async fn test_sequence_jump_return_resumes_parent_execution() -> Result<()> {
     let yaml = r#"
 log:

--- a/webui/components/plugins/sequence-composer.tsx
+++ b/webui/components/plugins/sequence-composer.tsx
@@ -1525,10 +1525,23 @@ function ActionEditor({
                   onChange({
                     mode: "control",
                     control: action.control,
-                    value: `${action.control} ${event.target.value}`.trim(),
+                    value: `${action.control} ${event.target.value
+                      .replace(/\s+/g, " ")
+                      .trimStart()}`,
                   })
                 }
-                placeholder={action.control === "reject" ? "3" : "1,2,3"}
+                onBlur={(event) =>
+                  onChange({
+                    mode: "control",
+                    control: action.control,
+                    value: `${action.control} ${event.target.value}`
+                      .replace(/\s+/g, " ")
+                      .trim(),
+                  })
+                }
+                placeholder={
+                  action.control === "reject" ? "0 soa / 3" : "1,2,3"
+                }
                 className="h-8 max-w-[16rem] w-full font-mono text-xs"
                 disabled={readOnly}
               />
@@ -1677,13 +1690,14 @@ function parseCondition(value: string, conditionId: string): SequenceCondition {
 }
 
 function parseAction(value: unknown): SequenceAction {
-  const text = typeof value === "string" ? value.trim() : "";
+  const rawText = typeof value === "string" ? value : "";
+  const text = rawText.trim();
   const control = inferControlKind(text);
   if (text.startsWith("$")) {
     return { mode: "reference", value: text, control: "accept" };
   }
   if (control) {
-    return { mode: "control", value: text, control };
+    return { mode: "control", value: rawText.trimStart(), control };
   }
   // quick_setup detection — recognise inline executor forms like
   // `query_summary main pipeline` or `drop_resp` before falling back to text.
@@ -1731,7 +1745,10 @@ function serializeAction(action: SequenceAction) {
     if (action.control === "accept" || action.control === "return") {
       return action.control;
     }
-    return `${action.control} ${arg}`.trim();
+    const normalizedArg = arg.replace(/\s+/g, " ").trimStart();
+    return normalizedArg.trim()
+      ? `${action.control} ${normalizedArg}`
+      : action.control;
   }
   // `quick_setup` and `text` modes both store the raw form already.
   return action.value.trim();

--- a/webui/lib/i18n/locales/en-US/docs.ts
+++ b/webui/lib/i18n/locales/en-US/docs.ts
@@ -47,7 +47,7 @@ export const enUSDocs = {
     "args[].matches":
       "- Type: `string` or `array`\n- Required: No\n- Default: None\n- Function: Define the matching conditions of the current rule.\n- Supported forms:\n  - a single matcher string\n  - A list of multiple matchers\n- Operational impact:\n  - There is a logical AND relationship between multiple conditions.\n  - When not configured, it means there is no pre-matching condition.",
     "args[].exec":
-      "- Type: `string`; Required: No; Default: None\n- Function: Define the action to be performed after the rule is hit.\n- Support content:\n  - Plugin reference\n  - Shortcut expressions\n  - Built-in control flow\n- Operational impact:\n  - Directly determines the execution behavior of the current rule.",
+      "- Type: `string`; Required: No; Default: None\n- Function: Define the action to be performed after the rule is hit.\n- Support content:\n  - Plugin reference\n  - Shortcut expressions\n  - Built-in control flow, for example `accept`, `reject 0`, `reject 0 soa`, `reject 3`, `jump <tag>`\n- Operational impact:\n  - Directly determines the execution behavior of the current rule.",
   },
   forward: {
     concurrent:

--- a/webui/lib/i18n/locales/en-US/plugin-defined.ts
+++ b/webui/lib/i18n/locales/en-US/plugin-defined.ts
@@ -308,8 +308,9 @@ export const enUSPluginDefined = {
         "args[].exec": {
           label: "perform action",
           description:
-            "Define the action to be performed when the rule is hit.",
-          placeholder: "$forward_main / accept / reject 3 / jump seq_tag",
+            "Defines the action to perform when the rule matches. You can reference an executor or use built-in actions such as accept, return, reject, jump, goto, and mark.",
+          placeholder:
+            "$forward_main / accept / reject 0 / reject 0 soa / reject 3 / jump seq_tag",
         },
       },
     },

--- a/webui/lib/i18n/locales/zh-CN/docs.ts
+++ b/webui/lib/i18n/locales/zh-CN/docs.ts
@@ -44,7 +44,7 @@ export const zhCNDocs = {
     "args[].matches":
       "- 类型：`string` 或 `array`\n- 必填：否\n- 默认值：无\n- 作用：定义当前规则的匹配条件。\n- 支持形式：\n  - 单个 matcher 字符串\n  - 多个 matcher 组成的列表\n- 运行影响：\n  - 多个条件之间为逻辑与关系。\n  - 未配置时表示无前置匹配条件。",
     "args[].exec":
-      "- 类型：`string`；必填：否；默认值：无\n- 作用：定义规则命中后要执行的动作。\n- 支持内容：\n  - 插件引用\n  - 快捷表达式\n  - 内建控制流\n- 运行影响：\n  - 直接决定当前规则的执行行为。",
+      "- 类型：`string`；必填：否；默认值：无\n- 作用：定义规则命中后要执行的动作。\n- 支持内容：\n  - 插件引用\n  - 快捷表达式\n  - 内建控制流，例如 `accept`、`reject 0`、`reject 0 soa`、`reject 3`、`jump <tag>`\n- 运行影响：\n  - 直接决定当前规则的执行行为。",
   },
   forward: {
     concurrent:

--- a/webui/lib/i18n/locales/zh-CN/plugin-defined.ts
+++ b/webui/lib/i18n/locales/zh-CN/plugin-defined.ts
@@ -272,8 +272,10 @@ export const zhCNPluginDefined = {
         },
         "args[].exec": {
           label: "执行动作",
-          description: "定义规则命中后要执行的动作。",
-          placeholder: "$forward_main / accept / reject 3 / jump seq_tag",
+          description:
+            "定义规则命中后要执行的动作，可引用执行器或使用 accept、return、reject、jump、goto、mark 等内置动作。",
+          placeholder:
+            "$forward_main / accept / reject 0 / reject 0 soa / reject 3 / jump seq_tag",
         },
       },
     },

--- a/webui/lib/oxidns-yaml-monaco.ts
+++ b/webui/lib/oxidns-yaml-monaco.ts
@@ -76,6 +76,7 @@ const topLevelKeys = [
   "init_order",
 ];
 const sequenceControls = ["accept", "return", "reject", "mark", "jump", "goto"];
+const sequenceControlExamples = ["reject 0", "reject 0 soa", "reject 3"];
 const logLevels = ["off", "trace", "debug", "info", "warn", "error"];
 
 // Sub-keys for top-level config sections derived from the Rust config structs.
@@ -647,7 +648,7 @@ function controlSuggestions(
   monaco: MonacoApi,
   range: MonacoRange,
 ): CompletionItem[] {
-  return sequenceControls.map((control) => ({
+  const controls = sequenceControls.map((control) => ({
     label: control,
     kind: monaco.languages.CompletionItemKind.Keyword,
     insertText: control,
@@ -655,6 +656,15 @@ function controlSuggestions(
     detail: "sequence control",
     sortText: `3-${control}`,
   }));
+  const examples = sequenceControlExamples.map((control) => ({
+    label: control,
+    kind: monaco.languages.CompletionItemKind.Snippet,
+    insertText: control,
+    range,
+    detail: "sequence control example",
+    sortText: `3-${control}`,
+  }));
+  return [...controls, ...examples];
 }
 
 // Detects whether the line prefix ends with "jump " or "goto " (plus optional

--- a/webui/lib/plugin-definitions/docs.ts
+++ b/webui/lib/plugin-definitions/docs.ts
@@ -44,7 +44,7 @@ export const pluginFieldDocs = {
     "args[].matches":
       "- 类型：`string` 或 `array`\n- 必填：否\n- 默认值：无\n- 作用：定义当前规则的匹配条件。\n- 支持形式：\n  - 单个 matcher 字符串\n  - 多个 matcher 组成的列表\n- 运行影响：\n  - 多个条件之间为逻辑与关系。\n  - 未配置时表示无前置匹配条件。",
     "args[].exec":
-      "- 类型：`string`；必填：否；默认值：无\n- 作用：定义规则命中后要执行的动作。\n- 支持内容：\n  - 插件引用\n  - 快捷表达式\n  - 内建控制流\n- 运行影响：\n  - 直接决定当前规则的执行行为。",
+      "- 类型：`string`；必填：否；默认值：无\n- 作用：定义规则命中后要执行的动作。\n- 支持内容：\n  - 插件引用\n  - 快捷表达式\n  - 内建控制流，例如 `accept`、`reject 0`、`reject 0 soa`、`reject 3`、`jump <tag>`\n- 运行影响：\n  - 直接决定当前规则的执行行为。",
   },
   forward: {
     concurrent:

--- a/webui/lib/plugin-definitions/executor.ts
+++ b/webui/lib/plugin-definitions/executor.ts
@@ -53,10 +53,11 @@ export const executorPluginDefinitions: PluginKindDefinition[] = [
             },
             {
               key: "exec",
-              description: "定义规则命中后要执行的动作。",
+              description:
+                "定义规则命中后要执行的动作，可引用执行器或使用 accept、return、reject、jump、goto、mark 等内置动作。",
               label: "执行动作",
               type: "text",
-              placeholder: "$forward_main / accept / reject 3 / jump seq_tag",
+              placeholder: "$forward_main / accept / reject 3 / reject 0 soa / jump seq_tag",
             },
           ],
         },

--- a/webui/lib/plugin-definitions/executor.ts
+++ b/webui/lib/plugin-definitions/executor.ts
@@ -57,7 +57,8 @@ export const executorPluginDefinitions: PluginKindDefinition[] = [
                 "定义规则命中后要执行的动作，可引用执行器或使用 accept、return、reject、jump、goto、mark 等内置动作。",
               label: "执行动作",
               type: "text",
-              placeholder: "$forward_main / accept / reject 3 / reject 0 soa / jump seq_tag",
+              placeholder:
+                "$forward_main / accept / reject 0 / reject 0 soa / reject 3 / jump seq_tag",
             },
           ],
         },


### PR DESCRIPTION
## Why

`reject 0` is useful for intentionally answering a query with `NOERROR` while providing no answers. One practical use is suppressing selected query types, such as HTTPS/SVCB (`qtype HTTPS`), without telling clients that the domain itself does not exist.

However, changing plain `reject 0` to add an SOA by default would make the existing RCODE-based `reject [rcode]` action less predictable. This update keeps the default behavior simple and adds an explicit opt-in form instead.

## What changed

- Kept plain `reject 0` as a simple `NOERROR` response without a synthetic SOA.
- Added explicit sequence syntax `reject 0 soa` for SOA-backed NODATA-style responses:
  - RCODE `NOERROR`;
  - empty Answer section;
  - synthetic SOA in the Authority section.
- The SOA class follows the request question class.
- The synthetic SOA TTL and SOA minimum TTL are both fixed at 300 seconds as a conservative default to avoid long negative caching.
- Updated Chinese/English configuration docs and WebUI sequence metadata.
- Added tests covering:
  - unchanged plain `reject 0` behavior;
  - `reject 0 soa` response shape;
  - SOA class following the question class.

## Compatibility

- Existing `reject`, `reject 0`, and non-zero reject rcodes keep their simple RCODE response behavior.
- Configs that want SOA-backed NODATA must opt in explicitly:

```yaml
- matches: "qtype HTTPS"
  exec: "reject 0 soa"
```

## Validation

- `just check`
- Runtime smoke test on a local deployment:
  - API health returned OK;
  - WebUI root returned 200;
  - ordinary `A` / `AAAA` lookups returned normal answers;
  - `HTTPS` / type 65 lookup returned `NOERROR`, 0 answers, and one SOA authority record with TTL/minimum TTL 300.
