### PR TITLE
feat(cli): add upstream probe diagnostics

### DIFF
--- a/docs/docs/cli.md
+++ b/docs/docs/cli.md
@@ -13,6 +13,7 @@ sidebar_position: 3
 - `check`
 - `build-info`
 - `export-dat`
+- `probe`
 - `service`
 - `upgrade`
 
@@ -25,6 +26,7 @@ sidebar_position: 3
 | 临时开启调试日志 | `oxidns start -c config.yaml -l debug` |
 | 查看插件依赖图 | `oxidns check -c config.yaml --graph` |
 | 查看当前二进制编译能力 | `oxidns build-info` |
+| 探测上游连通性和并发行为 | `oxidns probe upstream tcp://1.1.1.1:53` |
 | 安装系统服务 | `sudo oxidns service install -d /var/lib/oxidns -c /etc/oxidns/config.yaml` |
 | 检查新版本 | `oxidns upgrade check` |
 | 从 dat 导出规则文件 | `oxidns export-dat --file ./rules/geosite.dat --kind geosite --selector cn --out-dir ./rules/exported` |
@@ -44,6 +46,8 @@ oxidns start --help
 oxidns check --help
 oxidns build-info --help
 oxidns export-dat --help
+oxidns probe --help
+oxidns probe upstream --help
 oxidns service --help
 oxidns upgrade --help
 ```
@@ -114,6 +118,82 @@ oxidns check -c config.yaml --graph
 - 校验成功时返回退出码 `0`，并输出简短成功信息。
 - 传入 `--graph` 时，会额外按插件初始化顺序输出纯文本依赖图。
 - 校验失败时返回非零退出码，并输出具体错误原因。
+
+## `probe`
+
+主动探测运行时外部目标。当前提供 `probe upstream`，用于检查单个 DNS 上游的连通性、基础响应信息、域名解析结果，以及并发 / pipeline 行为。
+
+### `probe upstream`
+
+典型用法：
+
+```bash
+oxidns probe upstream udp://1.1.1.1:53
+oxidns probe upstream tcp://1.1.1.1:53
+oxidns probe upstream tls://dns.google:853 --qname example.com. --qtype A
+oxidns probe upstream https://dns.google/dns-query --json
+oxidns probe upstream tcp://dns.example.com:53 -c config.yaml --outbound remote
+```
+
+参数说明：
+
+- `<addr>`
+  - 要探测的 upstream 地址。
+  - 支持与 forward upstream 一致的地址写法，例如 `udp://`、`tcp://`、`tcp+pipeline://`、`tls://`、`tls+pipeline://`、`https://`、`doh://`、`h3://`、`quic://`、`doq://`。
+  - 不带 scheme 时按 UDP 处理。
+- `-c, --config <PATH>`
+  - 可选读取配置文件，只复用其中的 `network.outbound` profile。
+  - 未指定时不会读取运行配置。
+- `-d, --working-dir <PATH>`
+  - 读取配置前切换工作目录。
+- `--outbound <NAME>`
+  - 使用指定 outbound profile 的 resolver / proxy 设置。
+- `--dial-addr <IP>`
+  - 直接连接指定 IP，同时保留 `<addr>` 中的主机名用于 TLS SNI 和 HTTP Host。
+- `--bootstrap <ADDR>`
+  - 使用指定 bootstrap DNS 解析域名型 upstream。
+- `--bootstrap-version <4|6>`
+  - bootstrap 解析时偏好的 IP 版本。
+- `--socks5 <ADDR>`
+  - 对支持代理的上游连接使用 SOCKS5。
+- `--port <PORT>`
+  - 覆盖 upstream 端口。
+- `--insecure-skip-verify`
+  - 跳过 TLS 证书校验，仅建议测试时使用。
+- `--timeout <DURATION>`
+  - 单次查询超时。
+  - 默认值：`5s`
+- `--qname <NAME>`
+  - 串行基线查询域名。
+  - 默认值：`example.com.`
+- `--qtype <TYPE>`
+  - 查询类型。
+  - 默认值：`A`
+- `--serial-samples <N>`
+  - 串行基线查询次数。
+  - 默认值：`2`
+- `--pipeline-concurrency <N>`
+  - 并发探测的查询数量；TCP / DoT 会强制在同一条连接上发送这些查询。
+  - 默认值：`16`
+- `--pipeline-rounds <N>`
+  - 并发探测轮数。
+  - 默认值：`2`
+- `--json`
+  - 输出结构化 JSON 报告。
+
+输出内容：
+
+- 目标信息：地址、协议、服务名、端口、超时。
+- 域名型 upstream 的解析结果：`resolved_ip` 和 `resolution_source`，来源可能是 `literal`、`dial_addr`、`configured`、`bootstrap` 或 `system`。
+- 串行基线：reachable / unreachable、平均延迟、rcode、answer 数量、TC / RA 标志和错误摘要。
+- 并发探测：supported / unsupported / unstable / inconclusive、成功数、超时数、响应 ID / question / qtype 不匹配数、其它错误和建议。
+- 非 JSON 模式会在探测过程中向 stderr 输出进度，最终报告输出到 stdout；JSON 模式只向 stdout 输出报告。
+
+协议行为：
+
+- UDP、DoH、DoH3 和 DoQ 使用对应 upstream 实现发起并发查询，用来评估该协议下的并发或多路复用表现。
+- TCP 和 DoT 会额外强制使用同一条连接发送并发查询，用来发现开启 pipeline 后可能出现的超时、连接关闭、协议错误、响应 ID 错乱或 question 串线。
+- 如果串行基线失败，并发结论会是 `inconclusive`，避免把基础连通性问题误判成 pipeline 问题。
 
 ## `build-info`
 

--- a/docs/docs/cli.md
+++ b/docs/docs/cli.md
@@ -184,7 +184,7 @@ oxidns probe upstream tcp://dns.example.com:53 -c config.yaml --outbound remote
 输出内容：
 
 - 目标信息：地址、协议、服务名、端口、超时。
-- 域名型 upstream 的解析结果：`resolved_ip` 和 `resolution_source`，来源可能是 `literal`、`dial_addr`、`configured`、`bootstrap` 或 `system`。
+- 域名型 upstream 的解析结果：`resolved_ip` 和 `resolution_source`，来源可能是 `literal`、`dial_addr`、`configured`、`bootstrap`、`system` 或 `proxy`。
 - 串行基线：reachable / unreachable、平均延迟、rcode、answer 数量、TC / RA 标志和错误摘要。
 - 并发探测：supported / unsupported / unstable / inconclusive、成功数、超时数、响应 ID / question / qtype 不匹配数、其它错误和建议。
 - 非 JSON 模式会在探测过程中向 stderr 输出进度，最终报告输出到 stdout；JSON 模式只向 stdout 输出报告。

--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -191,7 +191,7 @@ network:
       direct:
         resolver: system
         proxy: none
-      oversea:
+      remote:
         resolver:
           nameservers:
             - addr: "1.1.1.1:53"
@@ -225,7 +225,7 @@ network:
   - `none` 或 `direct`：直连。
   - `socks5`：通过 SOCKS5 代理连接目标地址，格式与上游 `socks5` 一致。
 
-当前 `download`、`upgrade`、`http_request` 可通过 `args.outbound: oversea` 引用 profile。旧字段 `socks5` 继续兼容；当同一个插件同时配置 `outbound` 和 `socks5` 时，`socks5` 会覆盖 profile 中的代理设置，但 resolver 仍来自该 outbound profile。`forward` upstream 未配置 `outbound` 时会使用 `network.outbound.default`；也可通过 `outbound: oversea` 显式接入其他 profile。upstream 本地 `dial_addr`、`bootstrap`、`socks5` 优先于 profile 注入值。
+当前 `download`、`upgrade`、`http_request` 可通过 `args.outbound: remote` 引用 profile。旧字段 `socks5` 继续兼容；当同一个插件同时配置 `outbound` 和 `socks5` 时，`socks5` 会覆盖 profile 中的代理设置，但 resolver 仍来自该 outbound profile。`forward` upstream 未配置 `outbound` 时会使用 `network.outbound.default`；也可通过 `outbound: remote` 显式接入其他 profile。upstream 本地 `dial_addr`、`bootstrap`、`socks5` 优先于 profile 注入值。
 
 ### `api`
 
@@ -613,62 +613,3 @@ args:
   - "$core_domains"
   - "&/etc/oxidns/domains.txt"
 ```
-
-## 上游统一结构
-
-`forward` 的 `upstreams` 使用统一的 `UpstreamConfig`。
-
-示例：
-
-```yaml
-upstreams:
-  - addr: "udp://1.1.1.1:53"
-  - addr: "https://resolver.example/dns-query"
-    outbound: oversea
-    bootstrap: "8.8.8.8:53"
-    timeout: 5s
-    enable_http3: true
-```
-
-常用字段：
-
-- `addr`
-  - 上游地址。
-  - 未写协议时按 UDP 处理。
-  - 支持 `udp://`、`tcp://`、`tcp+pipeline://`、`tls://`、`tls+pipeline://`、`quic://`、`doq://`、`https://`、`doh://`、`h3://`。
-  - DoH 应写完整路径，例如 `https://resolver.example/dns-query`。
-- `dial_addr`
-  - 指定实际连接 IP，但仍保留 `addr` 中的主机名用于 SNI/校验。
-- `port`
-  - 覆盖端口。
-- `outbound`
-  - 引用 `network.outbound.profiles` 中的 profile，为该 upstream 注入 resolver/proxy 默认值。
-  - 未配置时使用 `network.outbound.default`；没有 default 时保持系统解析/直连。
-  - upstream 本地 `dial_addr`、`bootstrap`、`socks5` 优先于 profile。
-  - profile proxy 严格应用；UDP、DoQ、DoH3 upstream 不支持 profile SOCKS5 proxy。
-- `bootstrap`
-  - 当上游地址是域名时，用于解析上游域名的引导 DNS，必须写为 `IP:port`。
-- `bootstrap_version`
-  - `4` 或 `6`。
-- `socks5`
-  - SOCKS5 代理。
-  - 支持 `host:port` 与 `user:pass@host:port`。
-  - IPv6 需写成 `[addr]:port`。
-- `idle_timeout`
-  - 空闲连接超时，单位秒。
-- `min_conns`
-  - 连接池最小预热连接数，默认 `0`，范围 `0..4096`，且不能大于 `max_conns`。
-- `max_conns`
-  - 连接池最大连接数，范围 `1..4096`。
-- `insecure_skip_verify`
-  - 跳过 TLS 证书校验，仅建议测试环境使用。
-- `timeout`
-  - 单次查询超时，默认 `5s`。
-- `enable_pipeline`
-  - TCP/DoT 请求流水线。
-- `enable_http3`
-  - DoH 使用 HTTP/3。
-- `so_mark`
-  - Linux `SO_MARK`。
-- `bind_to_device`
-  - Linux `SO_BINDTODEVICE`。

--- a/docs/docs/plugin-reference/executor.mdx
+++ b/docs/docs/plugin-reference/executor.mdx
@@ -359,6 +359,8 @@ import Admonition from "@theme/Admonition";
 - 作用：控制 TCP 或 DoT 流水线。
 - 示例：`enable_pipeline: true`
 - 说明：也可直接通过 `tcp+pipeline://` 或 `tls+pipeline://` 在 `addr` 中启用。
+- 建议：开启前先用 `oxidns probe upstream <addr>` 探测目标上游。该命令会对 TCP/DoT 强制同一条连接并发查询，帮助判断该上游是否适合启用 pipeline，避免遇到超时、连接关闭、响应 ID 错乱或 question 串线。
+- 判定：探测结果为 `supported` 时再考虑开启；如果为 `unsupported`、`unstable` 或 `inconclusive`，建议保持关闭，或降低并发 / 延长超时后重新测试。
 
 #### `upstreams[].enable_http3`
 
@@ -2608,7 +2610,7 @@ old-static.example.com static.example.net
       force: false
       cleanup: true
       timeout: 30s
-      outbound: oversea
+      outbound: remote
       socks5: 127.0.0.1:1080
       insecure_skip_verify: false
 ```
@@ -2692,7 +2694,7 @@ old-static.example.com static.example.net
   type: download
   args:
     timeout: 30s
-    outbound: oversea
+    outbound: remote
     socks5: "127.0.0.1:1080"
     downloads:
       - url: "https://example.com/geosite.dat"

--- a/docs/i18n/en/docusaurus-plugin-content-docs/current/cli.md
+++ b/docs/i18n/en/docusaurus-plugin-content-docs/current/cli.md
@@ -13,6 +13,7 @@ Available top-level commands:
 - `check`
 - `build-info`
 - `export-dat`
+- `probe`
 - `service`
 - `upgrade`
 
@@ -25,6 +26,7 @@ Available top-level commands:
 | Temporarily enable debug logging | `oxidns start -c config.yaml -l debug` |
 | Print the plugin dependency graph | `oxidns check -c config.yaml --graph` |
 | Inspect compiled binary capabilities | `oxidns build-info` |
+| Probe upstream reachability and concurrency behavior | `oxidns probe upstream tcp://1.1.1.1:53` |
 | Install as a system service | `sudo oxidns service install -d /var/lib/oxidns -c /etc/oxidns/config.yaml` |
 | Check for a new release | `oxidns upgrade check` |
 | Export rules from a dat file | `oxidns export-dat --file ./rules/geosite.dat --kind geosite --selector cn --out-dir ./rules/exported` |
@@ -44,6 +46,8 @@ oxidns start --help
 oxidns check --help
 oxidns build-info --help
 oxidns export-dat --help
+oxidns probe --help
+oxidns probe upstream --help
 oxidns service --help
 oxidns upgrade --help
 ```
@@ -114,6 +118,82 @@ Behavior:
 - On success, exits with code `0` and prints a short success line.
 - With `--graph`, it also prints a plain-text dependency graph in plugin initialization order.
 - On failure, exits non-zero and prints the validation error.
+
+## `probe`
+
+Actively probes runtime-facing external targets. The current subcommand is `probe upstream`, which checks one DNS upstream for reachability, basic response details, hostname resolution, and concurrency / pipeline behavior.
+
+### `probe upstream`
+
+Typical usage:
+
+```bash
+oxidns probe upstream udp://1.1.1.1:53
+oxidns probe upstream tcp://1.1.1.1:53
+oxidns probe upstream tls://dns.google:853 --qname example.com. --qtype A
+oxidns probe upstream https://dns.google/dns-query --json
+oxidns probe upstream tcp://dns.example.com:53 -c config.yaml --outbound remote
+```
+
+Arguments:
+
+- `<addr>`
+  - Upstream address to probe.
+  - Accepts the same address forms as forward upstreams, including `udp://`, `tcp://`, `tcp+pipeline://`, `tls://`, `tls+pipeline://`, `https://`, `doh://`, `h3://`, `quic://`, and `doq://`.
+  - Addresses without a scheme are treated as UDP.
+- `-c, --config <PATH>`
+  - Optionally read a configuration file and reuse only its `network.outbound` profiles.
+  - When omitted, no runtime config is read.
+- `-d, --working-dir <PATH>`
+  - Change the working directory before reading the config.
+- `--outbound <NAME>`
+  - Use resolver / proxy settings from the named outbound profile.
+- `--dial-addr <IP>`
+  - Connect directly to the specified IP while preserving the hostname from `<addr>` for TLS SNI and HTTP Host.
+- `--bootstrap <ADDR>`
+  - Use the specified bootstrap DNS server to resolve hostname upstreams.
+- `--bootstrap-version <4|6>`
+  - Preferred IP version for bootstrap resolution.
+- `--socks5 <ADDR>`
+  - Use a SOCKS5 proxy for upstream transports that support proxying.
+- `--port <PORT>`
+  - Override the upstream port.
+- `--insecure-skip-verify`
+  - Skip TLS certificate verification. Use only for testing.
+- `--timeout <DURATION>`
+  - Per-query timeout.
+  - Default: `5s`
+- `--qname <NAME>`
+  - Query name used for the serial baseline.
+  - Default: `example.com.`
+- `--qtype <TYPE>`
+  - Query type.
+  - Default: `A`
+- `--serial-samples <N>`
+  - Number of serial baseline queries.
+  - Default: `2`
+- `--pipeline-concurrency <N>`
+  - Number of concurrent probe queries. For TCP / DoT, these queries are forced onto one connection.
+  - Default: `16`
+- `--pipeline-rounds <N>`
+  - Number of concurrency probe rounds.
+  - Default: `2`
+- `--json`
+  - Print a structured JSON report.
+
+Output includes:
+
+- Target details: address, protocol, server name, port, and timeout.
+- Hostname upstream resolution: `resolved_ip` and `resolution_source`; sources may be `literal`, `dial_addr`, `configured`, `bootstrap`, or `system`.
+- Serial baseline: reachable / unreachable, average latency, rcode, answer count, TC / RA flags, and error summary.
+- Concurrency probe: supported / unsupported / unstable / inconclusive, success count, timeout count, response ID / question / qtype mismatch count, other errors, and recommendation.
+- Non-JSON mode prints probe progress to stderr while the final report goes to stdout. JSON mode writes only the report to stdout.
+
+Protocol behavior:
+
+- UDP, DoH, DoH3, and DoQ use the matching upstream implementation to send concurrent queries and evaluate concurrency or multiplexing behavior for that protocol.
+- TCP and DoT additionally force concurrent queries through one connection to detect pipeline-specific timeouts, connection closes, protocol errors, response ID confusion, or crossed questions.
+- If the serial baseline fails, the concurrency verdict is `inconclusive` so a basic reachability problem is not misclassified as a pipeline problem.
 
 ## `build-info`
 

--- a/docs/i18n/en/docusaurus-plugin-content-docs/current/cli.md
+++ b/docs/i18n/en/docusaurus-plugin-content-docs/current/cli.md
@@ -184,7 +184,7 @@ Arguments:
 Output includes:
 
 - Target details: address, protocol, server name, port, and timeout.
-- Hostname upstream resolution: `resolved_ip` and `resolution_source`; sources may be `literal`, `dial_addr`, `configured`, `bootstrap`, or `system`.
+- Hostname upstream resolution: `resolved_ip` and `resolution_source`; sources may be `literal`, `dial_addr`, `configured`, `bootstrap`, `system`, or `proxy`.
 - Serial baseline: reachable / unreachable, average latency, rcode, answer count, TC / RA flags, and error summary.
 - Concurrency probe: supported / unsupported / unstable / inconclusive, success count, timeout count, response ID / question / qtype mismatch count, other errors, and recommendation.
 - Non-JSON mode prints probe progress to stderr while the final report goes to stdout. JSON mode writes only the report to stdout.

--- a/docs/i18n/en/docusaurus-plugin-content-docs/current/configuration.md
+++ b/docs/i18n/en/docusaurus-plugin-content-docs/current/configuration.md
@@ -190,7 +190,7 @@ network:
       direct:
         resolver: system
         proxy: none
-      oversea:
+      remote:
         resolver:
           nameservers:
             - addr: "1.1.1.1:53"
@@ -224,7 +224,7 @@ Field notes:
   - `none` or `direct`: Connect directly.
   - `socks5`: Connect through a SOCKS5 proxy. The format is the same as upstream `socks5`.
 
-`download`, `upgrade`, and `http_request` can reference a profile with `args.outbound: oversea`. The legacy `socks5` field remains supported. When both `outbound` and `socks5` are set on the same plugin, `socks5` overrides the profile proxy while the resolver still comes from the outbound profile. `forward` upstreams use `network.outbound.default` when `outbound` is omitted; they can also set `outbound: oversea` to select another profile. Local upstream `dial_addr`, `bootstrap`, and `socks5` fields override profile-injected values.
+`download`, `upgrade`, and `http_request` can reference a profile with `args.outbound: remote`. The legacy `socks5` field remains supported. When both `outbound` and `socks5` are set on the same plugin, `socks5` overrides the profile proxy while the resolver still comes from the outbound profile. `forward` upstreams use `network.outbound.default` when `outbound` is omitted; they can also set `outbound: remote` to select another profile. Local upstream `dial_addr`, `bootstrap`, and `socks5` fields override profile-injected values.
 
 ### `api`
 
@@ -614,62 +614,3 @@ args:
   - "$core_domains"
   - "&/etc/oxidns/domains.txt"
 ```
-
-## Unified Upstream Structure
-
-`forward.upstreams` uses a shared `UpstreamConfig` shape.
-
-Example:
-
-```yaml
-upstreams:
-  - addr: "udp://1.1.1.1:53"
-  - addr: "https://resolver.example/dns-query"
-    outbound: oversea
-    bootstrap: "8.8.8.8:53"
-    timeout: 5s
-    enable_http3: true
-```
-
-Common fields:
-
-- `addr`
-  - Upstream address.
-  - Defaults to UDP when no scheme is given.
-  - Supports `udp://`, `tcp://`, `tcp+pipeline://`, `tls://`, `tls+pipeline://`, `quic://`, `doq://`, `https://`, `doh://`, and `h3://`.
-  - DoH should include the full path, for example `https://resolver.example/dns-query`.
-- `dial_addr`
-  - Actual connection IP, while keeping the hostname from `addr` for SNI and certificate validation.
-- `port`
-  - Overrides the port.
-- `outbound`
-  - References a profile under `network.outbound.profiles` to inject resolver/proxy defaults for this upstream.
-  - When omitted, `network.outbound.default` is used; without a default, the upstream keeps system resolution/direct dialing.
-  - Local `dial_addr`, `bootstrap`, and `socks5` fields take precedence over the profile.
-  - Profile proxying is strict; UDP, DoQ, and DoH3 upstreams do not support profile SOCKS5 proxying.
-- `bootstrap`
-  - Bootstrap DNS used to resolve the upstream hostname when `addr` is domain-based. Must be `IP:port`.
-- `bootstrap_version`
-  - `4` or `6`.
-- `socks5`
-  - SOCKS5 proxy.
-  - Supports `host:port` and `user:pass@host:port`.
-  - IPv6 must use `[addr]:port`.
-- `idle_timeout`
-  - Idle connection timeout in seconds.
-- `min_conns`
-  - Minimum warmed pool connections. Default: `0`; range: `0..4096`; must not exceed `max_conns`.
-- `max_conns`
-  - Maximum pool size, in the range `1..4096`.
-- `insecure_skip_verify`
-  - Skips TLS certificate validation. Recommended only for test environments.
-- `timeout`
-  - Per-query timeout. Default: `5s`.
-- `enable_pipeline`
-  - Enables TCP or DoT pipelining.
-- `enable_http3`
-  - Uses HTTP/3 for DoH.
-- `so_mark`
-  - Linux `SO_MARK`.
-- `bind_to_device`
-  - Linux `SO_BINDTODEVICE`.

