### PR TITLE
fix(server): stop spinning on HTTP/3 accept errors

### DIFF
--- a/src/plugin/server/http/http3_server.rs
+++ b/src/plugin/server/http/http3_server.rs
@@ -157,8 +157,11 @@ async fn handle_h3_connection(
                 return;
             }
             Err(e) => {
-                warn!("Error accepting HTTP/3 request from {}: {}", src, e);
-                continue;
+                warn!("HTTP/3 connection accept error from {}: {}", src, e);
+                // `h3::server::Connection::accept` reports connection-level errors. The h3
+                // crate caches handled connection errors, so retrying accept can complete
+                // immediately with the same error and spin the task.
+                return;
             }
         };
 


### PR DESCRIPTION
HTTP/3 accept failures are connection-level terminal errors in h3. Return from the connection handler instead of retrying accept so closed or failed QUIC connections cannot loop on the cached error and burn CPU.