--- a/docs/i18n/en/docusaurus-plugin-content-docs/current/plugin-reference/executor.mdx
+++ b/docs/i18n/en/docusaurus-plugin-content-docs/current/plugin-reference/executor.mdx
@@ -311,6 +311,8 @@ Sends DNS queries to upstreams.
 - Type: `boolean`; Required: no; Default: `false`
 - Purpose: Enable pipelining for TCP or DoT.
 - Notes: `tcp+pipeline://` and `tls+pipeline://` force this on.
+- Recommendation: Before enabling it, run `oxidns probe upstream <addr>` against the target upstream. For TCP/DoT, the probe forces concurrent queries through one connection so you can decide whether that upstream is safe for pipeline mode and catch timeouts, connection closes, response ID confusion, or crossed questions first.
+- Verdict: If the probe reports `supported`, enabling pipeline is reasonable. If it reports `unsupported`, `unstable`, or `inconclusive`, keep pipeline disabled or retest with lower concurrency / a longer timeout.
 
 #### `upstreams[].enable_http3`
 
@@ -2498,7 +2500,7 @@ Runs the OxiDNS upgrade flow from the executor pipeline. It is suitable for main
       force: false
       cleanup: true
       timeout: 30s
-      outbound: oversea
+      outbound: remote
       socks5: 127.0.0.1:1080
       insecure_skip_verify: false
 ```
@@ -2577,7 +2579,7 @@ Downloads one or more `http/https` files into a local directory and overwrites t
   type: download
   args:
     timeout: 30s
-    outbound: oversea
+    outbound: remote
     socks5: "127.0.0.1:1080"
     downloads:
       - url: "https://example.com/geosite.dat"

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -8,12 +8,12 @@ mod check;
 #[cfg(feature = "provider-protobuf")]
 pub mod export_dat;
 mod graph;
+mod probe;
 pub mod service;
 #[cfg(feature = "plugin-upgrade")]
 mod upgrade;
 
 use std::path::PathBuf;
-#[cfg(feature = "plugin-upgrade")]
 use std::time::Duration;
 
 use clap::{Args, Parser, Subcommand};
@@ -42,6 +42,8 @@ pub enum Command {
     /// Export selected rules from a dat file into text files.
     #[cfg(feature = "provider-protobuf")]
     ExportDat(ExportDatOptions),
+    /// Probe DNS upstream connectivity and behavior.
+    Probe(ProbeOptions),
     /// Manage the operating system service.
     Service(ServiceOptions),
     /// Check, download, or apply OxiDNS release upgrades.
@@ -130,6 +132,91 @@ pub enum DatKind {
 pub enum ExportFormat {
     Oxidns,
     Original,
+}
+
+/// Runtime probe command options.
+#[derive(Args, Clone, Debug, PartialEq, Eq)]
+pub struct ProbeOptions {
+    #[command(subcommand)]
+    pub command: ProbeCommand,
+}
+
+/// Supported runtime probes.
+#[derive(Subcommand, Clone, Debug, PartialEq, Eq)]
+pub enum ProbeCommand {
+    /// Probe one DNS upstream endpoint.
+    Upstream(ProbeUpstreamOptions),
+}
+
+/// DNS upstream probe options.
+#[derive(Args, Clone, Debug, PartialEq, Eq)]
+pub struct ProbeUpstreamOptions {
+    /// Upstream address, e.g. 1.1.1.1, tcp://1.1.1.1:53, tls://dns.google:853.
+    pub addr: String,
+
+    /// Optional runtime configuration whose network.outbound profiles are used.
+    #[arg(short = 'c', long = "config")]
+    pub config: Option<PathBuf>,
+
+    /// Working directory for resolving relative config paths.
+    #[arg(short = 'd', long = "working-dir")]
+    pub working_dir: Option<PathBuf>,
+
+    /// Named network outbound profile for this probe.
+    #[arg(long = "outbound")]
+    pub outbound: Option<String>,
+
+    /// Direct IP address to dial while preserving the address host as SNI/name.
+    #[arg(long = "dial-addr")]
+    pub dial_addr: Option<std::net::IpAddr>,
+
+    /// Bootstrap DNS server used to resolve hostname upstreams.
+    #[arg(long = "bootstrap")]
+    pub bootstrap: Option<String>,
+
+    /// IP version preference for bootstrap resolution: 4 or 6.
+    #[arg(long = "bootstrap-version")]
+    pub bootstrap_version: Option<u8>,
+
+    /// SOCKS5 proxy for TCP-like upstream transports.
+    #[arg(long = "socks5")]
+    pub socks5: Option<String>,
+
+    /// Override the upstream port.
+    #[arg(long = "port")]
+    pub port: Option<u16>,
+
+    /// Disable TLS certificate verification for encrypted upstreams.
+    #[arg(long = "insecure-skip-verify", default_value_t = false)]
+    pub insecure_skip_verify: bool,
+
+    /// Per-query timeout such as 5s, 2s, or 500ms.
+    #[arg(long = "timeout", value_parser = parse_cli_duration, default_value = "5s")]
+    pub timeout: Duration,
+
+    /// Query name used for the serial baseline probe.
+    #[arg(long = "qname", default_value = "example.com.")]
+    pub qname: String,
+
+    /// Query record type used by the probe.
+    #[arg(long = "qtype", default_value = "A")]
+    pub qtype: String,
+
+    /// Number of serial baseline queries.
+    #[arg(long = "serial-samples", default_value_t = 2)]
+    pub serial_samples: usize,
+
+    /// Number of concurrent queries sent on one TCP/DoT connection.
+    #[arg(long = "pipeline-concurrency", default_value_t = 16)]
+    pub pipeline_concurrency: usize,
+
+    /// Number of pipeline probe rounds.
+    #[arg(long = "pipeline-rounds", default_value_t = 2)]
+    pub pipeline_rounds: usize,
+
+    /// Print JSON instead of the human-readable summary.
+    #[arg(long = "json", default_value_t = false)]
+    pub json: bool,
 }
 
 /// Upgrade command options.
@@ -226,7 +313,6 @@ pub enum UpgradeAction {
     Apply,
 }
 
-#[cfg(feature = "plugin-upgrade")]
 fn parse_cli_duration(raw: &str) -> std::result::Result<Duration, String> {
     crate::infra::system::parse_simple_duration(raw)
 }
@@ -283,6 +369,7 @@ pub fn run() -> Result<()> {
         Command::BuildInfo => build_info::run(),
         #[cfg(feature = "provider-protobuf")]
         Command::ExportDat(options) => export_dat::run(options),
+        Command::Probe(options) => probe::run(options),
         Command::Service(options) => service::run(options),
         #[cfg(feature = "plugin-upgrade")]
         Command::Upgrade(options) => upgrade::run(options),
@@ -395,6 +482,103 @@ mod tests {
         assert_eq!(cli.command, Command::BuildInfo);
     }
 
+    #[test]
+    fn parse_probe_upstream_defaults() {
+        let args = ["oxidns", "probe", "upstream", "tcp://1.1.1.1:53"];
+
+        let cli = Cli::parse_from(args);
+        assert_eq!(
+            cli.command,
+            Command::Probe(ProbeOptions {
+                command: ProbeCommand::Upstream(ProbeUpstreamOptions {
+                    addr: "tcp://1.1.1.1:53".to_string(),
+                    config: None,
+                    working_dir: None,
+                    outbound: None,
+                    dial_addr: None,
+                    bootstrap: None,
+                    bootstrap_version: None,
+                    socks5: None,
+                    port: None,
+                    insecure_skip_verify: false,
+                    timeout: Duration::from_secs(5),
+                    qname: "example.com.".to_string(),
+                    qtype: "A".to_string(),
+                    serial_samples: 2,
+                    pipeline_concurrency: 16,
+                    pipeline_rounds: 2,
+                    json: false,
+                }),
+            })
+        );
+    }
+
+    #[test]
+    fn parse_probe_upstream_accepts_network_and_output_options() {
+        let args = [
+            "oxidns",
+            "probe",
+            "upstream",
+            "tls://dns.example.com:853",
+            "-c",
+            "config.yaml",
+            "-d",
+            "/tmp/oxidns",
+            "--outbound",
+            "remote",
+            "--dial-addr",
+            "203.0.113.53",
+            "--bootstrap",
+            "8.8.8.8:53",
+            "--bootstrap-version",
+            "4",
+            "--socks5",
+            "127.0.0.1:1080",
+            "--port",
+            "8853",
+            "--insecure-skip-verify",
+            "--timeout",
+            "500ms",
+            "--qname",
+            "cloudflare.com.",
+            "--qtype",
+            "AAAA",
+            "--serial-samples",
+            "3",
+            "--pipeline-concurrency",
+            "8",
+            "--pipeline-rounds",
+            "4",
+            "--json",
+        ];
+
+        let cli = Cli::parse_from(args);
+        assert_eq!(
+            cli.command,
+            Command::Probe(ProbeOptions {
+                command: ProbeCommand::Upstream(ProbeUpstreamOptions {
+                    addr: "tls://dns.example.com:853".to_string(),
+                    config: Some(PathBuf::from("config.yaml")),
+                    working_dir: Some(PathBuf::from("/tmp/oxidns")),
+                    outbound: Some("remote".to_string()),
+                    dial_addr: Some("203.0.113.53".parse().unwrap()),
+                    bootstrap: Some("8.8.8.8:53".to_string()),
+                    bootstrap_version: Some(4),
+                    socks5: Some("127.0.0.1:1080".to_string()),
+                    port: Some(8853),
+                    insecure_skip_verify: true,
+                    timeout: Duration::from_millis(500),
+                    qname: "cloudflare.com.".to_string(),
+                    qtype: "AAAA".to_string(),
+                    serial_samples: 3,
+                    pipeline_concurrency: 8,
+                    pipeline_rounds: 4,
+                    json: true,
+                }),
+            })
+        );
+    }
+
     #[cfg(feature = "plugin-upgrade")]
     #[test]
     fn parse_upgrade_apply_with_options() {
@@ -416,7 +600,7 @@ mod tests {
             "--timeout",
             "2m",
             "--outbound",
-            "oversea",
+            "remote",
             "--socks5",
             "127.0.0.1:1080",
             "--insecure-skip-verify",
@@ -443,7 +627,7 @@ mod tests {
                 allow_prerelease: true,
                 force: false,
                 timeout: Duration::from_secs(120),
-                outbound: Some("oversea".to_string()),
+                outbound: Some("remote".to_string()),
                 socks5: Some("127.0.0.1:1080".to_string()),
                 insecure_skip_verify: true,
                 github_token: Some("ghp_test_token".to_string()),

--- a/src/cli/probe.rs
+++ b/src/cli/probe.rs
@@ -5,7 +5,7 @@
 
 use std::path::{Path, PathBuf};
 
-use serde::Deserialize;
+use serde_yaml_ng::{Mapping, Value};
 
 use crate::cli::{ProbeCommand, ProbeOptions, ProbeUpstreamOptions};
 use crate::config::env_expand;
@@ -105,40 +105,57 @@ fn read_probe_outbound_config(config_path: &Path) -> Result<NetworkOutboundConfi
             err
         ))
     })?;
-    let mut value: serde_yaml_ng::Value = serde_yaml_ng::from_str(&string).map_err(|err| {
+    let value: Value = serde_yaml_ng::from_str(&string).map_err(|err| {
         DnsError::config(format!(
             "failed to parse probe config {}: {}",
             config_path.display(),
             err
         ))
     })?;
-    env_expand::expand_env_in_value(&mut value).map_err(|err| {
+    let mut outbound_value = extract_probe_outbound_value(value).map_err(|err| {
         DnsError::config(format!(
-            "env expansion failed in probe config {}: {}",
+            "failed to read network.outbound from probe config {}: {}",
             config_path.display(),
             err
         ))
     })?;
-    let config: ProbeRuntimeConfig = serde_yaml_ng::from_value(value).map_err(|err| {
+    env_expand::expand_env_in_value(&mut outbound_value).map_err(|err| {
+        DnsError::config(format!(
+            "env expansion failed in probe network.outbound config {}: {}",
+            config_path.display(),
+            err
+        ))
+    })?;
+    serde_yaml_ng::from_value(outbound_value).map_err(|err| {
         DnsError::config(format!(
             "failed to deserialize network.outbound from probe config {}: {}",
             config_path.display(),
             err
         ))
-    })?;
-    Ok(config.network.outbound)
+    })
 }
 
-#[derive(Debug, Default, Deserialize)]
-struct ProbeRuntimeConfig {
-    #[serde(default)]
-    network: ProbeNetworkConfig,
+fn extract_probe_outbound_value(value: Value) -> std::result::Result<Value, &'static str> {
+    let mut root = match value {
+        Value::Mapping(root) => root,
+        Value::Null => return Ok(empty_mapping_value()),
+        _ => return Err("root must be a mapping"),
+    };
+    let Some(network) = root.remove("network") else {
+        return Ok(empty_mapping_value());
+    };
+    let mut network = match network {
+        Value::Mapping(network) => network,
+        Value::Null => return Ok(empty_mapping_value()),
+        _ => return Err("network must be a mapping"),
+    };
+    Ok(network
+        .remove("outbound")
+        .unwrap_or_else(empty_mapping_value))
 }
 
-#[derive(Debug, Default, Deserialize)]
-struct ProbeNetworkConfig {
-    #[serde(default)]
-    outbound: NetworkOutboundConfig,
+fn empty_mapping_value() -> Value {
+    Value::Mapping(Mapping::new())
 }
 
 fn print_human_report(report: &UpstreamProbeReport) {
@@ -377,6 +394,8 @@ network:
 plugins:
   - tag: ""
     type: ""
+    args:
+      path: ${OXIDNS_PROBE_REVIEW_UNSET_DO_NOT_DEFINE}
 "#,
         )
         .expect("config should write");

--- a/src/cli/probe.rs
+++ b/src/cli/probe.rs
@@ -3,15 +3,20 @@
 
 //! CLI support for runtime diagnostics.
 
+use std::net::IpAddr;
 use std::path::{Path, PathBuf};
+use std::sync::mpsc::RecvTimeoutError;
+use std::time::Duration;
 
 use serde_yaml_ng::{Mapping, Value};
 
 use crate::cli::{ProbeCommand, ProbeOptions, ProbeUpstreamOptions};
 use crate::config::env_expand;
-use crate::config::types::NetworkOutboundConfig;
+use crate::config::types::{NetworkOutboundConfig, OutboundProxyConfig};
 use crate::infra::error::{DnsError, Result};
+use crate::infra::network::dial::try_lookup_server_name;
 use crate::infra::network::outbound;
+use crate::infra::network::proxy::parse_socks5_opt_with_resolver;
 use crate::infra::network::upstream::UpstreamConfig;
 use crate::infra::network::upstream::probe::{
     ProbeProgress, ProbeStageReport, ProbeVerdict, UpstreamProbeConfig, UpstreamProbeReport,
@@ -26,7 +31,7 @@ pub fn run(options: ProbeOptions) -> Result<()> {
 
 fn run_upstream(options: ProbeUpstreamOptions) -> Result<()> {
     prepare_working_dir(options.working_dir.as_ref())?;
-    prepare_outbound(options.config.as_ref())?;
+    prepare_outbound(options.config.as_ref(), options.timeout)?;
 
     let qtype = parse_record_type(&options.qtype)?;
     let probe_config = UpstreamProbeConfig {
@@ -87,9 +92,9 @@ fn prepare_working_dir(working_dir: Option<&PathBuf>) -> Result<()> {
     Ok(())
 }
 
-fn prepare_outbound(config_path: Option<&PathBuf>) -> Result<()> {
+fn prepare_outbound(config_path: Option<&PathBuf>, timeout: Duration) -> Result<()> {
     if let Some(config_path) = config_path {
-        let outbound_config = read_probe_outbound_config(config_path)?;
+        let outbound_config = read_probe_outbound_config(config_path, timeout)?;
         outbound::install_global(&outbound_config)?;
     } else {
         outbound::clear_global();
@@ -97,7 +102,10 @@ fn prepare_outbound(config_path: Option<&PathBuf>) -> Result<()> {
     Ok(())
 }
 
-fn read_probe_outbound_config(config_path: &Path) -> Result<NetworkOutboundConfig> {
+fn read_probe_outbound_config(
+    config_path: &Path,
+    timeout: Duration,
+) -> Result<NetworkOutboundConfig> {
     let string = std::fs::read_to_string(config_path).map_err(|err| {
         DnsError::config(format!(
             "failed to read probe config {}: {}",
@@ -126,13 +134,71 @@ fn read_probe_outbound_config(config_path: &Path) -> Result<NetworkOutboundConfi
             err
         ))
     })?;
-    serde_yaml_ng::from_value(outbound_value).map_err(|err| {
+    let mut config: NetworkOutboundConfig =
+        serde_yaml_ng::from_value(outbound_value).map_err(|err| {
+            DnsError::config(format!(
+                "failed to deserialize network.outbound from probe config {}: {}",
+                config_path.display(),
+                err
+            ))
+        })?;
+    config.validate().map_err(|err| {
         DnsError::config(format!(
-            "failed to deserialize network.outbound from probe config {}: {}",
+            "invalid network.outbound in probe config {}: {}",
             config_path.display(),
             err
         ))
-    })
+    })?;
+    normalize_probe_outbound_proxies(&mut config, timeout)?;
+    Ok(config)
+}
+
+fn normalize_probe_outbound_proxies(
+    config: &mut NetworkOutboundConfig,
+    timeout: Duration,
+) -> Result<()> {
+    normalize_probe_outbound_proxies_with(config, timeout, lookup_host_with_timeout)
+}
+
+fn normalize_probe_outbound_proxies_with<F>(
+    config: &mut NetworkOutboundConfig,
+    timeout: Duration,
+    mut resolve_host: F,
+) -> Result<()>
+where
+    F: FnMut(&str, Duration) -> Result<IpAddr>,
+{
+    for (profile_name, profile) in &mut config.profiles {
+        let Some(OutboundProxyConfig::Socks5 { socks5 }) = &mut profile.proxy else {
+            continue;
+        };
+        let resolved = parse_socks5_opt_with_resolver(socks5, |host| resolve_host(host, timeout))
+            .ok_or_else(|| {
+            DnsError::config(format!(
+                "network.outbound profile '{}' has invalid socks5 proxy '{}'",
+                profile_name, socks5
+            ))
+        })?;
+        *socks5 = resolved.to_resolved_config_string();
+    }
+    Ok(())
+}
+
+fn lookup_host_with_timeout(host: &str, timeout: Duration) -> Result<IpAddr> {
+    let host = host.to_string();
+    let (sender, receiver) = std::sync::mpsc::channel();
+    std::thread::spawn(move || {
+        let _ = sender.send(try_lookup_server_name(&host));
+    });
+    match receiver.recv_timeout(timeout) {
+        Ok(result) => result,
+        Err(RecvTimeoutError::Timeout) => Err(DnsError::plugin(format!(
+            "system resolver timed out after {timeout:?}"
+        ))),
+        Err(RecvTimeoutError::Disconnected) => Err(DnsError::plugin(
+            "system resolver task was canceled".to_string(),
+        )),
+    }
 }
 
 fn extract_probe_outbound_value(value: Value) -> std::result::Result<Value, &'static str> {
@@ -370,9 +436,12 @@ fn verdict_label(verdict: ProbeVerdict) -> &'static str {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashMap;
+    use std::net::Ipv4Addr;
     use std::time::Duration;
 
     use super::*;
+    use crate::config::types::OutboundProfileConfig;
     use crate::infra::network::outbound::TestGlobalGuard;
     use crate::infra::network::upstream::ConnectionInfo;
 
@@ -400,7 +469,8 @@ plugins:
         )
         .expect("config should write");
 
-        prepare_outbound(Some(&config_path)).expect("outbound-only config should load");
+        prepare_outbound(Some(&config_path), Duration::from_secs(1))
+            .expect("outbound-only config should load");
 
         let info = ConnectionInfo::try_from(UpstreamConfig {
             tag: None,
@@ -430,5 +500,67 @@ plugins:
                 .profile(),
             "remote"
         );
+    }
+
+    #[test]
+    fn read_probe_outbound_config_validates_network_outbound() {
+        let tmp = tempfile::TempDir::new().expect("temp dir should create");
+        let config_path = tmp.path().join("config.yaml");
+        std::fs::write(
+            &config_path,
+            r#"
+network:
+  outbound:
+    profiles:
+      remote:
+        resolver:
+          nameservers:
+            - addr: tls://dns.google:853
+"#,
+        )
+        .expect("config should write");
+
+        let error = read_probe_outbound_config(&config_path, Duration::from_millis(10))
+            .expect_err("invalid outbound config should fail validation")
+            .to_string();
+
+        assert!(error.contains("requires dial_addr"), "{error}");
+    }
+
+    #[test]
+    fn normalize_probe_outbound_proxies_resolves_profile_proxy_hostname() {
+        let mut config = NetworkOutboundConfig {
+            default: None,
+            profiles: HashMap::from([(
+                "remote".to_string(),
+                OutboundProfileConfig {
+                    resolver: None,
+                    proxy: Some(OutboundProxyConfig::Socks5 {
+                        socks5: "user:pass@proxy.example.com:1080".to_string(),
+                    }),
+                },
+            )]),
+        };
+
+        normalize_probe_outbound_proxies_with(
+            &mut config,
+            Duration::from_millis(10),
+            |host, timeout| {
+                assert_eq!(host, "proxy.example.com");
+                assert_eq!(timeout, Duration::from_millis(10));
+                Ok(IpAddr::from(Ipv4Addr::LOCALHOST))
+            },
+        )
+        .expect("proxy should normalize");
+
+        let proxy = config
+            .profiles
+            .get("remote")
+            .and_then(|profile| profile.proxy.as_ref())
+            .expect("profile proxy should exist");
+        let OutboundProxyConfig::Socks5 { socks5 } = proxy else {
+            panic!("profile proxy should remain socks5");
+        };
+        assert_eq!(socks5, "user:pass@127.0.0.1:1080");
     }
 }

--- a/src/cli/probe.rs
+++ b/src/cli/probe.rs
@@ -1,0 +1,305 @@
+// SPDX-FileCopyrightText: 2025 Sven Shi
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+//! CLI support for runtime diagnostics.
+
+use std::path::PathBuf;
+
+use crate::cli::{ProbeCommand, ProbeOptions, ProbeUpstreamOptions};
+use crate::config;
+use crate::infra::error::{DnsError, Result};
+use crate::infra::network::outbound;
+use crate::infra::network::upstream::UpstreamConfig;
+use crate::infra::network::upstream::probe::{
+    ProbeProgress, ProbeStageReport, ProbeVerdict, UpstreamProbeConfig, UpstreamProbeReport,
+    parse_record_type, probe_upstream, probe_upstream_with_progress,
+};
+
+pub fn run(options: ProbeOptions) -> Result<()> {
+    match options.command {
+        ProbeCommand::Upstream(options) => run_upstream(options),
+    }
+}
+
+fn run_upstream(options: ProbeUpstreamOptions) -> Result<()> {
+    prepare_working_dir(options.working_dir.as_ref())?;
+    prepare_outbound(options.config.as_ref())?;
+
+    let qtype = parse_record_type(&options.qtype)?;
+    let probe_config = UpstreamProbeConfig {
+        upstream: UpstreamConfig {
+            tag: Some("cli_probe".to_string()),
+            addr: options.addr.clone(),
+            outbound: options.outbound.clone(),
+            dial_addr: options.dial_addr,
+            port: options.port,
+            bootstrap: options.bootstrap.clone(),
+            bootstrap_version: options.bootstrap_version,
+            socks5: options.socks5.clone(),
+            idle_timeout: None,
+            max_conns: None,
+            min_conns: None,
+            insecure_skip_verify: Some(options.insecure_skip_verify),
+            timeout: Some(options.timeout),
+            enable_pipeline: None,
+            enable_http3: None,
+            so_mark: None,
+            bind_to_device: None,
+        },
+        qname: options.qname.clone(),
+        qtype,
+        serial_samples: options.serial_samples,
+        pipeline_concurrency: options.pipeline_concurrency,
+        pipeline_rounds: options.pipeline_rounds,
+    };
+
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .map_err(|err| DnsError::runtime(format!("failed to create probe runtime: {err}")))?;
+    let report = if options.json {
+        runtime.block_on(probe_upstream(probe_config))?
+    } else {
+        runtime.block_on(probe_upstream_with_progress(probe_config, print_progress))?
+    };
+
+    if options.json {
+        println!("{}", serde_json::to_string_pretty(&report)?);
+    } else {
+        print_human_report(&report);
+    }
+    Ok(())
+}
+
+fn prepare_working_dir(working_dir: Option<&PathBuf>) -> Result<()> {
+    if let Some(working_dir) = working_dir {
+        std::env::set_current_dir(working_dir).map_err(|err| {
+            DnsError::runtime(format!(
+                "failed to switch working directory to {}: {}",
+                working_dir.display(),
+                err
+            ))
+        })?;
+    }
+    Ok(())
+}
+
+fn prepare_outbound(config_path: Option<&PathBuf>) -> Result<()> {
+    if let Some(config_path) = config_path {
+        let config = config::init(config_path)?;
+        outbound::install_global(&config.network.outbound)?;
+    } else {
+        outbound::clear_global();
+    }
+    Ok(())
+}
+
+fn print_human_report(report: &UpstreamProbeReport) {
+    println!();
+    println!("Upstream Probe");
+    println!("==============");
+    print_kv("Address", report.target.address.as_str());
+    print_kv("Protocol", report.target.protocol.as_str());
+    print_kv(
+        "Server",
+        format!("{}:{}", report.target.server_name, report.target.port).as_str(),
+    );
+    print_kv(
+        "Resolved IP",
+        report.target.resolved_ip.as_deref().unwrap_or("-"),
+    );
+    print_kv(
+        "Resolution",
+        report.target.resolution_source.as_deref().unwrap_or("-"),
+    );
+    if report.target.uses_bootstrap {
+        match report.target.resolution_error.as_deref() {
+            Some(error) => print_kv("Bootstrap", format!("failed ({error})").as_str()),
+            None => print_kv("Bootstrap", "resolved"),
+        }
+    }
+    print_kv(
+        "Query",
+        format!("{} {}", report.query.qname, report.query.qtype).as_str(),
+    );
+    print_kv("Timeout", format!("{}ms", report.timeout_ms).as_str());
+
+    print_serial_report(&report.serial);
+    print_pipeline_report(report);
+    println!();
+    println!("Recommendation");
+    println!("--------------");
+    println!("{}", report.recommendation);
+}
+
+fn print_serial_report(serial: &ProbeStageReport) {
+    println!();
+    println!("Serial Baseline");
+    println!("---------------");
+    print_kv("Verdict", verdict_label(serial.verdict));
+    print_kv(
+        "Success",
+        format!("{}/{}", serial.success_count, serial.total_queries).as_str(),
+    );
+    print_kv(
+        "Avg Latency",
+        latency_label(serial.average_latency_ms).as_str(),
+    );
+    print_kv("Failures", serial.failure_count.to_string().as_str());
+    if let Some(sample) = serial.results.iter().find(|result| result.ok) {
+        print_kv("Rcode", sample.rcode.as_deref().unwrap_or("unknown"));
+        print_kv(
+            "Answers",
+            sample.answer_count.unwrap_or_default().to_string().as_str(),
+        );
+        print_kv(
+            "Truncated",
+            sample.truncated.unwrap_or(false).to_string().as_str(),
+        );
+        print_kv(
+            "Recursion",
+            sample
+                .recursion_available
+                .unwrap_or(false)
+                .to_string()
+                .as_str(),
+        );
+    }
+    print_errors(&serial.errors);
+}
+
+fn print_pipeline_report(report: &UpstreamProbeReport) {
+    let pipeline = &report.pipeline;
+    println!();
+    println!(
+        "{}",
+        if matches!(report.target.protocol.as_str(), "tcp" | "dot") {
+            "Pipeline Probe"
+        } else {
+            "Concurrency Probe"
+        }
+    );
+    println!(
+        "{}",
+        if matches!(report.target.protocol.as_str(), "tcp" | "dot") {
+            "--------------"
+        } else {
+            "-----------------"
+        }
+    );
+    print_kv("Verdict", verdict_label(pipeline.verdict));
+    print_kv("Concurrency", pipeline.concurrency.to_string().as_str());
+    print_kv("Rounds", pipeline.rounds.to_string().as_str());
+    print_kv(
+        "Success",
+        format!("{}/{}", pipeline.success_count, pipeline.total_queries).as_str(),
+    );
+    print_kv("Timeouts", pipeline.timeout_count.to_string().as_str());
+    print_kv("Mismatches", pipeline.mismatch_count.to_string().as_str());
+    print_kv("Other Errors", pipeline.error_count.to_string().as_str());
+    print_kv(
+        "Avg Latency",
+        latency_label(pipeline.average_latency_ms).as_str(),
+    );
+    print_errors(&pipeline.errors);
+}
+
+fn print_kv(label: &str, value: &str) {
+    println!("{label:>14}: {value}");
+}
+
+fn print_errors(errors: &[String]) {
+    if errors.is_empty() {
+        return;
+    }
+    println!("        Errors:");
+    for error in errors.iter().take(5) {
+        println!("                - {error}");
+    }
+}
+
+fn print_progress(event: ProbeProgress) {
+    match event {
+        ProbeProgress::Preparing { address } => {
+            eprintln!("probe: preparing {address}");
+        }
+        ProbeProgress::Resolved {
+            server_name,
+            resolved_ip,
+            source,
+            error,
+        } => {
+            if let Some(error) = error {
+                eprintln!(
+                    "probe: resolving {server_name} via {} failed: {error}",
+                    source.unwrap_or_else(|| "unknown".to_string())
+                );
+            } else if let Some(ip) = resolved_ip {
+                eprintln!(
+                    "probe: resolved {server_name} -> {ip} ({})",
+                    source.unwrap_or_else(|| "unknown".to_string())
+                );
+            } else {
+                eprintln!("probe: no pre-resolved IP for {server_name}");
+            }
+        }
+        ProbeProgress::SerialStarted { samples } => {
+            eprintln!("probe: running serial baseline ({samples} sample(s))");
+        }
+        ProbeProgress::SerialSampleFinished { index, ok } => {
+            eprintln!(
+                "probe: serial sample #{} {}",
+                index + 1,
+                if ok { "ok" } else { "failed" }
+            );
+        }
+        ProbeProgress::ConcurrencyStarted {
+            protocol,
+            strategy,
+            concurrency,
+            rounds,
+        } => {
+            eprintln!(
+                "probe: running {protocol} {strategy} probe ({rounds} round(s), concurrency {concurrency})"
+            );
+        }
+        ProbeProgress::ConcurrencyRoundFinished {
+            round,
+            success_count,
+            total_queries,
+        } => {
+            eprintln!(
+                "probe: concurrency round #{} finished ({success_count}/{total_queries} ok)",
+                round + 1
+            );
+        }
+        ProbeProgress::Finished {
+            serial,
+            concurrency,
+        } => {
+            eprintln!(
+                "probe: finished (serial={}, concurrency={})",
+                verdict_label(serial),
+                verdict_label(concurrency)
+            );
+        }
+    }
+}
+
+fn latency_label(value: Option<u128>) -> String {
+    value
+        .map(|latency| format!("{latency}ms"))
+        .unwrap_or_else(|| "n/a".to_string())
+}
+
+fn verdict_label(verdict: ProbeVerdict) -> &'static str {
+    match verdict {
+        ProbeVerdict::Reachable => "reachable",
+        ProbeVerdict::Unreachable => "unreachable",
+        ProbeVerdict::Supported => "supported",
+        ProbeVerdict::Unsupported => "unsupported",
+        ProbeVerdict::Unstable => "unstable",
+        ProbeVerdict::Inconclusive => "inconclusive",
+        ProbeVerdict::NotApplicable => "not_applicable",
+    }
+}

--- a/src/cli/probe.rs
+++ b/src/cli/probe.rs
@@ -3,10 +3,13 @@
 
 //! CLI support for runtime diagnostics.
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
+
+use serde::Deserialize;
 
 use crate::cli::{ProbeCommand, ProbeOptions, ProbeUpstreamOptions};
-use crate::config;
+use crate::config::env_expand;
+use crate::config::types::NetworkOutboundConfig;
 use crate::infra::error::{DnsError, Result};
 use crate::infra::network::outbound;
 use crate::infra::network::upstream::UpstreamConfig;
@@ -86,12 +89,56 @@ fn prepare_working_dir(working_dir: Option<&PathBuf>) -> Result<()> {
 
 fn prepare_outbound(config_path: Option<&PathBuf>) -> Result<()> {
     if let Some(config_path) = config_path {
-        let config = config::init(config_path)?;
-        outbound::install_global(&config.network.outbound)?;
+        let outbound_config = read_probe_outbound_config(config_path)?;
+        outbound::install_global(&outbound_config)?;
     } else {
         outbound::clear_global();
     }
     Ok(())
+}
+
+fn read_probe_outbound_config(config_path: &Path) -> Result<NetworkOutboundConfig> {
+    let string = std::fs::read_to_string(config_path).map_err(|err| {
+        DnsError::config(format!(
+            "failed to read probe config {}: {}",
+            config_path.display(),
+            err
+        ))
+    })?;
+    let mut value: serde_yaml_ng::Value = serde_yaml_ng::from_str(&string).map_err(|err| {
+        DnsError::config(format!(
+            "failed to parse probe config {}: {}",
+            config_path.display(),
+            err
+        ))
+    })?;
+    env_expand::expand_env_in_value(&mut value).map_err(|err| {
+        DnsError::config(format!(
+            "env expansion failed in probe config {}: {}",
+            config_path.display(),
+            err
+        ))
+    })?;
+    let config: ProbeRuntimeConfig = serde_yaml_ng::from_value(value).map_err(|err| {
+        DnsError::config(format!(
+            "failed to deserialize network.outbound from probe config {}: {}",
+            config_path.display(),
+            err
+        ))
+    })?;
+    Ok(config.network.outbound)
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct ProbeRuntimeConfig {
+    #[serde(default)]
+    network: ProbeNetworkConfig,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct ProbeNetworkConfig {
+    #[serde(default)]
+    outbound: NetworkOutboundConfig,
 }
 
 fn print_human_report(report: &UpstreamProbeReport) {
@@ -301,5 +348,68 @@ fn verdict_label(verdict: ProbeVerdict) -> &'static str {
         ProbeVerdict::Unstable => "unstable",
         ProbeVerdict::Inconclusive => "inconclusive",
         ProbeVerdict::NotApplicable => "not_applicable",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use super::*;
+    use crate::infra::network::outbound::TestGlobalGuard;
+    use crate::infra::network::upstream::ConnectionInfo;
+
+    #[test]
+    fn prepare_outbound_loads_only_network_outbound_from_config() {
+        let _guard = TestGlobalGuard::clean();
+        let tmp = tempfile::TempDir::new().expect("temp dir should create");
+        let config_path = tmp.path().join("config.yaml");
+        std::fs::write(
+            &config_path,
+            r#"
+network:
+  outbound:
+    profiles:
+      remote:
+        resolver:
+          nameservers:
+            - addr: 1.1.1.1:53
+plugins:
+  - tag: ""
+    type: ""
+"#,
+        )
+        .expect("config should write");
+
+        prepare_outbound(Some(&config_path)).expect("outbound-only config should load");
+
+        let info = ConnectionInfo::try_from(UpstreamConfig {
+            tag: None,
+            addr: "tls://dns.example.invalid:853".to_string(),
+            outbound: Some("remote".to_string()),
+            dial_addr: None,
+            port: None,
+            bootstrap: None,
+            bootstrap_version: None,
+            socks5: None,
+            idle_timeout: None,
+            max_conns: None,
+            min_conns: None,
+            insecure_skip_verify: None,
+            timeout: Some(Duration::from_secs(1)),
+            enable_pipeline: None,
+            enable_http3: None,
+            so_mark: None,
+            bind_to_device: None,
+        })
+        .expect("outbound resolver should be available to upstream config");
+
+        assert_eq!(
+            info.bootstrap
+                .as_ref()
+                .expect("outbound resolver should be injected")
+                .profile(),
+            "remote"
+        );
     }
 }

--- a/src/cli/probe.rs
+++ b/src/cli/probe.rs
@@ -31,7 +31,11 @@ pub fn run(options: ProbeOptions) -> Result<()> {
 
 fn run_upstream(options: ProbeUpstreamOptions) -> Result<()> {
     prepare_working_dir(options.working_dir.as_ref())?;
-    prepare_outbound(options.config.as_ref(), options.timeout)?;
+    prepare_outbound(
+        options.config.as_ref(),
+        options.outbound.as_deref(),
+        options.timeout,
+    )?;
 
     let qtype = parse_record_type(&options.qtype)?;
     let probe_config = UpstreamProbeConfig {
@@ -92,9 +96,13 @@ fn prepare_working_dir(working_dir: Option<&PathBuf>) -> Result<()> {
     Ok(())
 }
 
-fn prepare_outbound(config_path: Option<&PathBuf>, timeout: Duration) -> Result<()> {
+fn prepare_outbound(
+    config_path: Option<&PathBuf>,
+    selected_outbound: Option<&str>,
+    timeout: Duration,
+) -> Result<()> {
     if let Some(config_path) = config_path {
-        let outbound_config = read_probe_outbound_config(config_path, timeout)?;
+        let outbound_config = read_probe_outbound_config(config_path, selected_outbound, timeout)?;
         outbound::install_global(&outbound_config)?;
     } else {
         outbound::clear_global();
@@ -104,6 +112,7 @@ fn prepare_outbound(config_path: Option<&PathBuf>, timeout: Duration) -> Result<
 
 fn read_probe_outbound_config(
     config_path: &Path,
+    selected_outbound: Option<&str>,
     timeout: Duration,
 ) -> Result<NetworkOutboundConfig> {
     let string = std::fs::read_to_string(config_path).map_err(|err| {
@@ -142,6 +151,7 @@ fn read_probe_outbound_config(
                 err
             ))
         })?;
+    retain_probe_outbound_profiles(&mut config, selected_outbound)?;
     config.validate().map_err(|err| {
         DnsError::config(format!(
             "invalid network.outbound in probe config {}: {}",
@@ -151,6 +161,35 @@ fn read_probe_outbound_config(
     })?;
     normalize_probe_outbound_proxies(&mut config, timeout)?;
     Ok(config)
+}
+
+fn retain_probe_outbound_profiles(
+    config: &mut NetworkOutboundConfig,
+    selected_outbound: Option<&str>,
+) -> Result<()> {
+    if selected_outbound.is_some_and(|name| name.trim().is_empty()) {
+        return Err(DnsError::config("probe outbound profile cannot be empty"));
+    }
+    let selected_profile = selected_outbound
+        .map(str::trim)
+        .map(ToOwned::to_owned)
+        .or_else(|| config.default.clone());
+
+    let Some(profile_name) = selected_profile else {
+        config.profiles.clear();
+        config.default = None;
+        return Ok(());
+    };
+    let profile = config.profiles.remove(&profile_name).ok_or_else(|| {
+        DnsError::config(format!(
+            "network.outbound profile '{}' selected by probe was not found",
+            profile_name
+        ))
+    })?;
+    config.profiles.clear();
+    config.profiles.insert(profile_name.clone(), profile);
+    config.default = Some(profile_name);
+    Ok(())
 }
 
 fn normalize_probe_outbound_proxies(
@@ -469,7 +508,7 @@ plugins:
         )
         .expect("config should write");
 
-        prepare_outbound(Some(&config_path), Duration::from_secs(1))
+        prepare_outbound(Some(&config_path), Some("remote"), Duration::from_secs(1))
             .expect("outbound-only config should load");
 
         let info = ConnectionInfo::try_from(UpstreamConfig {
@@ -520,11 +559,70 @@ network:
         )
         .expect("config should write");
 
-        let error = read_probe_outbound_config(&config_path, Duration::from_millis(10))
-            .expect_err("invalid outbound config should fail validation")
-            .to_string();
+        let error =
+            read_probe_outbound_config(&config_path, Some("remote"), Duration::from_millis(10))
+                .expect_err("invalid outbound config should fail validation")
+                .to_string();
 
         assert!(error.contains("requires dial_addr"), "{error}");
+    }
+
+    #[test]
+    fn retain_probe_outbound_profiles_keeps_only_selected_profile() {
+        let mut config = NetworkOutboundConfig {
+            default: Some("standby".to_string()),
+            profiles: HashMap::from([
+                (
+                    "remote".to_string(),
+                    OutboundProfileConfig {
+                        resolver: None,
+                        proxy: Some(OutboundProxyConfig::Socks5 {
+                            socks5: "proxy.example.com:1080".to_string(),
+                        }),
+                    },
+                ),
+                (
+                    "standby".to_string(),
+                    OutboundProfileConfig {
+                        resolver: None,
+                        proxy: Some(OutboundProxyConfig::Socks5 {
+                            socks5: "standby.example.com:1080".to_string(),
+                        }),
+                    },
+                ),
+            ]),
+        };
+
+        retain_probe_outbound_profiles(&mut config, Some("remote"))
+            .expect("selected profile should be retained");
+        normalize_probe_outbound_proxies_with(
+            &mut config,
+            Duration::from_millis(10),
+            |host, timeout| {
+                assert_eq!(host, "proxy.example.com");
+                assert_eq!(timeout, Duration::from_millis(10));
+                Ok(IpAddr::from(Ipv4Addr::LOCALHOST))
+            },
+        )
+        .expect("selected proxy should normalize");
+
+        assert_eq!(config.default.as_deref(), Some("remote"));
+        assert_eq!(config.profiles.len(), 1);
+        assert!(config.profiles.contains_key("remote"));
+    }
+
+    #[test]
+    fn retain_probe_outbound_profiles_rejects_missing_selected_profile() {
+        let mut config = NetworkOutboundConfig {
+            default: None,
+            profiles: HashMap::new(),
+        };
+
+        let error = retain_probe_outbound_profiles(&mut config, Some("missing"))
+            .expect_err("missing profile should fail")
+            .to_string();
+
+        assert!(error.contains("missing"), "{error}");
     }
 
     #[test]

--- a/src/cli/probe.rs
+++ b/src/cli/probe.rs
@@ -515,7 +515,7 @@ network:
       remote:
         resolver:
           nameservers:
-            - addr: tls://dns.google:853
+            - addr: dns.google:53
 "#,
         )
         .expect("config should write");

--- a/src/cli/upgrade.rs
+++ b/src/cli/upgrade.rs
@@ -632,7 +632,7 @@ api:
 network:
   outbound:
     profiles:
-      oversea:
+      remote:
         resolver:
           nameservers:
             - addr: tls://dns.google:853

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -880,9 +880,9 @@ mod tests {
             r#"
 network:
   outbound:
-    default: oversea
+    default: remote
     profiles:
-      oversea:
+      remote:
         resolver:
           nameservers:
             - addr: 1.1.1.1:53
@@ -906,9 +906,9 @@ plugins:
             r#"
 network:
   outbound:
-    default: " oversea "
+    default: " remote "
     profiles:
-      oversea:
+      remote:
         resolver: system
 plugins:
   - tag: ok
@@ -930,7 +930,7 @@ plugins:
 network:
   outbound:
     profiles:
-      " oversea ":
+      " remote ":
         resolver: system
 plugins:
   - tag: ok
@@ -952,7 +952,7 @@ plugins:
 network:
   outbound:
     profiles:
-      oversea:
+      remote:
         resolver:
           nameservers:
             - addr: tcp://1.1.1.1:53
@@ -977,7 +977,7 @@ plugins:
 network:
   outbound:
     profiles:
-      oversea:
+      remote:
         resolver:
           nameservers:
             - addr: udp://[2001:4860:4860::8888]:53
@@ -998,7 +998,7 @@ plugins:
 network:
   outbound:
     profiles:
-      oversea:
+      remote:
         resolver:
           nameservers:
             - addr: udp://2001:4860:4860::8888:53
@@ -1022,7 +1022,7 @@ plugins:
 network:
   outbound:
     profiles:
-      oversea:
+      remote:
         resolver:
           bootstrap:
             - 1.1.1.1:53
@@ -1043,7 +1043,7 @@ plugins:
 network:
   outbound:
     profiles:
-      oversea:
+      remote:
         resolver:
           nameservers:
             - addr: tls://dns.google:853
@@ -1067,7 +1067,7 @@ plugins:
 network:
   outbound:
     profiles:
-      oversea:
+      remote:
         resolver:
           nameservers:
             - addr: doq://94.140.14.14:853
@@ -1094,7 +1094,7 @@ plugins:
 network:
   outbound:
     profiles:
-      oversea:
+      remote:
         resolver:
           nameservers:
             - addr: ftp://1.1.1.1:53
@@ -1119,7 +1119,7 @@ plugins:
 network:
   outbound:
     profiles:
-      oversea:
+      remote:
         resolver:
           nameservers:
             - addr: tls://1.1.1.1:853
@@ -1144,7 +1144,7 @@ plugins:
 network:
   outbound:
     profiles:
-      oversea:
+      remote:
         resolver:
           nameservers:
             - addr: https://1.1.1.1/dns-query
@@ -1169,7 +1169,7 @@ plugins:
 network:
   outbound:
     profiles:
-      oversea:
+      remote:
         resolver:
           nameservers:
             - addr: doq://94.140.14.14:853
@@ -1194,7 +1194,7 @@ plugins:
 network:
   outbound:
     profiles:
-      oversea:
+      remote:
         resolver:
           nameservers:
             - addr: h3://1.1.1.1/dns-query
@@ -1218,7 +1218,7 @@ plugins:
 network:
   outbound:
     profiles:
-      oversea:
+      remote:
         resolver:
           nameservers:
             - addr: 1.1.1.1:53
@@ -1243,7 +1243,7 @@ plugins:
 network:
   outbound:
     profiles:
-      oversea:
+      remote:
         proxy:
           socks5: user:pass@proxy.example.com:1080
 plugins:
@@ -1263,7 +1263,7 @@ plugins:
 network:
   outbound:
     profiles:
-      oversea:
+      remote:
         proxy:
           socks5: 127.0.0.1
 plugins:

--- a/src/infra/network/metrics.rs
+++ b/src/infra/network/metrics.rs
@@ -420,7 +420,7 @@ mod tests {
         reset_metrics_for_tests();
         init().expect("network metrics should register");
 
-        let profile = profile_scope("oversea");
+        let profile = profile_scope("remote");
         resolver_cache_hit(&profile);
         resolver_cache_miss(&profile);
         let started_at_ms = AppClock::elapsed_millis();
@@ -439,7 +439,7 @@ mod tests {
         assert!(output.contains("network_resolver_refresh_total"));
         assert!(output.contains("network_resolver_error_total"));
         assert!(output.contains("network_upstream_pool_refresh_total"));
-        assert!(output.contains("outbound_profile=\"oversea\""));
-        assert!(output.contains("outbound_profile=\"oversea\",protocol=\"udp\",reason=\"init\""));
+        assert!(output.contains("outbound_profile=\"remote\""));
+        assert!(output.contains("outbound_profile=\"remote\",protocol=\"udp\",reason=\"init\""));
     }
 }

--- a/src/infra/network/outbound.rs
+++ b/src/infra/network/outbound.rs
@@ -361,7 +361,7 @@ mod tests {
         let config = NetworkOutboundConfig {
             default: None,
             profiles: HashMap::from([(
-                "oversea".to_string(),
+                "remote".to_string(),
                 OutboundProfileConfig {
                     resolver: Some(OutboundResolverConfig::Nameservers(
                         OutboundResolverDetailedConfig {
@@ -382,21 +382,21 @@ mod tests {
         };
         let runtime = OutboundRuntime::from_config(&config).expect("outbound config should parse");
         let policy = runtime
-            .resolve_policy(Some("oversea"), None)
+            .resolve_policy(Some("remote"), None)
             .expect("profile should resolve");
         assert!(policy.proxy().is_some());
         let (resolver, _) = policy
             .resolver()
             .expect("profile resolver should be configured");
-        assert_eq!(resolver.profile(), "oversea");
+        assert_eq!(resolver.profile(), "remote");
     }
 
     #[test]
     fn test_resolve_policy_default_keeps_profile_metric_label() {
         let config = NetworkOutboundConfig {
-            default: Some("oversea".to_string()),
+            default: Some("remote".to_string()),
             profiles: HashMap::from([(
-                "oversea".to_string(),
+                "remote".to_string(),
                 OutboundProfileConfig {
                     resolver: Some(OutboundResolverConfig::Nameservers(
                         OutboundResolverDetailedConfig {
@@ -421,7 +421,7 @@ mod tests {
         let (resolver, _) = policy
             .resolver()
             .expect("default profile resolver should be configured");
-        assert_eq!(resolver.profile(), "oversea");
+        assert_eq!(resolver.profile(), "remote");
     }
 
     #[test]

--- a/src/infra/network/proxy.rs
+++ b/src/infra/network/proxy.rs
@@ -39,6 +39,21 @@ pub struct Socks5Opt {
     pub(crate) socket_addr: SocketAddr,
 }
 
+impl Socks5Opt {
+    pub(crate) fn to_resolved_config_string(&self) -> String {
+        let host = match self.socket_addr.ip() {
+            IpAddr::V4(ip) => ip.to_string(),
+            IpAddr::V6(ip) => format!("[{ip}]"),
+        };
+        match (self.username.as_deref(), self.password.as_deref()) {
+            (Some(username), Some(password)) => {
+                format!("{username}:{password}@{host}:{}", self.socket_addr.port())
+            }
+            _ => format!("{host}:{}", self.socket_addr.port()),
+        }
+    }
+}
+
 #[derive(Debug)]
 struct Socks5Parts {
     username: Option<String>,

--- a/src/infra/network/resolver/name.rs
+++ b/src/infra/network/resolver/name.rs
@@ -510,8 +510,8 @@ mod tests {
     #[tokio::test]
     async fn resolver_metrics_record_hit_miss_refresh_and_error() {
         start_clock();
-        let profile = network_metrics::profile_scope("oversea");
-        let before = network_metrics::snapshot_for_profile_for_tests("oversea");
+        let profile = network_metrics::profile_scope("remote");
+        let before = network_metrics::snapshot_for_profile_for_tests("remote");
         let client = Arc::new(FakeClient::new(
             "fake",
             vec![
@@ -551,7 +551,7 @@ mod tests {
         assert_eq!(second, first);
         assert!(err.to_string().contains("boom"));
 
-        let after = network_metrics::snapshot_for_profile_for_tests("oversea");
+        let after = network_metrics::snapshot_for_profile_for_tests("remote");
         assert!(
             after.resolver_cache_hit_total > before.resolver_cache_hit_total,
             "expected resolver cache hit metric to increase: before={before:?}, after={after:?}"

--- a/src/infra/network/upstream/config.rs
+++ b/src/infra/network/upstream/config.rs
@@ -311,7 +311,7 @@ impl ConnectionInfo {
     pub(crate) const DEFAULT_MAX_CONNS_LOAD: u16 = 64;
     pub(crate) const DEFAULT_MAX_CONNS_SIZE: usize = 64;
     pub(crate) const DEFAULT_MIN_CONNS_SIZE: usize = 0;
-    const DEFAULT_QUERY_TIMEOUT: Duration = Duration::from_secs(5);
+    pub(crate) const DEFAULT_QUERY_TIMEOUT: Duration = Duration::from_secs(5);
     pub(crate) const MAX_CONFIGURED_CONNS_SIZE: usize = 4096;
 
     pub fn with_addr(addr: &str) -> Result<Self> {

--- a/src/infra/network/upstream/mod.rs
+++ b/src/infra/network/upstream/mod.rs
@@ -14,6 +14,7 @@ mod config;
 mod conn;
 mod pool;
 mod pooled;
+pub mod probe;
 mod traits;
 
 pub use builder::UpstreamBuilder;

--- a/src/infra/network/upstream/probe.rs
+++ b/src/infra/network/upstream/probe.rs
@@ -267,6 +267,12 @@ struct ResolutionProbe {
     apply_to_connection: bool,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum BlockingProbeError {
+    TimedOut,
+    Canceled,
+}
+
 fn validate_probe_config(config: &UpstreamProbeConfig) -> Result<()> {
     if config.serial_samples == 0 {
         return Err(DnsError::config(
@@ -332,22 +338,36 @@ where
     F: FnOnce(String) -> Option<Socks5Opt> + Send + 'static,
 {
     let raw_owned = raw.to_string();
-    match tokio::time::timeout(
-        timeout,
-        tokio::task::spawn_blocking(move || parse(raw_owned)),
-    )
-    .await
-    {
-        Ok(Ok(Some(socks5))) => Ok(socks5.to_resolved_config_string()),
-        Ok(Ok(None)) => Err(DnsError::plugin(format!(
+    match run_probe_blocking_with_timeout(timeout, move || parse(raw_owned)).await {
+        Ok(Some(socks5)) => Ok(socks5.to_resolved_config_string()),
+        Ok(None) => Err(DnsError::plugin(format!(
             "upstream has invalid socks5 proxy '{raw}'"
         ))),
-        Ok(Err(err)) => Err(DnsError::plugin(format!(
-            "SOCKS5 proxy resolver task failed: {err}"
-        ))),
-        Err(_) => Err(DnsError::plugin(format!(
+        Err(BlockingProbeError::Canceled) => Err(DnsError::plugin(
+            "SOCKS5 proxy resolver task was canceled".to_string(),
+        )),
+        Err(BlockingProbeError::TimedOut) => Err(DnsError::plugin(format!(
             "SOCKS5 proxy resolution timed out after {timeout:?}"
         ))),
+    }
+}
+
+async fn run_probe_blocking_with_timeout<T, F>(
+    timeout: Duration,
+    operation: F,
+) -> std::result::Result<T, BlockingProbeError>
+where
+    T: Send + 'static,
+    F: FnOnce() -> T + Send + 'static,
+{
+    let (sender, receiver) = tokio::sync::oneshot::channel();
+    std::thread::spawn(move || {
+        let _ = sender.send(operation());
+    });
+    match tokio::time::timeout(timeout, receiver).await {
+        Ok(Ok(value)) => Ok(value),
+        Ok(Err(_)) => Err(BlockingProbeError::Canceled),
+        Err(_) => Err(BlockingProbeError::TimedOut),
     }
 }
 
@@ -390,31 +410,30 @@ async fn resolve_remote_ip(info: &ConnectionInfo, has_dial_addr: bool) -> Resolu
     }
 
     let server_name = info.server_name.clone();
-    match tokio::time::timeout(
-        info.timeout,
-        tokio::task::spawn_blocking(move || try_lookup_server_name(&server_name)),
-    )
+    match run_probe_blocking_with_timeout(info.timeout, move || {
+        try_lookup_server_name(&server_name)
+    })
     .await
     {
-        Ok(Ok(Ok(ip))) => ResolutionProbe {
+        Ok(Ok(ip)) => ResolutionProbe {
             ip: Some(ip),
             source: Some("system".to_string()),
             error: None,
             apply_to_connection: info.socks5.is_none(),
         },
-        Ok(Ok(Err(err))) => ResolutionProbe {
+        Ok(Err(err)) => ResolutionProbe {
             ip: None,
             source: Some("system".to_string()),
             error: Some(err.to_string()),
             apply_to_connection: false,
         },
-        Ok(Err(err)) => ResolutionProbe {
+        Err(BlockingProbeError::Canceled) => ResolutionProbe {
             ip: None,
             source: Some("system".to_string()),
-            error: Some(format!("system resolver task failed: {err}")),
+            error: Some("system resolver task was canceled".to_string()),
             apply_to_connection: false,
         },
-        Err(_) => ResolutionProbe {
+        Err(BlockingProbeError::TimedOut) => ResolutionProbe {
             ip: None,
             source: Some("system".to_string()),
             error: Some(format!(
@@ -1176,12 +1195,21 @@ fn parse_name(raw: &str) -> Result<Name> {
 
 fn pipeline_name(base: &str, round: usize, index: usize) -> Result<Name> {
     let base = base.trim_end_matches('.');
+    let fallback = if base.is_empty() {
+        None
+    } else {
+        Some(parse_name(format!("{base}.").as_str())?)
+    };
     let raw = if base.is_empty() {
         format!("oxidns-probe-{round}-{index}.")
     } else {
         format!("oxidns-probe-{round}-{index}.{base}.")
     };
-    parse_name(&raw)
+    match parse_name(&raw) {
+        Ok(name) => Ok(name),
+        Err(_) => fallback
+            .ok_or_else(|| DnsError::protocol(format!("invalid probe pipeline qname '{}'", raw))),
+    }
 }
 
 fn probe_query_id(round: usize, index: usize) -> u16 {
@@ -1519,6 +1547,29 @@ mod tests {
     #[test]
     fn parse_record_type_accepts_lowercase() {
         assert_eq!(parse_record_type("aaaa").unwrap(), RecordType::AAAA);
+    }
+
+    #[test]
+    fn pipeline_name_uses_synthetic_prefix_when_it_fits() {
+        let name = pipeline_name("example.com.", 1, 2).expect("pipeline name should parse");
+
+        assert_eq!(name.to_fqdn(), "oxidns-probe-1-2.example.com.");
+    }
+
+    #[test]
+    fn pipeline_name_falls_back_to_base_when_prefix_exceeds_dns_limit() {
+        let base = format!(
+            "{}.{}.{}.{}.",
+            "a".repeat(63),
+            "b".repeat(63),
+            "c".repeat(63),
+            "d".repeat(61)
+        );
+        parse_name(&base).expect("base qname should be valid");
+
+        let name = pipeline_name(&base, 0, 0).expect("fallback name should parse");
+
+        assert_eq!(name.to_fqdn(), base);
     }
 
     #[test]

--- a/src/infra/network/upstream/probe.rs
+++ b/src/infra/network/upstream/probe.rs
@@ -236,7 +236,7 @@ where
     let pipeline = run_pipeline_probe(
         &mut connection_info,
         &config,
-        serial.success_count > 0,
+        serial_baseline_is_clean(&serial),
         &mut progress,
     )
     .await;
@@ -410,7 +410,7 @@ async fn resolve_remote_ip(info: &ConnectionInfo, has_dial_addr: bool) -> Resolu
         };
     }
 
-    if info.socks5.is_some() {
+    if should_delegate_name_resolution_to_socks5(info) {
         return ResolutionProbe {
             ip: None,
             source: Some("proxy".to_string()),
@@ -453,6 +453,12 @@ async fn resolve_remote_ip(info: &ConnectionInfo, has_dial_addr: bool) -> Resolu
             apply_to_connection: false,
         },
     }
+}
+
+fn should_delegate_name_resolution_to_socks5(info: &ConnectionInfo) -> bool {
+    // Match upstream dialing: SOCKS5 receives the domain only when no configured
+    // resolver or static remote IP can provide a concrete connection address.
+    info.remote_ip.is_none() && info.bootstrap.is_none() && info.socks5.is_some()
 }
 
 fn resolution_blocks_direct_probe(info: &ConnectionInfo, resolution: &ResolutionProbe) -> bool {
@@ -560,10 +566,14 @@ where
     ProbeStageReport::from_results(ProbeVerdict::Unreachable, results)
 }
 
+fn serial_baseline_is_clean(serial: &ProbeStageReport) -> bool {
+    serial.total_queries > 0 && serial.success_count == serial.total_queries
+}
+
 async fn run_pipeline_probe<F>(
     connection_info: &mut ConnectionInfo,
     config: &UpstreamProbeConfig,
-    serial_reachable: bool,
+    serial_baseline_clean: bool,
     progress: &mut F,
 ) -> PipelineProbeReport
 where
@@ -581,11 +591,12 @@ where
         rounds: config.pipeline_rounds,
     });
 
-    if !serial_reachable {
+    if !serial_baseline_clean {
         return PipelineProbeReport::inconclusive(
             config.pipeline_concurrency,
             config.pipeline_rounds,
-            "serial baseline failed; pipeline behavior cannot be isolated".to_string(),
+            "serial baseline was not fully successful; concurrency behavior cannot be isolated"
+                .to_string(),
         );
     }
 
@@ -1626,6 +1637,71 @@ mod tests {
         assert_eq!(report.pipeline.verdict, ProbeVerdict::Inconclusive);
     }
 
+    #[tokio::test]
+    async fn probe_concurrency_is_inconclusive_when_serial_is_partial() {
+        let config = UpstreamProbeConfig {
+            upstream: make_upstream_config(
+                "tcp://127.0.0.1:9".to_string(),
+                Duration::from_millis(10),
+            ),
+            qname: "example.com.".to_string(),
+            qtype: RecordType::A,
+            serial_samples: 2,
+            pipeline_concurrency: 2,
+            pipeline_rounds: 1,
+        };
+        let serial = ProbeStageReport::from_results(
+            ProbeVerdict::Reachable,
+            vec![
+                ProbeQueryResult {
+                    index: 0,
+                    query_name: "example.com.".to_string(),
+                    query_id: 1,
+                    ok: true,
+                    latency_ms: Some(1),
+                    response_id: Some(1),
+                    rcode: Some("NoError".to_string()),
+                    answer_count: Some(1),
+                    authoritative: Some(false),
+                    truncated: Some(false),
+                    recursion_available: Some(true),
+                    error_kind: None,
+                    error: None,
+                },
+                query_error_result(
+                    1,
+                    2,
+                    "example.com.".to_string(),
+                    ERROR_KIND_TIMEOUT,
+                    "timed out waiting for serial response".to_string(),
+                    Some(10),
+                ),
+            ],
+        );
+        let mut connection_info =
+            ConnectionInfo::with_addr("tcp://127.0.0.1:9").expect("addr should parse");
+        let mut progress = |_| {};
+
+        let pipeline = run_pipeline_probe(
+            &mut connection_info,
+            &config,
+            serial_baseline_is_clean(&serial),
+            &mut progress,
+        )
+        .await;
+
+        assert_eq!(serial.success_count, 1);
+        assert!(!serial_baseline_is_clean(&serial));
+        assert_eq!(pipeline.verdict, ProbeVerdict::Inconclusive);
+        assert_eq!(pipeline.total_queries, 0);
+        assert!(
+            pipeline
+                .errors
+                .iter()
+                .any(|error| error.contains("serial baseline was not fully successful"))
+        );
+    }
+
     #[test]
     fn parse_record_type_accepts_lowercase() {
         assert_eq!(parse_record_type("aaaa").unwrap(), RecordType::AAAA);
@@ -1709,6 +1785,32 @@ mod tests {
         assert_eq!(resolution.source.as_deref(), Some("proxy"));
         assert_eq!(resolution.error, None);
         assert!(!resolution.apply_to_connection);
+    }
+
+    #[tokio::test]
+    async fn resolve_remote_ip_prefers_bootstrap_over_proxy_resolution() {
+        let answer_ip = Ipv4Addr::new(192, 0, 2, 54);
+        let resolver_addr = start_fake_bootstrap_resolver(answer_ip).await;
+        let resolver = Arc::new(
+            NameResolver::new(vec![resolver_addr.to_string()], Some(4))
+                .expect("bootstrap resolver should build"),
+        );
+        let mut info =
+            ConnectionInfo::with_addr("tcp://dns.example.invalid:53").expect("addr should parse");
+        info.bootstrap = Some(resolver);
+        info.socks5 = Some(Socks5Opt {
+            username: None,
+            password: None,
+            socket_addr: SocketAddr::from((Ipv4Addr::LOCALHOST, 1080)),
+        });
+        info.timeout = Duration::from_millis(500);
+
+        let resolution = resolve_remote_ip(&info, false).await;
+
+        assert_eq!(resolution.ip, Some(IpAddr::V4(answer_ip)));
+        assert_eq!(resolution.source.as_deref(), Some("bootstrap"));
+        assert_eq!(resolution.error, None);
+        assert!(resolution.apply_to_connection);
     }
 
     #[tokio::test]

--- a/src/infra/network/upstream/probe.rs
+++ b/src/infra/network/upstream/probe.rs
@@ -7,7 +7,7 @@ use std::collections::HashMap;
 use std::net::IpAddr;
 use std::str::FromStr;
 use std::sync::Arc;
-use std::time::{Duration, Instant};
+use std::time::Instant;
 
 use futures::StreamExt;
 use futures::stream::FuturesUnordered;
@@ -284,7 +284,19 @@ fn validate_probe_config(config: &UpstreamProbeConfig) -> Result<()> {
             "probe pipeline_rounds must be <= {MAX_PROBE_SAMPLES}"
         )));
     }
+    if pipeline_sample_count(config)? > MAX_PROBE_SAMPLES {
+        return Err(DnsError::config(format!(
+            "probe pipeline_concurrency * pipeline_rounds must be <= {MAX_PROBE_SAMPLES}"
+        )));
+    }
     Ok(())
+}
+
+fn pipeline_sample_count(config: &UpstreamProbeConfig) -> Result<usize> {
+    config
+        .pipeline_concurrency
+        .checked_mul(config.pipeline_rounds)
+        .ok_or_else(|| DnsError::config("probe pipeline sample count overflowed"))
 }
 
 async fn resolve_remote_ip(info: &ConnectionInfo, has_dial_addr: bool) -> ResolutionProbe {
@@ -325,17 +337,38 @@ async fn resolve_remote_ip(info: &ConnectionInfo, has_dial_addr: bool) -> Resolu
         };
     }
 
-    match try_lookup_server_name(&info.server_name) {
-        Ok(ip) => ResolutionProbe {
+    let server_name = info.server_name.clone();
+    match tokio::time::timeout(
+        info.timeout,
+        tokio::task::spawn_blocking(move || try_lookup_server_name(&server_name)),
+    )
+    .await
+    {
+        Ok(Ok(Ok(ip))) => ResolutionProbe {
             ip: Some(ip),
             source: Some("system".to_string()),
             error: None,
             apply_to_connection: info.socks5.is_none(),
         },
-        Err(err) => ResolutionProbe {
+        Ok(Ok(Err(err))) => ResolutionProbe {
             ip: None,
             source: Some("system".to_string()),
             error: Some(err.to_string()),
+            apply_to_connection: false,
+        },
+        Ok(Err(err)) => ResolutionProbe {
+            ip: None,
+            source: Some("system".to_string()),
+            error: Some(format!("system resolver task failed: {err}")),
+            apply_to_connection: false,
+        },
+        Err(_) => ResolutionProbe {
+            ip: None,
+            source: Some("system".to_string()),
+            error: Some(format!(
+                "system resolver timed out after {:?}",
+                info.timeout
+            )),
             apply_to_connection: false,
         },
     }
@@ -436,7 +469,8 @@ where
         );
     }
 
-    let mut results = Vec::with_capacity(config.pipeline_concurrency * config.pipeline_rounds);
+    let capacity = pipeline_sample_count(config).unwrap_or(MAX_PROBE_SAMPLES);
+    let mut results = Vec::with_capacity(capacity);
     let mut stage_errors = Vec::new();
     if uses_single_connection_pipeline(connection_info.connection_type) {
         for round in 0..config.pipeline_rounds {
@@ -505,7 +539,8 @@ where
     let upstream: Arc<dyn Upstream> = Arc::from(UpstreamBuilder::with_connection_info(
         connection_info.clone(),
     )?);
-    let mut results = Vec::with_capacity(config.pipeline_concurrency * config.pipeline_rounds);
+    let capacity = pipeline_sample_count(config).unwrap_or(MAX_PROBE_SAMPLES);
+    let mut results = Vec::with_capacity(capacity);
 
     for round in 0..config.pipeline_rounds {
         let mut futures = FuturesUnordered::new();
@@ -596,11 +631,13 @@ async fn run_pipeline_round(
                 TcpTransportWriter::new(writer),
                 config,
                 round,
-                connection_info.timeout,
+                &deadline,
             )
             .await
         }
-        ConnectionType::DoT => run_dot_pipeline_round(stream, connection_info, config, round).await,
+        ConnectionType::DoT => {
+            run_dot_pipeline_round(stream, connection_info, config, round, &deadline).await
+        }
         _ => Err(DnsError::protocol(
             "pipeline probe reached non-TCP upstream",
         )),
@@ -613,8 +650,8 @@ async fn run_dot_pipeline_round(
     connection_info: &ConnectionInfo,
     config: &UpstreamProbeConfig,
     round: usize,
+    deadline: &QueryDeadline,
 ) -> Result<Vec<ProbeQueryResult>> {
-    let deadline = QueryDeadline::new(connection_info.timeout);
     let tls_stream = connect_tls(
         stream,
         TlsDialOptions::new(
@@ -633,7 +670,7 @@ async fn run_dot_pipeline_round(
     .await?;
     let transport = TcpTransport::new(tls_stream);
     let (reader, writer) = transport.into_split();
-    run_pipeline_round_with_io(reader, writer, config, round, connection_info.timeout).await
+    run_pipeline_round_with_io(reader, writer, config, round, deadline).await
 }
 
 #[cfg(not(feature = "upstream-dot"))]
@@ -642,6 +679,7 @@ async fn run_dot_pipeline_round(
     _connection_info: &ConnectionInfo,
     _config: &UpstreamProbeConfig,
     _round: usize,
+    _deadline: &QueryDeadline,
 ) -> Result<Vec<ProbeQueryResult>> {
     Err(DnsError::plugin(
         "upstream DoT is not compiled into this build; rebuild with --features upstream-dot",
@@ -653,7 +691,7 @@ async fn run_pipeline_round_with_io<R, W>(
     mut writer: TcpTransportWriter<W>,
     config: &UpstreamProbeConfig,
     round: usize,
-    timeout: Duration,
+    deadline: &QueryDeadline,
 ) -> Result<Vec<ProbeQueryResult>>
 where
     R: AsyncRead + Unpin,
@@ -661,13 +699,18 @@ where
 {
     let mut pending = HashMap::with_capacity(config.pipeline_concurrency);
     let mut results = Vec::with_capacity(config.pipeline_concurrency);
+    let mut unexpected_count = 0usize;
+    let max_unexpected = config.pipeline_concurrency;
 
     for index in 0..config.pipeline_concurrency {
         let global_index = round * config.pipeline_concurrency + index;
         let query_id = probe_query_id(round + 1, index);
         let query_name = pipeline_name(&config.qname, round, index)?;
         let request = make_query(query_id, query_name.clone(), config.qtype);
-        writer.write_message(&request).await?;
+        match deadline.run(writer.write_message(&request)).await {
+            DeadlineOutcome::Completed(result) => result?,
+            DeadlineOutcome::Expired => return Err(deadline.timeout_error()),
+        }
         pending.insert(
             query_id,
             PendingQuery {
@@ -679,18 +722,32 @@ where
         );
     }
 
-    let round_deadline = tokio::time::Instant::now() + timeout;
     while !pending.is_empty() {
-        let now = tokio::time::Instant::now();
-        if now >= round_deadline {
+        let Some(remaining) = deadline.remaining() else {
             break;
-        }
-        let remaining = round_deadline.saturating_duration_since(now);
+        };
         match tokio::time::timeout(remaining, reader.read_message()).await {
             Ok(Ok(response)) => {
                 let response_id = response.id();
                 let Some(pending_query) = pending.remove(&response_id) else {
-                    results.push(unexpected_response_result(response));
+                    unexpected_count += 1;
+                    if unexpected_count <= max_unexpected {
+                        results.push(unexpected_response_result(response));
+                    }
+                    if unexpected_count >= max_unexpected {
+                        results.extend(pending.drain().map(|(query_id, pending_query)| {
+                            query_error_result(
+                                pending_query.index,
+                                query_id,
+                                pending_query.query_name,
+                                ERROR_KIND_PROTOCOL,
+                                "too many unexpected pipeline responses".to_string(),
+                                Some(pending_query.sent_at.elapsed().as_millis()),
+                            )
+                        }));
+                        results.sort_by_key(|result| result.index);
+                        return Ok(results);
+                    }
                     continue;
                 };
                 results.push(result_from_response(
@@ -1092,6 +1149,7 @@ mod tests {
     use std::net::{Ipv4Addr, SocketAddr};
     use std::sync::Arc;
     use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::time::Duration;
 
     use tokio::net::{TcpListener, TcpStream, UdpSocket};
 
@@ -1103,6 +1161,7 @@ mod tests {
         Reverse,
         DropPipelined,
         SwapQuestions,
+        UnexpectedFlood,
     }
 
     fn make_upstream_config(addr: String, timeout: Duration) -> UpstreamConfig {
@@ -1204,6 +1263,19 @@ mod tests {
                 requests.into_iter().map(response_for_request).collect()
             }
             FakeBehavior::DropPipelined => requests.into_iter().map(response_for_request).collect(),
+            FakeBehavior::UnexpectedFlood if requests.len() > 1 => {
+                let question = requests
+                    .first()
+                    .and_then(Message::first_question)
+                    .expect("request should have question")
+                    .clone();
+                (0..requests.len().saturating_mul(4))
+                    .map(|index| response_with_question(0x7000 + index as u16, question.clone()))
+                    .collect()
+            }
+            FakeBehavior::UnexpectedFlood => {
+                requests.into_iter().map(response_for_request).collect()
+            }
             FakeBehavior::SwapQuestions if requests.len() > 1 => {
                 let questions = requests
                     .iter()
@@ -1296,6 +1368,26 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn probe_pipeline_caps_unexpected_responses() {
+        let addr = start_fake_tcp_server(FakeBehavior::UnexpectedFlood).await;
+
+        let report = probe_fake_server(addr, Duration::from_millis(500)).await;
+
+        assert_eq!(report.serial.verdict, ProbeVerdict::Reachable);
+        assert_eq!(report.pipeline.verdict, ProbeVerdict::Unstable);
+        assert_eq!(report.pipeline.mismatch_count, 4);
+        assert_eq!(report.pipeline.error_count, 4);
+        assert_eq!(report.pipeline.total_queries, 8);
+        assert!(
+            report
+                .pipeline
+                .errors
+                .iter()
+                .any(|error| error == "too many unexpected pipeline responses")
+        );
+    }
+
+    #[tokio::test]
     async fn probe_udp_concurrency_supported() {
         let addr = start_fake_udp_server().await;
 
@@ -1343,6 +1435,27 @@ mod tests {
     #[test]
     fn pipeline_verdict_marks_mismatch_unstable() {
         assert_eq!(pipeline_verdict(4, 3, 0, 1), ProbeVerdict::Unstable);
+    }
+
+    #[test]
+    fn validate_probe_config_rejects_excessive_pipeline_sample_product() {
+        let config = UpstreamProbeConfig {
+            upstream: make_upstream_config(
+                "tcp://127.0.0.1:53".to_string(),
+                Duration::from_millis(10),
+            ),
+            qname: "example.com.".to_string(),
+            qtype: RecordType::A,
+            serial_samples: 1,
+            pipeline_concurrency: MAX_PROBE_SAMPLES,
+            pipeline_rounds: 2,
+        };
+
+        let error = validate_probe_config(&config)
+            .expect_err("excessive pipeline sample product should fail")
+            .to_string();
+
+        assert!(error.contains("pipeline_concurrency * pipeline_rounds"));
     }
 
     #[test]

--- a/src/infra/network/upstream/probe.rs
+++ b/src/infra/network/upstream/probe.rs
@@ -738,6 +738,7 @@ fn connection_error_results(
     round: usize,
     error: String,
 ) -> Vec<ProbeQueryResult> {
+    let error_kind = connection_error_kind(error.as_str());
     (0..config.pipeline_concurrency)
         .map(|index| {
             let global_index = round * config.pipeline_concurrency + index;
@@ -749,7 +750,7 @@ fn connection_error_results(
                 global_index,
                 query_id,
                 query_name,
-                ERROR_KIND_PROTOCOL,
+                error_kind,
                 error.clone(),
                 None,
             )
@@ -807,7 +808,13 @@ impl PipelineProbeReport {
         let mismatch_count = count_error_kind(&results, ERROR_KIND_MISMATCH);
         let error_count = results
             .iter()
-            .filter(|result| !result.ok && result.error_kind.as_deref() != Some(ERROR_KIND_TIMEOUT))
+            .filter(|result| {
+                !result.ok
+                    && !matches!(
+                        result.error_kind.as_deref(),
+                        Some(ERROR_KIND_TIMEOUT | ERROR_KIND_MISMATCH)
+                    )
+            })
             .count();
         let verdict = pipeline_verdict(total_queries, success_count, timeout_count, mismatch_count);
         let average_latency_ms = average_latency(&results);
@@ -970,11 +977,24 @@ fn query_error_result(
 }
 
 fn query_error_kind(error: &str) -> &'static str {
-    if error.to_ascii_lowercase().contains("timeout") {
+    if is_timeout_error(error) {
         ERROR_KIND_TIMEOUT
     } else {
         ERROR_KIND_QUERY
     }
+}
+
+fn connection_error_kind(error: &str) -> &'static str {
+    if is_timeout_error(error) {
+        ERROR_KIND_TIMEOUT
+    } else {
+        ERROR_KIND_PROTOCOL
+    }
+}
+
+fn is_timeout_error(error: &str) -> bool {
+    let error = error.to_ascii_lowercase();
+    error.contains("timeout") || error.contains("timed out")
 }
 
 fn unexpected_response_result(response: Message) -> ProbeQueryResult {
@@ -1323,6 +1343,57 @@ mod tests {
     #[test]
     fn pipeline_verdict_marks_mismatch_unstable() {
         assert_eq!(pipeline_verdict(4, 3, 0, 1), ProbeVerdict::Unstable);
+    }
+
+    #[test]
+    fn query_error_kind_recognizes_timed_out_errors() {
+        assert_eq!(
+            query_error_kind("UDP query timed out after retries"),
+            ERROR_KIND_TIMEOUT
+        );
+    }
+
+    #[test]
+    fn connection_error_results_preserve_timeout_kind() {
+        let config = UpstreamProbeConfig {
+            upstream: make_upstream_config(
+                "tcp://127.0.0.1:53".to_string(),
+                Duration::from_millis(10),
+            ),
+            qname: "example.com.".to_string(),
+            qtype: RecordType::A,
+            serial_samples: 1,
+            pipeline_concurrency: 2,
+            pipeline_rounds: 1,
+        };
+
+        let results =
+            connection_error_results(&config, 0, "DNS query timeout after 10ms".to_string());
+
+        assert_eq!(count_error_kind(&results, ERROR_KIND_TIMEOUT), 2);
+        assert!(
+            results
+                .iter()
+                .all(|result| { result.error_kind.as_deref() == Some(ERROR_KIND_TIMEOUT) })
+        );
+    }
+
+    #[test]
+    fn pipeline_report_does_not_double_count_mismatches_as_other_errors() {
+        let results = vec![query_error_result(
+            0,
+            1,
+            "example.com.".to_string(),
+            ERROR_KIND_MISMATCH,
+            "response ID mismatch: expected 1, got 2".to_string(),
+            Some(1),
+        )];
+
+        let report = PipelineProbeReport::from_results(true, 1, 1, results, Vec::new());
+
+        assert_eq!(report.mismatch_count, 1);
+        assert_eq!(report.error_count, 0);
+        assert_eq!(report.verdict, ProbeVerdict::Unstable);
     }
 
     #[test]

--- a/src/infra/network/upstream/probe.rs
+++ b/src/infra/network/upstream/probe.rs
@@ -1,0 +1,1348 @@
+// SPDX-FileCopyrightText: 2025 Sven Shi
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+//! Active diagnostics for configured DNS upstream endpoints.
+
+use std::collections::HashMap;
+use std::net::IpAddr;
+use std::str::FromStr;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use futures::StreamExt;
+use futures::stream::FuturesUnordered;
+use serde::Serialize;
+use tokio::io::{AsyncRead, AsyncWrite};
+
+use crate::infra::clock::AppClock;
+use crate::infra::error::{DnsError, Result};
+use crate::infra::network::dial::{DialTarget, SocketOptions, try_lookup_server_name};
+#[cfg(feature = "upstream-dot")]
+use crate::infra::network::dial::{TlsDialOptions, connect_tls};
+use crate::infra::network::proxy::connect_tcp;
+#[cfg(feature = "upstream-dot")]
+use crate::infra::network::transport::tcp::TcpTransport;
+use crate::infra::network::transport::tcp::{TcpTransportReader, TcpTransportWriter};
+use crate::infra::network::upstream::builder::UpstreamBuilder;
+use crate::infra::network::upstream::config::{ConnectionInfo, ConnectionType, UpstreamConfig};
+use crate::infra::network::upstream::pool::{DeadlineOutcome, QueryDeadline};
+use crate::infra::network::upstream::traits::Upstream;
+use crate::proto::{DNSClass, Message, MessageType, Name, Question, RecordType};
+
+const ERROR_KIND_TIMEOUT: &str = "timeout";
+const ERROR_KIND_MISMATCH: &str = "mismatch";
+const ERROR_KIND_PROTOCOL: &str = "protocol";
+const ERROR_KIND_QUERY: &str = "query";
+const MAX_PROBE_SAMPLES: usize = 4096;
+
+#[derive(Clone, Debug)]
+pub struct UpstreamProbeConfig {
+    pub upstream: UpstreamConfig,
+    pub qname: String,
+    pub qtype: RecordType,
+    pub serial_samples: usize,
+    pub pipeline_concurrency: usize,
+    pub pipeline_rounds: usize,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ProbeVerdict {
+    Reachable,
+    Unreachable,
+    Supported,
+    Unsupported,
+    Unstable,
+    Inconclusive,
+    NotApplicable,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+pub struct UpstreamProbeTarget {
+    pub address: String,
+    pub protocol: String,
+    pub server_name: String,
+    pub port: u16,
+    pub resolved_ip: Option<String>,
+    pub resolution_source: Option<String>,
+    pub uses_bootstrap: bool,
+    pub resolution_error: Option<String>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+pub struct ProbeQuery {
+    pub qname: String,
+    pub qtype: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+pub struct ProbeQueryResult {
+    pub index: usize,
+    pub query_name: String,
+    pub query_id: u16,
+    pub ok: bool,
+    pub latency_ms: Option<u128>,
+    pub response_id: Option<u16>,
+    pub rcode: Option<String>,
+    pub answer_count: Option<u16>,
+    pub authoritative: Option<bool>,
+    pub truncated: Option<bool>,
+    pub recursion_available: Option<bool>,
+    pub error_kind: Option<String>,
+    pub error: Option<String>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+pub struct ProbeStageReport {
+    pub verdict: ProbeVerdict,
+    pub total_queries: usize,
+    pub success_count: usize,
+    pub failure_count: usize,
+    pub average_latency_ms: Option<u128>,
+    pub results: Vec<ProbeQueryResult>,
+    pub errors: Vec<String>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+pub struct PipelineProbeReport {
+    pub verdict: ProbeVerdict,
+    pub applicable: bool,
+    pub concurrency: usize,
+    pub rounds: usize,
+    pub total_queries: usize,
+    pub success_count: usize,
+    pub timeout_count: usize,
+    pub mismatch_count: usize,
+    pub error_count: usize,
+    pub average_latency_ms: Option<u128>,
+    pub results: Vec<ProbeQueryResult>,
+    pub errors: Vec<String>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+pub struct UpstreamProbeReport {
+    pub target: UpstreamProbeTarget,
+    pub query: ProbeQuery,
+    pub timeout_ms: u128,
+    pub serial: ProbeStageReport,
+    pub pipeline: PipelineProbeReport,
+    pub recommendation: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum ProbeProgress {
+    Preparing {
+        address: String,
+    },
+    Resolved {
+        server_name: String,
+        resolved_ip: Option<String>,
+        source: Option<String>,
+        error: Option<String>,
+    },
+    SerialStarted {
+        samples: usize,
+    },
+    SerialSampleFinished {
+        index: usize,
+        ok: bool,
+    },
+    ConcurrencyStarted {
+        protocol: String,
+        strategy: String,
+        concurrency: usize,
+        rounds: usize,
+    },
+    ConcurrencyRoundFinished {
+        round: usize,
+        success_count: usize,
+        total_queries: usize,
+    },
+    Finished {
+        serial: ProbeVerdict,
+        concurrency: ProbeVerdict,
+    },
+}
+
+#[derive(Clone, Debug)]
+struct PendingQuery {
+    index: usize,
+    query_name: String,
+    qtype: RecordType,
+    sent_at: Instant,
+}
+
+pub async fn probe_upstream(config: UpstreamProbeConfig) -> Result<UpstreamProbeReport> {
+    probe_upstream_with_progress(config, |_| {}).await
+}
+
+pub async fn probe_upstream_with_progress<F>(
+    config: UpstreamProbeConfig,
+    mut progress: F,
+) -> Result<UpstreamProbeReport>
+where
+    F: FnMut(ProbeProgress),
+{
+    validate_probe_config(&config)?;
+    AppClock::start();
+    progress(ProbeProgress::Preparing {
+        address: config.upstream.addr.clone(),
+    });
+
+    let base_name = parse_name(&config.qname)?;
+    let mut connection_info = ConnectionInfo::try_from(config.upstream.clone())?;
+    let uses_bootstrap = connection_info.bootstrap.is_some();
+    let resolution = resolve_remote_ip(&connection_info, config.upstream.dial_addr.is_some()).await;
+    if let Some(ip) = resolution.ip
+        && resolution.apply_to_connection
+    {
+        connection_info.remote_ip = Some(ip);
+        connection_info.bootstrap = None;
+        connection_info.bootstrap_timeout = None;
+    }
+    progress(ProbeProgress::Resolved {
+        server_name: connection_info.server_name.clone(),
+        resolved_ip: resolution.ip.map(|ip| ip.to_string()),
+        source: resolution.source.clone(),
+        error: resolution.error.clone(),
+    });
+
+    let target = UpstreamProbeTarget {
+        address: connection_info.raw_addr.clone(),
+        protocol: protocol_name(connection_info.connection_type).to_string(),
+        server_name: connection_info.server_name.clone(),
+        port: connection_info.port,
+        resolved_ip: resolution.ip.map(|ip| ip.to_string()),
+        resolution_source: resolution.source,
+        uses_bootstrap,
+        resolution_error: resolution.error,
+    };
+
+    let serial = run_serial_probe(&connection_info, &config, &base_name, &mut progress).await?;
+    let pipeline = run_pipeline_probe(
+        &connection_info,
+        &config,
+        serial.success_count > 0,
+        &mut progress,
+    )
+    .await;
+    let recommendation = recommendation(&serial, &pipeline);
+    progress(ProbeProgress::Finished {
+        serial: serial.verdict,
+        concurrency: pipeline.verdict,
+    });
+
+    Ok(UpstreamProbeReport {
+        target,
+        query: ProbeQuery {
+            qname: base_name.to_fqdn(),
+            qtype: qtype_name(config.qtype),
+        },
+        timeout_ms: connection_info.timeout.as_millis(),
+        serial,
+        pipeline,
+        recommendation,
+    })
+}
+
+#[derive(Clone, Debug)]
+struct ResolutionProbe {
+    ip: Option<IpAddr>,
+    source: Option<String>,
+    error: Option<String>,
+    apply_to_connection: bool,
+}
+
+fn validate_probe_config(config: &UpstreamProbeConfig) -> Result<()> {
+    if config.serial_samples == 0 {
+        return Err(DnsError::config(
+            "probe serial_samples must be greater than 0",
+        ));
+    }
+    if config.serial_samples > MAX_PROBE_SAMPLES {
+        return Err(DnsError::config(format!(
+            "probe serial_samples must be <= {MAX_PROBE_SAMPLES}"
+        )));
+    }
+    if config.pipeline_concurrency == 0 {
+        return Err(DnsError::config(
+            "probe pipeline_concurrency must be greater than 0",
+        ));
+    }
+    if config.pipeline_concurrency > MAX_PROBE_SAMPLES {
+        return Err(DnsError::config(format!(
+            "probe pipeline_concurrency must be <= {MAX_PROBE_SAMPLES}"
+        )));
+    }
+    if config.pipeline_rounds == 0 {
+        return Err(DnsError::config(
+            "probe pipeline_rounds must be greater than 0",
+        ));
+    }
+    if config.pipeline_rounds > MAX_PROBE_SAMPLES {
+        return Err(DnsError::config(format!(
+            "probe pipeline_rounds must be <= {MAX_PROBE_SAMPLES}"
+        )));
+    }
+    Ok(())
+}
+
+async fn resolve_remote_ip(info: &ConnectionInfo, has_dial_addr: bool) -> ResolutionProbe {
+    if let Some(ip) = info.remote_ip {
+        let source = if has_dial_addr {
+            "dial_addr"
+        } else if IpAddr::from_str(&info.server_name).is_ok() {
+            "literal"
+        } else {
+            "configured"
+        };
+        return ResolutionProbe {
+            ip: Some(ip),
+            source: Some(source.to_string()),
+            error: None,
+            apply_to_connection: true,
+        };
+    }
+
+    if let Some(resolver) = info.bootstrap.as_ref() {
+        let timeout = info.bootstrap_timeout.unwrap_or(info.timeout);
+        return match resolver
+            .resolve(&info.server_name, QueryDeadline::new(timeout))
+            .await
+        {
+            Ok(ip) => ResolutionProbe {
+                ip: Some(ip),
+                source: Some("bootstrap".to_string()),
+                error: None,
+                apply_to_connection: true,
+            },
+            Err(err) => ResolutionProbe {
+                ip: None,
+                source: Some("bootstrap".to_string()),
+                error: Some(err.to_string()),
+                apply_to_connection: false,
+            },
+        };
+    }
+
+    match try_lookup_server_name(&info.server_name) {
+        Ok(ip) => ResolutionProbe {
+            ip: Some(ip),
+            source: Some("system".to_string()),
+            error: None,
+            apply_to_connection: info.socks5.is_none(),
+        },
+        Err(err) => ResolutionProbe {
+            ip: None,
+            source: Some("system".to_string()),
+            error: Some(err.to_string()),
+            apply_to_connection: false,
+        },
+    }
+}
+
+async fn run_serial_probe<F>(
+    connection_info: &ConnectionInfo,
+    config: &UpstreamProbeConfig,
+    base_name: &Name,
+    progress: &mut F,
+) -> Result<ProbeStageReport>
+where
+    F: FnMut(ProbeProgress),
+{
+    progress(ProbeProgress::SerialStarted {
+        samples: config.serial_samples,
+    });
+    let upstream = UpstreamBuilder::with_connection_info(connection_info.clone())?;
+    let mut results = Vec::with_capacity(config.serial_samples);
+
+    for index in 0..config.serial_samples {
+        let query_id = probe_query_id(0, index);
+        let request = make_query(query_id, base_name.clone(), config.qtype);
+        let started = Instant::now();
+        let result = match upstream.query(request).await {
+            Ok(response) => result_from_response(
+                index,
+                query_id,
+                base_name.to_fqdn(),
+                config.qtype,
+                started,
+                response,
+            ),
+            Err(err) => query_error_result(
+                index,
+                query_id,
+                base_name.to_fqdn(),
+                ERROR_KIND_QUERY,
+                err.to_string(),
+                Some(started.elapsed().as_millis()),
+            ),
+        };
+        progress(ProbeProgress::SerialSampleFinished {
+            index,
+            ok: result.ok,
+        });
+        results.push(result);
+    }
+
+    let success_count = results.iter().filter(|result| result.ok).count();
+    let verdict = if success_count == 0 {
+        ProbeVerdict::Unreachable
+    } else {
+        ProbeVerdict::Reachable
+    };
+
+    Ok(ProbeStageReport::from_results(verdict, results))
+}
+
+async fn run_pipeline_probe<F>(
+    connection_info: &ConnectionInfo,
+    config: &UpstreamProbeConfig,
+    serial_reachable: bool,
+    progress: &mut F,
+) -> PipelineProbeReport
+where
+    F: FnMut(ProbeProgress),
+{
+    let strategy = if uses_single_connection_pipeline(connection_info.connection_type) {
+        "single_connection_pipeline"
+    } else {
+        "concurrent_upstream_queries"
+    };
+    progress(ProbeProgress::ConcurrencyStarted {
+        protocol: protocol_name(connection_info.connection_type).to_string(),
+        strategy: strategy.to_string(),
+        concurrency: config.pipeline_concurrency,
+        rounds: config.pipeline_rounds,
+    });
+
+    if !serial_reachable {
+        return PipelineProbeReport::inconclusive(
+            config.pipeline_concurrency,
+            config.pipeline_rounds,
+            "serial baseline failed; pipeline behavior cannot be isolated".to_string(),
+        );
+    }
+
+    if uses_single_connection_pipeline(connection_info.connection_type)
+        && connection_info.remote_ip.is_none()
+        && connection_info.bootstrap.is_some()
+    {
+        return PipelineProbeReport::inconclusive(
+            config.pipeline_concurrency,
+            config.pipeline_rounds,
+            "bootstrap resolution failed; cannot open a direct pipeline probe connection"
+                .to_string(),
+        );
+    }
+
+    let mut results = Vec::with_capacity(config.pipeline_concurrency * config.pipeline_rounds);
+    let mut stage_errors = Vec::new();
+    if uses_single_connection_pipeline(connection_info.connection_type) {
+        for round in 0..config.pipeline_rounds {
+            match run_pipeline_round(connection_info, config, round).await {
+                Ok(mut round_results) => {
+                    let success_count = round_results.iter().filter(|result| result.ok).count();
+                    let total_queries = round_results.len();
+                    progress(ProbeProgress::ConcurrencyRoundFinished {
+                        round,
+                        success_count,
+                        total_queries,
+                    });
+                    results.append(&mut round_results);
+                }
+                Err(err) => {
+                    stage_errors.push(err.to_string());
+                    let round_results = connection_error_results(config, round, err.to_string());
+                    progress(ProbeProgress::ConcurrencyRoundFinished {
+                        round,
+                        success_count: 0,
+                        total_queries: round_results.len(),
+                    });
+                    results.extend(round_results);
+                }
+            }
+        }
+    } else {
+        match run_generic_concurrency_probe(connection_info, config, progress).await {
+            Ok(mut generic_results) => results.append(&mut generic_results),
+            Err(err) => {
+                stage_errors.push(err.to_string());
+                for round in 0..config.pipeline_rounds {
+                    let round_results = connection_error_results(config, round, err.to_string());
+                    progress(ProbeProgress::ConcurrencyRoundFinished {
+                        round,
+                        success_count: 0,
+                        total_queries: round_results.len(),
+                    });
+                    results.extend(round_results);
+                }
+            }
+        }
+    }
+
+    PipelineProbeReport::from_results(
+        true,
+        config.pipeline_concurrency,
+        config.pipeline_rounds,
+        results,
+        stage_errors,
+    )
+}
+
+fn uses_single_connection_pipeline(connection_type: ConnectionType) -> bool {
+    matches!(connection_type, ConnectionType::TCP | ConnectionType::DoT)
+}
+
+async fn run_generic_concurrency_probe<F>(
+    connection_info: &ConnectionInfo,
+    config: &UpstreamProbeConfig,
+    progress: &mut F,
+) -> Result<Vec<ProbeQueryResult>>
+where
+    F: FnMut(ProbeProgress),
+{
+    let upstream: Arc<dyn Upstream> = Arc::from(UpstreamBuilder::with_connection_info(
+        connection_info.clone(),
+    )?);
+    let mut results = Vec::with_capacity(config.pipeline_concurrency * config.pipeline_rounds);
+
+    for round in 0..config.pipeline_rounds {
+        let mut futures = FuturesUnordered::new();
+        for index in 0..config.pipeline_concurrency {
+            let upstream = upstream.clone();
+            let global_index = round * config.pipeline_concurrency + index;
+            let query_id = probe_query_id(round + 1, index);
+            let query_name = pipeline_name(&config.qname, round, index)?;
+            let query_name_text = query_name.to_fqdn();
+            let request = make_query(query_id, query_name, config.qtype);
+            let qtype = config.qtype;
+            let sent_at = Instant::now();
+            futures.push(async move {
+                match upstream.query(request).await {
+                    Ok(response) => result_from_response(
+                        global_index,
+                        query_id,
+                        query_name_text,
+                        qtype,
+                        sent_at,
+                        response,
+                    ),
+                    Err(err) => {
+                        let error = err.to_string();
+                        query_error_result(
+                            global_index,
+                            query_id,
+                            query_name_text,
+                            query_error_kind(error.as_str()),
+                            error,
+                            Some(sent_at.elapsed().as_millis()),
+                        )
+                    }
+                }
+            });
+        }
+
+        while let Some(result) = futures.next().await {
+            results.push(result);
+        }
+        let round_start = round * config.pipeline_concurrency;
+        let round_end = round_start + config.pipeline_concurrency;
+        let success_count = results
+            .iter()
+            .filter(|result| result.index >= round_start && result.index < round_end && result.ok)
+            .count();
+        progress(ProbeProgress::ConcurrencyRoundFinished {
+            round,
+            success_count,
+            total_queries: config.pipeline_concurrency,
+        });
+    }
+
+    results.sort_by_key(|result| result.index);
+    Ok(results)
+}
+
+async fn run_pipeline_round(
+    connection_info: &ConnectionInfo,
+    config: &UpstreamProbeConfig,
+    round: usize,
+) -> Result<Vec<ProbeQueryResult>> {
+    let deadline = QueryDeadline::new(connection_info.timeout);
+    let stream = match deadline
+        .run(connect_tcp(
+            DialTarget::new(
+                connection_info.remote_ip,
+                connection_info.server_name.clone(),
+                connection_info.port,
+            ),
+            SocketOptions::new(
+                connection_info.so_mark,
+                connection_info.bind_to_device.clone(),
+            ),
+            connection_info.socks5.clone(),
+        ))
+        .await
+    {
+        DeadlineOutcome::Completed(result) => result?,
+        DeadlineOutcome::Expired => return Err(deadline.timeout_error()),
+    };
+
+    match connection_info.connection_type {
+        ConnectionType::TCP => {
+            let (reader, writer) = stream.into_split();
+            run_pipeline_round_with_io(
+                TcpTransportReader::new(reader),
+                TcpTransportWriter::new(writer),
+                config,
+                round,
+                connection_info.timeout,
+            )
+            .await
+        }
+        ConnectionType::DoT => run_dot_pipeline_round(stream, connection_info, config, round).await,
+        _ => Err(DnsError::protocol(
+            "pipeline probe reached non-TCP upstream",
+        )),
+    }
+}
+
+#[cfg(feature = "upstream-dot")]
+async fn run_dot_pipeline_round(
+    stream: tokio::net::TcpStream,
+    connection_info: &ConnectionInfo,
+    config: &UpstreamProbeConfig,
+    round: usize,
+) -> Result<Vec<ProbeQueryResult>> {
+    let deadline = QueryDeadline::new(connection_info.timeout);
+    let tls_stream = connect_tls(
+        stream,
+        TlsDialOptions::new(
+            DialTarget::new(
+                connection_info.remote_ip,
+                connection_info.server_name.clone(),
+                connection_info.port,
+            ),
+            connection_info.insecure_skip_verify,
+            deadline
+                .remaining()
+                .ok_or_else(|| deadline.timeout_error())?,
+            vec![b"dot".to_vec()],
+        ),
+    )
+    .await?;
+    let transport = TcpTransport::new(tls_stream);
+    let (reader, writer) = transport.into_split();
+    run_pipeline_round_with_io(reader, writer, config, round, connection_info.timeout).await
+}
+
+#[cfg(not(feature = "upstream-dot"))]
+async fn run_dot_pipeline_round(
+    _stream: tokio::net::TcpStream,
+    _connection_info: &ConnectionInfo,
+    _config: &UpstreamProbeConfig,
+    _round: usize,
+) -> Result<Vec<ProbeQueryResult>> {
+    Err(DnsError::plugin(
+        "upstream DoT is not compiled into this build; rebuild with --features upstream-dot",
+    ))
+}
+
+async fn run_pipeline_round_with_io<R, W>(
+    mut reader: TcpTransportReader<R>,
+    mut writer: TcpTransportWriter<W>,
+    config: &UpstreamProbeConfig,
+    round: usize,
+    timeout: Duration,
+) -> Result<Vec<ProbeQueryResult>>
+where
+    R: AsyncRead + Unpin,
+    W: AsyncWrite + Unpin,
+{
+    let mut pending = HashMap::with_capacity(config.pipeline_concurrency);
+    let mut results = Vec::with_capacity(config.pipeline_concurrency);
+
+    for index in 0..config.pipeline_concurrency {
+        let global_index = round * config.pipeline_concurrency + index;
+        let query_id = probe_query_id(round + 1, index);
+        let query_name = pipeline_name(&config.qname, round, index)?;
+        let request = make_query(query_id, query_name.clone(), config.qtype);
+        writer.write_message(&request).await?;
+        pending.insert(
+            query_id,
+            PendingQuery {
+                index: global_index,
+                query_name: query_name.to_fqdn(),
+                qtype: config.qtype,
+                sent_at: Instant::now(),
+            },
+        );
+    }
+
+    let round_deadline = tokio::time::Instant::now() + timeout;
+    while !pending.is_empty() {
+        let now = tokio::time::Instant::now();
+        if now >= round_deadline {
+            break;
+        }
+        let remaining = round_deadline.saturating_duration_since(now);
+        match tokio::time::timeout(remaining, reader.read_message()).await {
+            Ok(Ok(response)) => {
+                let response_id = response.id();
+                let Some(pending_query) = pending.remove(&response_id) else {
+                    results.push(unexpected_response_result(response));
+                    continue;
+                };
+                results.push(result_from_response(
+                    pending_query.index,
+                    response_id,
+                    pending_query.query_name,
+                    pending_query.qtype,
+                    pending_query.sent_at,
+                    response,
+                ));
+            }
+            Ok(Err(err)) => {
+                results.extend(pending.drain().map(|(query_id, pending_query)| {
+                    query_error_result(
+                        pending_query.index,
+                        query_id,
+                        pending_query.query_name,
+                        ERROR_KIND_PROTOCOL,
+                        format!("connection closed before response: {err}"),
+                        Some(pending_query.sent_at.elapsed().as_millis()),
+                    )
+                }));
+                return Ok(results);
+            }
+            Err(_) => break,
+        }
+    }
+
+    results.extend(pending.drain().map(|(query_id, pending_query)| {
+        query_error_result(
+            pending_query.index,
+            query_id,
+            pending_query.query_name,
+            ERROR_KIND_TIMEOUT,
+            "timed out waiting for pipelined response".to_string(),
+            Some(pending_query.sent_at.elapsed().as_millis()),
+        )
+    }));
+    results.sort_by_key(|result| result.index);
+    Ok(results)
+}
+
+fn connection_error_results(
+    config: &UpstreamProbeConfig,
+    round: usize,
+    error: String,
+) -> Vec<ProbeQueryResult> {
+    (0..config.pipeline_concurrency)
+        .map(|index| {
+            let global_index = round * config.pipeline_concurrency + index;
+            let query_id = probe_query_id(round + 1, index);
+            let query_name = pipeline_name(&config.qname, round, index)
+                .map(|name| name.to_fqdn())
+                .unwrap_or_else(|_| config.qname.clone());
+            query_error_result(
+                global_index,
+                query_id,
+                query_name,
+                ERROR_KIND_PROTOCOL,
+                error.clone(),
+                None,
+            )
+        })
+        .collect()
+}
+
+impl ProbeStageReport {
+    fn from_results(verdict: ProbeVerdict, results: Vec<ProbeQueryResult>) -> Self {
+        let total_queries = results.len();
+        let success_count = results.iter().filter(|result| result.ok).count();
+        let failure_count = total_queries.saturating_sub(success_count);
+        let average_latency_ms = average_latency(&results);
+        let errors = collect_errors(&results, Vec::new());
+        Self {
+            verdict,
+            total_queries,
+            success_count,
+            failure_count,
+            average_latency_ms,
+            results,
+            errors,
+        }
+    }
+}
+
+impl PipelineProbeReport {
+    fn inconclusive(concurrency: usize, rounds: usize, reason: String) -> Self {
+        Self {
+            verdict: ProbeVerdict::Inconclusive,
+            applicable: true,
+            concurrency,
+            rounds,
+            total_queries: 0,
+            success_count: 0,
+            timeout_count: 0,
+            mismatch_count: 0,
+            error_count: 0,
+            average_latency_ms: None,
+            results: Vec::new(),
+            errors: vec![reason],
+        }
+    }
+
+    fn from_results(
+        applicable: bool,
+        concurrency: usize,
+        rounds: usize,
+        results: Vec<ProbeQueryResult>,
+        stage_errors: Vec<String>,
+    ) -> Self {
+        let total_queries = results.len();
+        let success_count = results.iter().filter(|result| result.ok).count();
+        let timeout_count = count_error_kind(&results, ERROR_KIND_TIMEOUT);
+        let mismatch_count = count_error_kind(&results, ERROR_KIND_MISMATCH);
+        let error_count = results
+            .iter()
+            .filter(|result| !result.ok && result.error_kind.as_deref() != Some(ERROR_KIND_TIMEOUT))
+            .count();
+        let verdict = pipeline_verdict(total_queries, success_count, timeout_count, mismatch_count);
+        let average_latency_ms = average_latency(&results);
+        let errors = collect_errors(&results, stage_errors);
+
+        Self {
+            verdict,
+            applicable,
+            concurrency,
+            rounds,
+            total_queries,
+            success_count,
+            timeout_count,
+            mismatch_count,
+            error_count,
+            average_latency_ms,
+            results,
+            errors,
+        }
+    }
+}
+
+fn pipeline_verdict(
+    total_queries: usize,
+    success_count: usize,
+    timeout_count: usize,
+    mismatch_count: usize,
+) -> ProbeVerdict {
+    if total_queries == 0 {
+        ProbeVerdict::Inconclusive
+    } else if success_count == total_queries {
+        ProbeVerdict::Supported
+    } else if mismatch_count > 0 {
+        ProbeVerdict::Unstable
+    } else if success_count == 0 && timeout_count > 0 {
+        ProbeVerdict::Unsupported
+    } else {
+        ProbeVerdict::Unstable
+    }
+}
+
+fn average_latency(results: &[ProbeQueryResult]) -> Option<u128> {
+    let mut count = 0u128;
+    let mut total = 0u128;
+    for latency in results.iter().filter_map(|result| result.latency_ms) {
+        total = total.saturating_add(latency);
+        count += 1;
+    }
+    (count > 0).then_some(total / count)
+}
+
+fn count_error_kind(results: &[ProbeQueryResult], kind: &str) -> usize {
+    results
+        .iter()
+        .filter(|result| result.error_kind.as_deref() == Some(kind))
+        .count()
+}
+
+fn collect_errors(results: &[ProbeQueryResult], mut stage_errors: Vec<String>) -> Vec<String> {
+    for error in results.iter().filter_map(|result| result.error.as_ref()) {
+        if !stage_errors.iter().any(|existing| existing == error) {
+            stage_errors.push(error.clone());
+        }
+        if stage_errors.len() >= 8 {
+            break;
+        }
+    }
+    stage_errors
+}
+
+fn result_from_response(
+    index: usize,
+    query_id: u16,
+    query_name: String,
+    qtype: RecordType,
+    started: Instant,
+    response: Message,
+) -> ProbeQueryResult {
+    let response_id = response.id();
+    let validation_error = validate_response(&response, query_id, query_name.as_str(), qtype);
+    let ok = validation_error.is_none();
+    ProbeQueryResult {
+        index,
+        query_name,
+        query_id,
+        ok,
+        latency_ms: Some(started.elapsed().as_millis()),
+        response_id: Some(response_id),
+        rcode: Some(format!("{:?}", response.rcode())),
+        answer_count: Some(response.answer_count()),
+        authoritative: Some(response.authoritative()),
+        truncated: Some(response.truncated()),
+        recursion_available: Some(response.recursion_available()),
+        error_kind: validation_error
+            .as_ref()
+            .map(|_| ERROR_KIND_MISMATCH.to_string()),
+        error: validation_error,
+    }
+}
+
+fn validate_response(
+    response: &Message,
+    query_id: u16,
+    query_name: &str,
+    qtype: RecordType,
+) -> Option<String> {
+    if response.id() != query_id {
+        return Some(format!(
+            "response ID mismatch: expected {}, got {}",
+            query_id,
+            response.id()
+        ));
+    }
+    if response.message_type() != MessageType::Response {
+        return Some("message is not a DNS response".to_string());
+    }
+    let Some(question) = response.first_question() else {
+        return Some("response does not echo a question".to_string());
+    };
+    let response_name = question.name().to_fqdn();
+    if !response_name.eq_ignore_ascii_case(query_name) {
+        return Some(format!(
+            "response question mismatch: expected {}, got {}",
+            query_name, response_name
+        ));
+    }
+    if question.qtype() != qtype {
+        return Some(format!(
+            "response qtype mismatch: expected {}, got {}",
+            qtype_name(qtype),
+            qtype_name(question.qtype())
+        ));
+    }
+    None
+}
+
+fn query_error_result(
+    index: usize,
+    query_id: u16,
+    query_name: String,
+    error_kind: &str,
+    error: String,
+    latency_ms: Option<u128>,
+) -> ProbeQueryResult {
+    ProbeQueryResult {
+        index,
+        query_name,
+        query_id,
+        ok: false,
+        latency_ms,
+        response_id: None,
+        rcode: None,
+        answer_count: None,
+        authoritative: None,
+        truncated: None,
+        recursion_available: None,
+        error_kind: Some(error_kind.to_string()),
+        error: Some(error),
+    }
+}
+
+fn query_error_kind(error: &str) -> &'static str {
+    if error.to_ascii_lowercase().contains("timeout") {
+        ERROR_KIND_TIMEOUT
+    } else {
+        ERROR_KIND_QUERY
+    }
+}
+
+fn unexpected_response_result(response: Message) -> ProbeQueryResult {
+    ProbeQueryResult {
+        index: usize::MAX,
+        query_name: "<unexpected>".to_string(),
+        query_id: response.id(),
+        ok: false,
+        latency_ms: None,
+        response_id: Some(response.id()),
+        rcode: Some(format!("{:?}", response.rcode())),
+        answer_count: Some(response.answer_count()),
+        authoritative: Some(response.authoritative()),
+        truncated: Some(response.truncated()),
+        recursion_available: Some(response.recursion_available()),
+        error_kind: Some(ERROR_KIND_MISMATCH.to_string()),
+        error: Some(format!("unexpected response ID {}", response.id())),
+    }
+}
+
+fn make_query(id: u16, name: Name, qtype: RecordType) -> Message {
+    let mut request = Message::new();
+    request.set_id(id);
+    request.set_recursion_desired(true);
+    request.add_question(Question::new(name, qtype, DNSClass::IN));
+    request
+}
+
+fn parse_name(raw: &str) -> Result<Name> {
+    Name::from_ascii(raw)
+        .map_err(|err| DnsError::protocol(format!("invalid probe qname '{}': {}", raw, err)))
+}
+
+fn pipeline_name(base: &str, round: usize, index: usize) -> Result<Name> {
+    let base = base.trim_end_matches('.');
+    let raw = if base.is_empty() {
+        format!("oxidns-probe-{round}-{index}.")
+    } else {
+        format!("oxidns-probe-{round}-{index}.{base}.")
+    };
+    parse_name(&raw)
+}
+
+fn probe_query_id(round: usize, index: usize) -> u16 {
+    0x4000u16.wrapping_add((round as u16).wrapping_mul(257)) ^ index as u16
+}
+
+fn qtype_name(qtype: RecordType) -> String {
+    <&'static str>::from(qtype).to_string()
+}
+
+fn protocol_name(connection_type: ConnectionType) -> &'static str {
+    match connection_type {
+        ConnectionType::UDP => "udp",
+        ConnectionType::TCP => "tcp",
+        ConnectionType::DoT => "dot",
+        ConnectionType::DoQ => "doq",
+        ConnectionType::DoH => "doh",
+    }
+}
+
+pub fn parse_record_type(raw: &str) -> Result<RecordType> {
+    RecordType::from_str(raw.trim().to_ascii_uppercase().as_str())
+        .map_err(|err| DnsError::config(format!("invalid probe qtype '{}': {}", raw, err)))
+}
+
+fn recommendation(serial: &ProbeStageReport, pipeline: &PipelineProbeReport) -> String {
+    if serial.verdict == ProbeVerdict::Unreachable {
+        return "serial DNS queries failed; check the address, protocol, bootstrap, proxy, firewall, or timeout".to_string();
+    }
+
+    match pipeline.verdict {
+        ProbeVerdict::Supported => {
+            "concurrent querying appears safe for this upstream at the tested concurrency"
+                .to_string()
+        }
+        ProbeVerdict::Unsupported => {
+            "avoid enabling pipeline or high concurrency for this upstream; concurrent queries did not complete".to_string()
+        }
+        ProbeVerdict::Unstable => {
+            "avoid enabling pipeline or high concurrency for this upstream; responses were incomplete, mismatched, or inconsistent".to_string()
+        }
+        ProbeVerdict::Inconclusive => {
+            "pipeline behavior is inconclusive; retry with a larger timeout or lower concurrency".to_string()
+        }
+        ProbeVerdict::NotApplicable => {
+            "pipeline probing is not applicable to this protocol".to_string()
+        }
+        _ => "review the probe results before changing upstream settings".to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::net::{Ipv4Addr, SocketAddr};
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use tokio::net::{TcpListener, TcpStream, UdpSocket};
+
+    use super::*;
+    use crate::proto::Rcode;
+
+    #[derive(Clone, Copy)]
+    enum FakeBehavior {
+        Reverse,
+        DropPipelined,
+        SwapQuestions,
+    }
+
+    fn make_upstream_config(addr: String, timeout: Duration) -> UpstreamConfig {
+        UpstreamConfig {
+            tag: None,
+            addr,
+            outbound: None,
+            dial_addr: None,
+            port: None,
+            bootstrap: None,
+            bootstrap_version: None,
+            socks5: None,
+            idle_timeout: None,
+            max_conns: None,
+            min_conns: None,
+            insecure_skip_verify: None,
+            timeout: Some(timeout),
+            enable_pipeline: None,
+            enable_http3: None,
+            so_mark: None,
+            bind_to_device: None,
+        }
+    }
+
+    async fn start_fake_tcp_server(behavior: FakeBehavior) -> SocketAddr {
+        let listener = TcpListener::bind(SocketAddr::from((Ipv4Addr::LOCALHOST, 0)))
+            .await
+            .expect("listener should bind");
+        let addr = listener.local_addr().expect("listener should have addr");
+        tokio::spawn(async move {
+            loop {
+                let Ok((stream, _)) = listener.accept().await else {
+                    break;
+                };
+                tokio::spawn(handle_fake_tcp_client(stream, behavior));
+            }
+        });
+        addr
+    }
+
+    async fn start_fake_udp_server() -> SocketAddr {
+        let socket = UdpSocket::bind(SocketAddr::from((Ipv4Addr::LOCALHOST, 0)))
+            .await
+            .expect("UDP socket should bind");
+        let addr = socket.local_addr().expect("UDP socket should have addr");
+        tokio::spawn(async move {
+            let mut buf = [0u8; 4096];
+            loop {
+                let Ok((len, peer)) = socket.recv_from(&mut buf).await else {
+                    break;
+                };
+                let Ok(request) = Message::from_bytes(&buf[..len]) else {
+                    continue;
+                };
+                let response = response_for_request(request);
+                let Ok(bytes) = response.to_bytes() else {
+                    continue;
+                };
+                let _ = socket.send_to(&bytes, peer).await;
+            }
+        });
+        addr
+    }
+
+    async fn handle_fake_tcp_client(stream: TcpStream, behavior: FakeBehavior) {
+        let (reader, writer) = stream.into_split();
+        let mut reader = TcpTransportReader::new(reader);
+        let mut writer = TcpTransportWriter::new(writer);
+
+        loop {
+            let Ok(first) = reader.read_message().await else {
+                break;
+            };
+            let mut batch = vec![first];
+            while batch.len() < 32 {
+                match tokio::time::timeout(Duration::from_millis(15), reader.read_message()).await {
+                    Ok(Ok(message)) => batch.push(message),
+                    _ => break,
+                }
+            }
+
+            if batch.len() > 1 && matches!(behavior, FakeBehavior::DropPipelined) {
+                continue;
+            }
+
+            let responses = fake_responses(batch, behavior);
+            for response in responses {
+                if writer.write_message(&response).await.is_err() {
+                    return;
+                }
+            }
+        }
+    }
+
+    fn fake_responses(mut requests: Vec<Message>, behavior: FakeBehavior) -> Vec<Message> {
+        match behavior {
+            FakeBehavior::Reverse => {
+                requests.reverse();
+                requests.into_iter().map(response_for_request).collect()
+            }
+            FakeBehavior::DropPipelined => requests.into_iter().map(response_for_request).collect(),
+            FakeBehavior::SwapQuestions if requests.len() > 1 => {
+                let questions = requests
+                    .iter()
+                    .map(|request| {
+                        request
+                            .first_question()
+                            .expect("request should have question")
+                            .clone()
+                    })
+                    .collect::<Vec<_>>();
+                requests
+                    .into_iter()
+                    .enumerate()
+                    .map(|(idx, request)| {
+                        let swapped = questions[(idx + 1) % questions.len()].clone();
+                        response_with_question(request.id(), swapped)
+                    })
+                    .collect()
+            }
+            FakeBehavior::SwapQuestions => requests.into_iter().map(response_for_request).collect(),
+        }
+    }
+
+    fn response_for_request(request: Message) -> Message {
+        let question = request
+            .first_question()
+            .expect("request should have question")
+            .clone();
+        response_with_question(request.id(), question)
+    }
+
+    fn response_with_question(id: u16, question: Question) -> Message {
+        let mut response = Message::new();
+        response.set_id(id);
+        response.set_message_type(MessageType::Response);
+        response.set_recursion_desired(true);
+        response.set_recursion_available(true);
+        response.set_rcode(Rcode::NoError);
+        response.add_question(question);
+        response
+    }
+
+    async fn probe_fake_server(
+        addr: SocketAddr,
+        behavior_timeout: Duration,
+    ) -> UpstreamProbeReport {
+        probe_upstream(UpstreamProbeConfig {
+            upstream: make_upstream_config(format!("tcp://{addr}"), behavior_timeout),
+            qname: "example.com.".to_string(),
+            qtype: RecordType::A,
+            serial_samples: 1,
+            pipeline_concurrency: 4,
+            pipeline_rounds: 1,
+        })
+        .await
+        .expect("probe should run")
+    }
+
+    #[tokio::test]
+    async fn probe_pipeline_supported_with_out_of_order_responses() {
+        let addr = start_fake_tcp_server(FakeBehavior::Reverse).await;
+
+        let report = probe_fake_server(addr, Duration::from_millis(500)).await;
+
+        assert_eq!(report.serial.verdict, ProbeVerdict::Reachable);
+        assert_eq!(report.pipeline.verdict, ProbeVerdict::Supported);
+        assert_eq!(report.pipeline.success_count, 4);
+    }
+
+    #[tokio::test]
+    async fn probe_pipeline_unsupported_when_pipelined_responses_timeout() {
+        let addr = start_fake_tcp_server(FakeBehavior::DropPipelined).await;
+
+        let report = probe_fake_server(addr, Duration::from_millis(80)).await;
+
+        assert_eq!(report.serial.verdict, ProbeVerdict::Reachable);
+        assert_eq!(report.pipeline.verdict, ProbeVerdict::Unsupported);
+        assert_eq!(report.pipeline.timeout_count, 4);
+    }
+
+    #[tokio::test]
+    async fn probe_pipeline_unstable_when_questions_are_crossed() {
+        let addr = start_fake_tcp_server(FakeBehavior::SwapQuestions).await;
+
+        let report = probe_fake_server(addr, Duration::from_millis(500)).await;
+
+        assert_eq!(report.serial.verdict, ProbeVerdict::Reachable);
+        assert_eq!(report.pipeline.verdict, ProbeVerdict::Unstable);
+        assert_eq!(report.pipeline.mismatch_count, 4);
+    }
+
+    #[tokio::test]
+    async fn probe_udp_concurrency_supported() {
+        let addr = start_fake_udp_server().await;
+
+        let report = probe_upstream(UpstreamProbeConfig {
+            upstream: make_upstream_config(format!("udp://{addr}"), Duration::from_millis(500)),
+            qname: "example.com.".to_string(),
+            qtype: RecordType::A,
+            serial_samples: 1,
+            pipeline_concurrency: 4,
+            pipeline_rounds: 1,
+        })
+        .await
+        .expect("probe should produce a report");
+
+        assert_eq!(report.serial.verdict, ProbeVerdict::Reachable);
+        assert_eq!(report.pipeline.verdict, ProbeVerdict::Supported);
+        assert_eq!(report.pipeline.success_count, 4);
+    }
+
+    #[tokio::test]
+    async fn probe_udp_concurrency_is_inconclusive_when_serial_fails() {
+        let report = probe_upstream(UpstreamProbeConfig {
+            upstream: make_upstream_config(
+                "udp://127.0.0.1:9".to_string(),
+                Duration::from_millis(20),
+            ),
+            qname: "example.com.".to_string(),
+            qtype: RecordType::A,
+            serial_samples: 1,
+            pipeline_concurrency: 2,
+            pipeline_rounds: 1,
+        })
+        .await
+        .expect("probe should produce a report");
+
+        assert_eq!(report.serial.verdict, ProbeVerdict::Unreachable);
+        assert_eq!(report.pipeline.verdict, ProbeVerdict::Inconclusive);
+    }
+
+    #[test]
+    fn parse_record_type_accepts_lowercase() {
+        assert_eq!(parse_record_type("aaaa").unwrap(), RecordType::AAAA);
+    }
+
+    #[test]
+    fn pipeline_verdict_marks_mismatch_unstable() {
+        assert_eq!(pipeline_verdict(4, 3, 0, 1), ProbeVerdict::Unstable);
+    }
+
+    #[test]
+    fn collect_errors_keeps_unique_messages() {
+        let counter = Arc::new(AtomicUsize::new(0));
+        let results = (0..3)
+            .map(|index| {
+                counter.fetch_add(1, Ordering::Relaxed);
+                query_error_result(
+                    index,
+                    index as u16,
+                    "example.com.".to_string(),
+                    ERROR_KIND_QUERY,
+                    "same".to_string(),
+                    None,
+                )
+            })
+            .collect::<Vec<_>>();
+
+        assert_eq!(counter.load(Ordering::Relaxed), 3);
+        assert_eq!(collect_errors(&results, Vec::new()), vec!["same"]);
+    }
+}

--- a/src/infra/network/upstream/probe.rs
+++ b/src/infra/network/upstream/probe.rs
@@ -7,7 +7,7 @@ use std::collections::HashMap;
 use std::net::IpAddr;
 use std::str::FromStr;
 use std::sync::Arc;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use futures::StreamExt;
 use futures::stream::FuturesUnordered;
@@ -19,7 +19,7 @@ use crate::infra::error::{DnsError, Result};
 use crate::infra::network::dial::{DialTarget, SocketOptions, try_lookup_server_name};
 #[cfg(feature = "upstream-dot")]
 use crate::infra::network::dial::{TlsDialOptions, connect_tls};
-use crate::infra::network::proxy::connect_tcp;
+use crate::infra::network::proxy::{Socks5Opt, connect_tcp, parse_socks5_opt};
 #[cfg(feature = "upstream-dot")]
 use crate::infra::network::transport::tcp::TcpTransport;
 use crate::infra::network::transport::tcp::{TcpTransportReader, TcpTransportWriter};
@@ -190,9 +190,10 @@ where
     });
 
     let base_name = parse_name(&config.qname)?;
-    let mut connection_info = ConnectionInfo::try_from(config.upstream.clone())?;
+    let upstream = prepare_probe_upstream_config(config.upstream.clone()).await?;
+    let mut connection_info = ConnectionInfo::try_from(upstream.clone())?;
     let uses_bootstrap = connection_info.bootstrap.is_some();
-    let resolution = resolve_remote_ip(&connection_info, config.upstream.dial_addr.is_some()).await;
+    let resolution = resolve_remote_ip(&connection_info, upstream.dial_addr.is_some()).await;
     if let Some(ip) = resolution.ip
         && resolution.apply_to_connection
     {
@@ -206,6 +207,7 @@ where
         source: resolution.source.clone(),
         error: resolution.error.clone(),
     });
+    let block_direct_probe = resolution_blocks_direct_probe(&connection_info, &resolution);
 
     let target = UpstreamProbeTarget {
         address: connection_info.raw_addr.clone(),
@@ -218,7 +220,19 @@ where
         resolution_error: resolution.error,
     };
 
-    let serial = run_serial_probe(&connection_info, &config, &base_name, &mut progress).await?;
+    let serial = if block_direct_probe {
+        run_resolution_failure_serial_probe(
+            &config,
+            &base_name,
+            target
+                .resolution_error
+                .as_deref()
+                .unwrap_or("system resolver failed"),
+            &mut progress,
+        )
+    } else {
+        run_serial_probe(&connection_info, &config, &base_name, &mut progress).await?
+    };
     let pipeline = run_pipeline_probe(
         &connection_info,
         &config,
@@ -299,6 +313,44 @@ fn pipeline_sample_count(config: &UpstreamProbeConfig) -> Result<usize> {
         .ok_or_else(|| DnsError::config("probe pipeline sample count overflowed"))
 }
 
+async fn prepare_probe_upstream_config(mut upstream: UpstreamConfig) -> Result<UpstreamConfig> {
+    if let Some(socks5) = upstream.socks5.as_deref() {
+        let timeout = upstream
+            .timeout
+            .unwrap_or(ConnectionInfo::DEFAULT_QUERY_TIMEOUT);
+        upstream.socks5 = Some(resolve_probe_socks5(socks5, timeout).await?);
+    }
+    Ok(upstream)
+}
+
+async fn resolve_probe_socks5(raw: &str, timeout: Duration) -> Result<String> {
+    resolve_probe_socks5_with(raw, timeout, |raw| parse_socks5_opt(raw.as_str())).await
+}
+
+async fn resolve_probe_socks5_with<F>(raw: &str, timeout: Duration, parse: F) -> Result<String>
+where
+    F: FnOnce(String) -> Option<Socks5Opt> + Send + 'static,
+{
+    let raw_owned = raw.to_string();
+    match tokio::time::timeout(
+        timeout,
+        tokio::task::spawn_blocking(move || parse(raw_owned)),
+    )
+    .await
+    {
+        Ok(Ok(Some(socks5))) => Ok(socks5.to_resolved_config_string()),
+        Ok(Ok(None)) => Err(DnsError::plugin(format!(
+            "upstream has invalid socks5 proxy '{raw}'"
+        ))),
+        Ok(Err(err)) => Err(DnsError::plugin(format!(
+            "SOCKS5 proxy resolver task failed: {err}"
+        ))),
+        Err(_) => Err(DnsError::plugin(format!(
+            "SOCKS5 proxy resolution timed out after {timeout:?}"
+        ))),
+    }
+}
+
 async fn resolve_remote_ip(info: &ConnectionInfo, has_dial_addr: bool) -> ResolutionProbe {
     if let Some(ip) = info.remote_ip {
         let source = if has_dial_addr {
@@ -374,6 +426,15 @@ async fn resolve_remote_ip(info: &ConnectionInfo, has_dial_addr: bool) -> Resolu
     }
 }
 
+fn resolution_blocks_direct_probe(info: &ConnectionInfo, resolution: &ResolutionProbe) -> bool {
+    resolution.ip.is_none()
+        && resolution.error.is_some()
+        && resolution.source.as_deref() == Some("system")
+        && info.remote_ip.is_none()
+        && info.bootstrap.is_none()
+        && info.socks5.is_none()
+}
+
 async fn run_serial_probe<F>(
     connection_info: &ConnectionInfo,
     config: &UpstreamProbeConfig,
@@ -426,6 +487,34 @@ where
     };
 
     Ok(ProbeStageReport::from_results(verdict, results))
+}
+
+fn run_resolution_failure_serial_probe<F>(
+    config: &UpstreamProbeConfig,
+    base_name: &Name,
+    error: &str,
+    progress: &mut F,
+) -> ProbeStageReport
+where
+    F: FnMut(ProbeProgress),
+{
+    progress(ProbeProgress::SerialStarted {
+        samples: config.serial_samples,
+    });
+    let mut results = Vec::with_capacity(config.serial_samples);
+    for index in 0..config.serial_samples {
+        let result = query_error_result(
+            index,
+            probe_query_id(0, index),
+            base_name.to_fqdn(),
+            query_error_kind(error),
+            error.to_string(),
+            None,
+        );
+        progress(ProbeProgress::SerialSampleFinished { index, ok: false });
+        results.push(result);
+    }
+    ProbeStageReport::from_results(ProbeVerdict::Unreachable, results)
 }
 
 async fn run_pipeline_probe<F>(
@@ -1435,6 +1524,59 @@ mod tests {
     #[test]
     fn pipeline_verdict_marks_mismatch_unstable() {
         assert_eq!(pipeline_verdict(4, 3, 0, 1), ProbeVerdict::Unstable);
+    }
+
+    #[test]
+    fn system_resolution_failure_blocks_direct_probe_without_proxy() {
+        let info =
+            ConnectionInfo::with_addr("tcp://dns.example.invalid:53").expect("addr should parse");
+        let resolution = ResolutionProbe {
+            ip: None,
+            source: Some("system".to_string()),
+            error: Some("system resolver timed out after 10ms".to_string()),
+            apply_to_connection: false,
+        };
+
+        assert!(resolution_blocks_direct_probe(&info, &resolution));
+    }
+
+    #[test]
+    fn system_resolution_failure_does_not_block_proxied_probe() {
+        let mut info =
+            ConnectionInfo::with_addr("tcp://dns.example.invalid:53").expect("addr should parse");
+        info.socks5 = Some(Socks5Opt {
+            username: None,
+            password: None,
+            socket_addr: SocketAddr::from((Ipv4Addr::LOCALHOST, 1080)),
+        });
+        let resolution = ResolutionProbe {
+            ip: None,
+            source: Some("system".to_string()),
+            error: Some("system resolver timed out after 10ms".to_string()),
+            apply_to_connection: false,
+        };
+
+        assert!(!resolution_blocks_direct_probe(&info, &resolution));
+    }
+
+    #[tokio::test]
+    async fn resolve_probe_socks5_respects_timeout() {
+        let started = Instant::now();
+
+        let error = resolve_probe_socks5_with(
+            "proxy.example.invalid:1080",
+            Duration::from_millis(10),
+            |_raw| {
+                std::thread::sleep(Duration::from_millis(200));
+                None
+            },
+        )
+        .await
+        .expect_err("slow SOCKS5 resolution should time out")
+        .to_string();
+
+        assert!(started.elapsed() < Duration::from_millis(150));
+        assert!(error.contains("SOCKS5 proxy resolution timed out"));
     }
 
     #[test]

--- a/src/infra/network/upstream/probe.rs
+++ b/src/infra/network/upstream/probe.rs
@@ -234,7 +234,7 @@ where
         run_serial_probe(&connection_info, &config, &base_name, &mut progress).await?
     };
     let pipeline = run_pipeline_probe(
-        &connection_info,
+        &mut connection_info,
         &config,
         serial.success_count > 0,
         &mut progress,
@@ -537,7 +537,7 @@ where
 }
 
 async fn run_pipeline_probe<F>(
-    connection_info: &ConnectionInfo,
+    connection_info: &mut ConnectionInfo,
     config: &UpstreamProbeConfig,
     serial_reachable: bool,
     progress: &mut F,
@@ -568,12 +568,12 @@ where
     if uses_single_connection_pipeline(connection_info.connection_type)
         && connection_info.remote_ip.is_none()
         && connection_info.bootstrap.is_some()
+        && let Err(err) = resolve_pipeline_remote_ip(connection_info).await
     {
         return PipelineProbeReport::inconclusive(
             config.pipeline_concurrency,
             config.pipeline_rounds,
-            "bootstrap resolution failed; cannot open a direct pipeline probe connection"
-                .to_string(),
+            format!("bootstrap resolution failed before pipeline probe: {err}"),
         );
     }
 
@@ -634,6 +634,22 @@ where
 
 fn uses_single_connection_pipeline(connection_type: ConnectionType) -> bool {
     matches!(connection_type, ConnectionType::TCP | ConnectionType::DoT)
+}
+
+async fn resolve_pipeline_remote_ip(connection_info: &mut ConnectionInfo) -> Result<()> {
+    let Some(resolver) = connection_info.bootstrap.as_ref() else {
+        return Ok(());
+    };
+    let timeout = connection_info
+        .bootstrap_timeout
+        .unwrap_or(connection_info.timeout);
+    let ip = resolver
+        .resolve(&connection_info.server_name, QueryDeadline::new(timeout))
+        .await?;
+    connection_info.remote_ip = Some(ip);
+    connection_info.bootstrap = None;
+    connection_info.bootstrap_timeout = None;
+    Ok(())
 }
 
 async fn run_generic_concurrency_probe<F>(
@@ -1263,7 +1279,7 @@ fn recommendation(serial: &ProbeStageReport, pipeline: &PipelineProbeReport) -> 
 
 #[cfg(test)]
 mod tests {
-    use std::net::{Ipv4Addr, SocketAddr};
+    use std::net::{IpAddr, Ipv4Addr, SocketAddr};
     use std::sync::Arc;
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::time::Duration;
@@ -1271,7 +1287,9 @@ mod tests {
     use tokio::net::{TcpListener, TcpStream, UdpSocket};
 
     use super::*;
-    use crate::proto::Rcode;
+    use crate::infra::network::resolver::NameResolver;
+    use crate::proto::rdata::A;
+    use crate::proto::{RData, Rcode, Record};
 
     #[derive(Clone, Copy)]
     enum FakeBehavior {
@@ -1334,6 +1352,32 @@ mod tests {
                     continue;
                 };
                 let response = response_for_request(request);
+                let Ok(bytes) = response.to_bytes() else {
+                    continue;
+                };
+                let _ = socket.send_to(&bytes, peer).await;
+            }
+        });
+        addr
+    }
+
+    async fn start_fake_bootstrap_resolver(answer_ip: Ipv4Addr) -> SocketAddr {
+        let socket = UdpSocket::bind(SocketAddr::from((Ipv4Addr::LOCALHOST, 0)))
+            .await
+            .expect("bootstrap resolver socket should bind");
+        let addr = socket
+            .local_addr()
+            .expect("bootstrap resolver should have addr");
+        tokio::spawn(async move {
+            let mut buf = [0u8; 4096];
+            loop {
+                let Ok((len, peer)) = socket.recv_from(&mut buf).await else {
+                    break;
+                };
+                let Ok(request) = Message::from_bytes(&buf[..len]) else {
+                    continue;
+                };
+                let response = resolver_response_for_request(request, answer_ip);
                 let Ok(bytes) = response.to_bytes() else {
                     continue;
                 };
@@ -1422,6 +1466,20 @@ mod tests {
             .expect("request should have question")
             .clone();
         response_with_question(request.id(), question)
+    }
+
+    fn resolver_response_for_request(request: Message, answer_ip: Ipv4Addr) -> Message {
+        let question = request
+            .first_question()
+            .expect("resolver request should have question")
+            .clone();
+        let mut response = response_with_question(request.id(), question.clone());
+        response.add_answer(Record::from_rdata(
+            question.name().clone(),
+            60,
+            RData::A(A(answer_ip)),
+        ));
+        response
     }
 
     fn response_with_question(id: u16, question: Question) -> Message {
@@ -1628,6 +1686,28 @@ mod tests {
 
         assert!(started.elapsed() < Duration::from_millis(150));
         assert!(error.contains("SOCKS5 proxy resolution timed out"));
+    }
+
+    #[tokio::test]
+    async fn resolve_pipeline_remote_ip_retries_bootstrap_resolution() {
+        let answer_ip = Ipv4Addr::new(192, 0, 2, 53);
+        let resolver_addr = start_fake_bootstrap_resolver(answer_ip).await;
+        let resolver = Arc::new(
+            NameResolver::new(vec![resolver_addr.to_string()], Some(4))
+                .expect("bootstrap resolver should build"),
+        );
+        let mut info =
+            ConnectionInfo::with_addr("tcp://dns.example.invalid:53").expect("addr should parse");
+        info.bootstrap = Some(resolver);
+        info.timeout = Duration::from_millis(500);
+
+        resolve_pipeline_remote_ip(&mut info)
+            .await
+            .expect("pipeline bootstrap retry should resolve");
+
+        assert_eq!(info.remote_ip, Some(IpAddr::V4(answer_ip)));
+        assert!(info.bootstrap.is_none());
+        assert!(info.bootstrap_timeout.is_none());
     }
 
     #[test]

--- a/src/infra/network/upstream/probe.rs
+++ b/src/infra/network/upstream/probe.rs
@@ -209,15 +209,15 @@ where
     });
     let block_direct_probe = resolution_blocks_direct_probe(&connection_info, &resolution);
 
-    let target = UpstreamProbeTarget {
+    let mut target = UpstreamProbeTarget {
         address: connection_info.raw_addr.clone(),
         protocol: protocol_name(connection_info.connection_type).to_string(),
         server_name: connection_info.server_name.clone(),
         port: connection_info.port,
         resolved_ip: resolution.ip.map(|ip| ip.to_string()),
-        resolution_source: resolution.source,
+        resolution_source: resolution.source.clone(),
         uses_bootstrap,
-        resolution_error: resolution.error,
+        resolution_error: resolution.error.clone(),
     };
 
     let serial = if block_direct_probe {
@@ -240,6 +240,7 @@ where
         &mut progress,
     )
     .await;
+    refresh_target_resolution_after_pipeline(&mut target, &connection_info);
     let recommendation = recommendation(&serial, &pipeline);
     progress(ProbeProgress::Finished {
         serial: serial.verdict,
@@ -409,6 +410,15 @@ async fn resolve_remote_ip(info: &ConnectionInfo, has_dial_addr: bool) -> Resolu
         };
     }
 
+    if info.socks5.is_some() {
+        return ResolutionProbe {
+            ip: None,
+            source: Some("proxy".to_string()),
+            error: None,
+            apply_to_connection: false,
+        };
+    }
+
     let server_name = info.server_name.clone();
     match run_probe_blocking_with_timeout(info.timeout, move || {
         try_lookup_server_name(&server_name)
@@ -452,6 +462,20 @@ fn resolution_blocks_direct_probe(info: &ConnectionInfo, resolution: &Resolution
         && info.remote_ip.is_none()
         && info.bootstrap.is_none()
         && info.socks5.is_none()
+}
+
+fn refresh_target_resolution_after_pipeline(
+    target: &mut UpstreamProbeTarget,
+    connection_info: &ConnectionInfo,
+) {
+    if target.uses_bootstrap
+        && target.resolved_ip.is_none()
+        && let Some(remote_ip) = connection_info.remote_ip
+    {
+        target.resolved_ip = Some(remote_ip.to_string());
+        target.resolution_source = Some("bootstrap".to_string());
+        target.resolution_error = None;
+    }
 }
 
 async fn run_serial_probe<F>(
@@ -1669,6 +1693,25 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn resolve_remote_ip_uses_proxy_source_without_system_lookup() {
+        let mut info =
+            ConnectionInfo::with_addr("tcp://dns.example.invalid:53").expect("addr should parse");
+        info.socks5 = Some(Socks5Opt {
+            username: None,
+            password: None,
+            socket_addr: SocketAddr::from((Ipv4Addr::LOCALHOST, 1080)),
+        });
+        info.timeout = Duration::from_nanos(1);
+
+        let resolution = resolve_remote_ip(&info, false).await;
+
+        assert_eq!(resolution.ip, None);
+        assert_eq!(resolution.source.as_deref(), Some("proxy"));
+        assert_eq!(resolution.error, None);
+        assert!(!resolution.apply_to_connection);
+    }
+
+    #[tokio::test]
     async fn resolve_probe_socks5_respects_timeout() {
         let started = Instant::now();
 
@@ -1708,6 +1751,29 @@ mod tests {
         assert_eq!(info.remote_ip, Some(IpAddr::V4(answer_ip)));
         assert!(info.bootstrap.is_none());
         assert!(info.bootstrap_timeout.is_none());
+    }
+
+    #[test]
+    fn refresh_target_resolution_after_pipeline_records_bootstrap_retry() {
+        let mut target = UpstreamProbeTarget {
+            address: "tcp://dns.example.invalid:53".to_string(),
+            protocol: "tcp".to_string(),
+            server_name: "dns.example.invalid".to_string(),
+            port: 53,
+            resolved_ip: None,
+            resolution_source: Some("bootstrap".to_string()),
+            uses_bootstrap: true,
+            resolution_error: Some("transient bootstrap failure".to_string()),
+        };
+        let mut info =
+            ConnectionInfo::with_addr("tcp://dns.example.invalid:53").expect("addr should parse");
+        info.remote_ip = Some(IpAddr::V4(Ipv4Addr::new(192, 0, 2, 53)));
+
+        refresh_target_resolution_after_pipeline(&mut target, &info);
+
+        assert_eq!(target.resolved_ip.as_deref(), Some("192.0.2.53"));
+        assert_eq!(target.resolution_source.as_deref(), Some("bootstrap"));
+        assert_eq!(target.resolution_error, None);
     }
 
     #[test]

--- a/src/infra/network/upstream/probe.rs
+++ b/src/infra/network/upstream/probe.rs
@@ -240,7 +240,8 @@ where
         &mut progress,
     )
     .await;
-    refresh_target_resolution_after_pipeline(&mut target, &connection_info);
+    refresh_target_bootstrap_resolution(&mut target, &mut connection_info, &serial, &pipeline)
+        .await;
     let recommendation = recommendation(&serial, &pipeline);
     progress(ProbeProgress::Finished {
         serial: serial.verdict,
@@ -470,14 +471,29 @@ fn resolution_blocks_direct_probe(info: &ConnectionInfo, resolution: &Resolution
         && info.socks5.is_none()
 }
 
-fn refresh_target_resolution_after_pipeline(
+async fn refresh_target_bootstrap_resolution(
+    target: &mut UpstreamProbeTarget,
+    connection_info: &mut ConnectionInfo,
+    serial: &ProbeStageReport,
+    pipeline: &PipelineProbeReport,
+) {
+    if !target.uses_bootstrap || target.resolved_ip.is_some() {
+        return;
+    }
+    if serial.success_count == 0 && pipeline.success_count == 0 {
+        return;
+    }
+    if connection_info.remote_ip.is_none() && connection_info.bootstrap.is_some() {
+        let _ = resolve_bootstrap_remote_ip(connection_info).await;
+    }
+    refresh_target_from_connection_remote_ip(target, connection_info);
+}
+
+fn refresh_target_from_connection_remote_ip(
     target: &mut UpstreamProbeTarget,
     connection_info: &ConnectionInfo,
 ) {
-    if target.uses_bootstrap
-        && target.resolved_ip.is_none()
-        && let Some(remote_ip) = connection_info.remote_ip
-    {
+    if let Some(remote_ip) = connection_info.remote_ip {
         target.resolved_ip = Some(remote_ip.to_string());
         target.resolution_source = Some("bootstrap".to_string());
         target.resolution_error = None;
@@ -603,7 +619,7 @@ where
     if uses_single_connection_pipeline(connection_info.connection_type)
         && connection_info.remote_ip.is_none()
         && connection_info.bootstrap.is_some()
-        && let Err(err) = resolve_pipeline_remote_ip(connection_info).await
+        && let Err(err) = resolve_bootstrap_remote_ip(connection_info).await
     {
         return PipelineProbeReport::inconclusive(
             config.pipeline_concurrency,
@@ -671,7 +687,7 @@ fn uses_single_connection_pipeline(connection_type: ConnectionType) -> bool {
     matches!(connection_type, ConnectionType::TCP | ConnectionType::DoT)
 }
 
-async fn resolve_pipeline_remote_ip(connection_info: &mut ConnectionInfo) -> Result<()> {
+async fn resolve_bootstrap_remote_ip(connection_info: &mut ConnectionInfo) -> Result<()> {
     let Some(resolver) = connection_info.bootstrap.as_ref() else {
         return Ok(());
     };
@@ -1834,7 +1850,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn resolve_pipeline_remote_ip_retries_bootstrap_resolution() {
+    async fn resolve_bootstrap_remote_ip_retries_bootstrap_resolution() {
         let answer_ip = Ipv4Addr::new(192, 0, 2, 53);
         let resolver_addr = start_fake_bootstrap_resolver(answer_ip).await;
         let resolver = Arc::new(
@@ -1846,7 +1862,7 @@ mod tests {
         info.bootstrap = Some(resolver);
         info.timeout = Duration::from_millis(500);
 
-        resolve_pipeline_remote_ip(&mut info)
+        resolve_bootstrap_remote_ip(&mut info)
             .await
             .expect("pipeline bootstrap retry should resolve");
 
@@ -1856,7 +1872,7 @@ mod tests {
     }
 
     #[test]
-    fn refresh_target_resolution_after_pipeline_records_bootstrap_retry() {
+    fn refresh_target_from_connection_remote_ip_records_bootstrap_retry() {
         let mut target = UpstreamProbeTarget {
             address: "tcp://dns.example.invalid:53".to_string(),
             protocol: "tcp".to_string(),
@@ -1871,11 +1887,63 @@ mod tests {
             ConnectionInfo::with_addr("tcp://dns.example.invalid:53").expect("addr should parse");
         info.remote_ip = Some(IpAddr::V4(Ipv4Addr::new(192, 0, 2, 53)));
 
-        refresh_target_resolution_after_pipeline(&mut target, &info);
+        refresh_target_from_connection_remote_ip(&mut target, &info);
 
         assert_eq!(target.resolved_ip.as_deref(), Some("192.0.2.53"));
         assert_eq!(target.resolution_source.as_deref(), Some("bootstrap"));
         assert_eq!(target.resolution_error, None);
+    }
+
+    #[tokio::test]
+    async fn refresh_target_bootstrap_resolution_retries_after_generic_success() {
+        let answer_ip = Ipv4Addr::new(192, 0, 2, 53);
+        let resolver_addr = start_fake_bootstrap_resolver(answer_ip).await;
+        let resolver = Arc::new(
+            NameResolver::new(vec![resolver_addr.to_string()], Some(4))
+                .expect("bootstrap resolver should build"),
+        );
+        let mut target = UpstreamProbeTarget {
+            address: "udp://dns.example.invalid:53".to_string(),
+            protocol: "udp".to_string(),
+            server_name: "dns.example.invalid".to_string(),
+            port: 53,
+            resolved_ip: None,
+            resolution_source: Some("bootstrap".to_string()),
+            uses_bootstrap: true,
+            resolution_error: Some("transient bootstrap failure".to_string()),
+        };
+        let mut info =
+            ConnectionInfo::with_addr("udp://dns.example.invalid:53").expect("addr should parse");
+        info.bootstrap = Some(resolver);
+        info.timeout = Duration::from_millis(500);
+        let serial = ProbeStageReport::from_results(
+            ProbeVerdict::Reachable,
+            vec![ProbeQueryResult {
+                index: 0,
+                query_name: "example.com.".to_string(),
+                query_id: 100,
+                ok: true,
+                latency_ms: Some(1),
+                response_id: Some(100),
+                rcode: Some("NOERROR".to_string()),
+                answer_count: Some(1),
+                authoritative: Some(false),
+                truncated: Some(false),
+                recursion_available: Some(true),
+                error_kind: None,
+                error: None,
+            }],
+        );
+        let pipeline = PipelineProbeReport::inconclusive(1, 1, "not run".to_string());
+
+        refresh_target_bootstrap_resolution(&mut target, &mut info, &serial, &pipeline).await;
+
+        assert_eq!(target.resolved_ip.as_deref(), Some("192.0.2.53"));
+        assert_eq!(target.resolution_source.as_deref(), Some("bootstrap"));
+        assert_eq!(target.resolution_error, None);
+        assert_eq!(info.remote_ip, Some(IpAddr::V4(answer_ip)));
+        assert!(info.bootstrap.is_none());
+        assert!(info.bootstrap_timeout.is_none());
     }
 
     #[test]

--- a/src/infra/network/upstream/tests.rs
+++ b/src/infra/network/upstream/tests.rs
@@ -159,7 +159,7 @@ fn install_test_outbound_config() {
     let config = NetworkOutboundConfig {
         default: None,
         profiles: HashMap::from([(
-            "oversea".to_string(),
+            "remote".to_string(),
             OutboundProfileConfig {
                 resolver: Some(OutboundResolverConfig::Nameservers(
                     OutboundResolverDetailedConfig {
@@ -183,9 +183,9 @@ fn install_test_outbound_config() {
 
 fn install_test_default_outbound_config() {
     let config = NetworkOutboundConfig {
-        default: Some("oversea".to_string()),
+        default: Some("remote".to_string()),
         profiles: HashMap::from([(
-            "oversea".to_string(),
+            "remote".to_string(),
             OutboundProfileConfig {
                 resolver: Some(OutboundResolverConfig::Nameservers(
                     OutboundResolverDetailedConfig {
@@ -211,7 +211,7 @@ fn install_test_outbound_resolver_only_config() {
     let config = NetworkOutboundConfig {
         default: None,
         profiles: HashMap::from([(
-            "oversea".to_string(),
+            "remote".to_string(),
             OutboundProfileConfig {
                 resolver: Some(OutboundResolverConfig::Nameservers(
                     OutboundResolverDetailedConfig {
@@ -233,9 +233,9 @@ fn install_test_outbound_resolver_only_config() {
 
 fn install_test_default_outbound_resolver_only_config() {
     let config = NetworkOutboundConfig {
-        default: Some("oversea".to_string()),
+        default: Some("remote".to_string()),
         profiles: HashMap::from([(
-            "oversea".to_string(),
+            "remote".to_string(),
             OutboundProfileConfig {
                 resolver: Some(OutboundResolverConfig::Nameservers(
                     OutboundResolverDetailedConfig {
@@ -323,7 +323,7 @@ fn test_connection_info_uses_outbound_resolver_for_domain() {
     install_test_outbound_resolver_only_config();
 
     let mut cfg = make_upstream_config("tls://dns.example.invalid:853");
-    cfg.outbound = Some("oversea".to_string());
+    cfg.outbound = Some("remote".to_string());
     let info = ConnectionInfo::try_from(cfg).expect("upstream config should parse");
 
     assert!(info.remote_ip.is_none());
@@ -334,7 +334,7 @@ fn test_connection_info_uses_outbound_resolver_for_domain() {
             .as_ref()
             .expect("outbound resolver should be injected")
             .profile(),
-        "oversea"
+        "remote"
     );
     outbound::clear_global();
 }
@@ -372,7 +372,7 @@ fn test_connection_info_uses_default_outbound_resolver_for_domain() {
             .as_ref()
             .expect("default outbound resolver should be injected")
             .profile(),
-        "oversea"
+        "remote"
     );
     outbound::clear_global();
 }
@@ -385,7 +385,7 @@ async fn test_udp_upstream_with_outbound_resolver_keeps_truncated_fallback() {
     install_test_outbound_resolver_only_config();
 
     let mut cfg = make_upstream_config("udp://dns.example.invalid:53");
-    cfg.outbound = Some("oversea".to_string());
+    cfg.outbound = Some("remote".to_string());
     let info = ConnectionInfo::try_from(cfg).expect("upstream config should parse");
     let upstream = UpstreamBuilder::with_connection_info(info).expect("upstream should build");
 
@@ -404,7 +404,7 @@ fn test_connection_info_dial_addr_takes_precedence_over_outbound_resolver() {
     install_test_outbound_config();
 
     let mut cfg = make_upstream_config("tls://dns.example.invalid:853");
-    cfg.outbound = Some("oversea".to_string());
+    cfg.outbound = Some("remote".to_string());
     cfg.dial_addr = Some(IpAddr::from_str("203.0.113.53").unwrap());
     let info = ConnectionInfo::try_from(cfg).expect("upstream config should parse");
 
@@ -424,7 +424,7 @@ fn test_connection_info_uses_outbound_proxy_when_local_socks5_absent() {
     install_test_outbound_config();
 
     let mut cfg = make_upstream_config("tcp://1.1.1.1:53");
-    cfg.outbound = Some("oversea".to_string());
+    cfg.outbound = Some("remote".to_string());
     let info = ConnectionInfo::try_from(cfg).expect("upstream config should parse");
 
     assert_eq!(
@@ -467,7 +467,7 @@ fn test_connection_info_rejects_outbound_proxy_for_udp_upstream() {
     install_test_outbound_config();
 
     let mut cfg = make_upstream_config("8.8.8.8");
-    cfg.outbound = Some("oversea".to_string());
+    cfg.outbound = Some("remote".to_string());
     let err = ConnectionInfo::try_from(cfg).expect_err("UDP upstream should reject profile proxy");
 
     assert!(err.to_string().contains("does not support UDP"), "{err}");
@@ -497,7 +497,7 @@ fn test_connection_info_local_socks5_overrides_outbound_proxy() {
     install_test_outbound_config();
 
     let mut cfg = make_upstream_config("tcp://1.1.1.1:53");
-    cfg.outbound = Some("oversea".to_string());
+    cfg.outbound = Some("remote".to_string());
     cfg.socks5 = Some("127.0.0.1:1081".to_string());
     let info = ConnectionInfo::try_from(cfg).expect("upstream config should parse");
 
@@ -565,7 +565,7 @@ fn test_connection_info_rejects_invalid_local_socks5_with_outbound_proxy() {
     install_test_outbound_config();
 
     let mut cfg = make_upstream_config("tcp://1.1.1.1:53");
-    cfg.outbound = Some("oversea".to_string());
+    cfg.outbound = Some("remote".to_string());
     cfg.socks5 = Some("127.0.0.1".to_string());
     let err = ConnectionInfo::try_from(cfg).expect_err("malformed local proxy should fail");
 


### PR DESCRIPTION
- Add `oxidns probe upstream <addr>` with serial reachability checks, resolved IP reporting, progress output, and JSON/human summaries.
- Probe TCP/DoT pipeline safety on a single connection and classify concurrent behavior for other upstream protocols.
- Document the probe workflow in CLI and forward upstream docs, including guidance for deciding whether to enable pipeline.
- Normalize outbound example profile names to `remote` across docs and tests.

Closed #236 