### PR TITLE
feat(scripts): support OpenWrt LuCI app lifecycle

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ OxiDNS 不试图替你隐藏复杂性。
 | 出站网络 | `network.outbound` 统一配置 HTTP 下载、升级检查、webhook 与 upstream 使用的 nameservers 与 SOCKS5 |
 | 系统联动 | `ipset`、`nftset`、`ros_address_list`、`reverse_lookup` |
 | 调试与运维 | 健康检查、配置校验、热重载、查询记录、Prometheus 插件指标、实时日志 |
-| 部署能力 | 多平台构建、Debian 包、独立 WebUI 托管、服务化安装 |
+| 部署能力 | 多平台构建、Debian 包、OpenWrt LuCI 插件、独立 WebUI 托管、服务化安装 |
 
 ---
 
@@ -152,10 +152,26 @@ irm https://oxidns.org/install.ps1 | iex
 
 默认情况下，Linux / macOS 会安装到 `/opt/oxidns`，在 `/usr/local/bin` 创建 `oxidns` 命令，并安装、启动系统服务。Windows 会安装到 `%ProgramFiles%\OxiDNS`，加入 Machine PATH，并安装、启动系统服务。仅需便携安装时，可设置 `OXIDNS_INSTALL_SERVICE=0`，详见快速开始。
 
+OpenWrt 用户可通过同一个安装脚本一键安装 [luci-app-oxidns](https://github.com/svenshi/luci-app-oxidns) LuCI 插件：
+
+```sh
+curl -fsSL https://oxidns.org/install.sh | sh
+# 或：
+wget -O- https://oxidns.org/install.sh | sh
+```
+
+脚本检测到 OpenWrt 后会自动下载并安装 LuCI 插件包；安装后可在 `Services -> OxiDNS` 中安装 OxiDNS 内核、托管 init 服务、编辑配置并查看日志。LuCI 插件不内置 OxiDNS 内核，首次安装内核时会从 OxiDNS 官方 GitHub Releases 下载并校验对应 Linux musl archive。
+
 卸载时默认保留 `config.yaml`：
 
 ```bash
 curl -fsSL https://oxidns.org/uninstall.sh | sudo sh
+```
+
+OpenWrt：
+
+```sh
+curl -fsSL https://oxidns.org/uninstall.sh | sh
 ```
 
 Windows 管理员 PowerShell：
@@ -174,6 +190,7 @@ irm https://oxidns.org/uninstall.ps1 | iex
 | Linux ARM64 | `oxidns-aarch64-unknown-linux-musl.tar.gz` |
 | Debian / Ubuntu x86_64 服务安装 | `*_amd64.deb` |
 | Debian / Ubuntu ARM64 服务安装 | `*_arm64.deb` |
+| OpenWrt / LuCI | OxiDNS 安装脚本，或 [`luci-app-oxidns`](https://github.com/svenshi/luci-app-oxidns) 的 `.ipk` / `.apk` 包 |
 | Alpine Linux x86_64 | `oxidns-x86_64-unknown-linux-musl.tar.gz` |
 | Alpine Linux ARM64 | `oxidns-aarch64-unknown-linux-musl.tar.gz` |
 | 32 位 ARM Linux，如部分树莓派 | `oxidns-arm-unknown-linux-musleabihf.tar.gz` |
@@ -220,6 +237,7 @@ cargo build --release --no-default-features --features standard        # 家用 
 
 - [配置总览](https://oxidns.org/configuration)
 - [快速开始](https://oxidns.org/quickstart)
+- [OpenWrt LuCI 插件](https://oxidns.org/openwrt)
 - [插件总览](https://oxidns.org/plugin-reference/overview)
 - [管理 API](https://oxidns.org/api)
 - [MikroTik 策略路由](https://oxidns.org/mikrotik-policy-routing)
@@ -232,12 +250,12 @@ cargo build --release --no-default-features --features standard        # 家用 
 
 ## 路线图
 
-以下是当前规划中的开发方向，按顺序排列。详细说明请参考[文档路线图](https://oxidns.org/roadmap)。
+以下是当前规划和近期已落地的方向，按顺序排列。详细说明请参考[文档路线图](https://oxidns.org/roadmap)。
 
 1. **编译定制化**：按功能模块拆分编译，用户 fork 后可自由组合插件，构建精简的定制版本，并通过自定义仓库实现自动更新
 2. **IP 优选**：对 DNS 响应中的多个 A/AAAA 地址并行测速，自动选出延迟最低的 IP 返回给客户端
-3. **MikroTik 深度集成**：新增从 RouterOS 拉取地址列表作为数据源，以及将本地 IP 集主动推送到 RouterOS 的能力
-4. **OpenWrt 支持**：通过 opkg 一键安装、服务自动托管，为 OpenWrt 用户提供原生部署体验
+3. **OpenWrt LuCI 插件**：通过 `luci-app-oxidns` 在 LuCI 中安装内核、托管服务、编辑配置并查看日志
+4. **MikroTik 深度集成**：新增从 RouterOS 拉取地址列表作为数据源，以及将本地 IP 集主动推送到 RouterOS 的能力
 5. **WebUI 与指标增强**：为各新增插件补充管理界面，扩展 Prometheus 指标覆盖范围
 
 长期来看，计划探索 WebAssembly 插件和动态链接库插件两种扩展机制，支持第三方开发者独立开发和分发插件。

--- a/README_EN.md
+++ b/README_EN.md
@@ -82,7 +82,7 @@ It is better suited for users who want explicit control over DNS behavior, rathe
 | Outbound networking | `network.outbound` centralizes nameservers and SOCKS5 settings for HTTP downloads, upgrade checks, webhooks, and upstreams |
 | System integrations | `ipset`, `nftset`, `ros_address_list`, `reverse_lookup` |
 | Debugging and operations | Health checks, config validation, hot reload, query records, Prometheus plugin metrics, real-time logs |
-| Deployment | Multi-platform builds, Debian packages, standalone WebUI hosting, service installation |
+| Deployment | Multi-platform builds, Debian packages, OpenWrt LuCI app, standalone WebUI hosting, service installation |
 
 ---
 
@@ -152,10 +152,26 @@ irm https://oxidns.org/install.ps1 | iex
 
 By default, Linux / macOS installs into `/opt/oxidns`, creates `/usr/local/bin/oxidns`, and installs and starts the system service. Windows installs into `%ProgramFiles%\OxiDNS`, adds it to the Machine PATH, and installs and starts the service. For a portable user install, set `OXIDNS_INSTALL_SERVICE=0`; see Quick Start for details.
 
+OpenWrt users can use the same installer script to install the [luci-app-oxidns](https://github.com/svenshi/luci-app-oxidns) LuCI app:
+
+```sh
+curl -fsSL https://oxidns.org/install.sh | sh
+# or:
+wget -O- https://oxidns.org/install.sh | sh
+```
+
+When the script detects OpenWrt, it downloads and installs the LuCI app package. LuCI then adds `Services -> OxiDNS` pages for installing the OxiDNS core, managing the init service, editing configuration, and viewing logs. The LuCI app does not embed the OxiDNS core; during first core install it downloads and verifies the matching Linux musl archive from the official OxiDNS GitHub Releases.
+
 Uninstall while keeping `config.yaml`:
 
 ```bash
 curl -fsSL https://oxidns.org/uninstall.sh | sudo sh
+```
+
+OpenWrt:
+
+```sh
+curl -fsSL https://oxidns.org/uninstall.sh | sh
 ```
 
 Elevated Windows PowerShell:
@@ -174,6 +190,7 @@ If you want to download a GitHub release directly, use this platform guide:
 | Linux ARM64 | `oxidns-aarch64-unknown-linux-musl.tar.gz` |
 | Debian / Ubuntu x86_64 service install | `*_amd64.deb` |
 | Debian / Ubuntu ARM64 service install | `*_arm64.deb` |
+| OpenWrt / LuCI | OxiDNS installer script, or `.ipk` / `.apk` packages from [`luci-app-oxidns`](https://github.com/svenshi/luci-app-oxidns) |
 | Alpine Linux x86_64 | `oxidns-x86_64-unknown-linux-musl.tar.gz` |
 | Alpine Linux ARM64 | `oxidns-aarch64-unknown-linux-musl.tar.gz` |
 | 32-bit ARM Linux, including some Raspberry Pi installs | `oxidns-arm-unknown-linux-musleabihf.tar.gz` |
@@ -220,6 +237,7 @@ See [Custom Build](https://oxidns.org/en/custom-build) for details.
 
 - [Configuration](https://oxidns.org/en/configuration)
 - [Quick Start](https://oxidns.org/en/quickstart)
+- [OpenWrt LuCI App](https://oxidns.org/en/openwrt)
 - [Plugin Overview](https://oxidns.org/en/plugin-reference/overview)
 - [Management API](https://oxidns.org/en/api)
 - [MikroTik Policy Routing](https://oxidns.org/en/mikrotik-policy-routing)
@@ -232,12 +250,12 @@ See [Custom Build](https://oxidns.org/en/custom-build) for details.
 
 ## Roadmap
 
-The following outlines the planned development directions in delivery order. See the [documentation roadmap](https://oxidns.org/en/roadmap) for full details.
+The following outlines planned directions and recently delivered platform work in delivery order. See the [documentation roadmap](https://oxidns.org/en/roadmap) for full details.
 
 1. **Custom builds**: Split compilation by plugin module so users can fork, select only the plugins they need, and auto-update from a custom repository
 2. **IP optimization**: Probe multiple A/AAAA addresses from a DNS response in parallel and return the lowest-latency IP to the client
-3. **MikroTik deep integration**: Add the ability to pull RouterOS address lists as a data source and to actively push local IP sets to RouterOS
-4. **OpenWrt support**: One-command install via opkg with automatic service management — a native deployment experience for OpenWrt users
+3. **OpenWrt LuCI app**: Use `luci-app-oxidns` to install the core, manage the service, edit config, and view logs from LuCI
+4. **MikroTik deep integration**: Add the ability to pull RouterOS address lists as a data source and to actively push local IP sets to RouterOS
 5. **WebUI and metrics improvements**: Add management interfaces for new plugins and expand Prometheus metric coverage
 
 Looking further ahead, two plugin extension mechanisms are planned: WebAssembly plugins and dynamic library plugins, enabling third-party developers to build and distribute plugins independently.

--- a/docs/docs/openwrt.mdx
+++ b/docs/docs/openwrt.mdx
@@ -1,0 +1,124 @@
+---
+title: OpenWrt LuCI 插件
+---
+
+import Admonition from '@theme/Admonition';
+
+OxiDNS 支持通过 [`luci-app-oxidns`](https://github.com/svenshi/luci-app-oxidns) 在 OpenWrt / LuCI 中部署和管理。
+
+安装后，LuCI 会出现 `Services -> OxiDNS` 页面，可用于安装 OxiDNS 内核二进制、管理 OpenWrt init 服务、编辑配置和查看日志。
+
+<Admonition type="info" title="插件边界">
+
+`luci-app-oxidns` 不内置 OxiDNS 内核，也不再管理独立的 OpenWrt `oxidns` 包。LuCI 负责从 OxiDNS 官方 GitHub Releases 下载 release archive、校验 SHA256 digest，并把二进制安装为 OpenWrt 服务。后续 OxiDNS 内核升级请使用 OxiDNS 自带的 WebUI / API / CLI 升级能力。
+
+</Admonition>
+
+## 一条命令安装 LuCI 插件
+
+在 OpenWrt 上以 root 用户执行：
+
+```sh
+curl -fsSL https://oxidns.org/install.sh | sh
+```
+
+没有 `curl` 时：
+
+```sh
+wget -O- https://oxidns.org/install.sh | sh
+```
+
+脚本检测到 OpenWrt 后会从 [`luci-app-oxidns` Releases](https://github.com/svenshi/luci-app-oxidns/releases) 读取最新包，按系统包管理器选择 `.ipk` 或 `.apk`，安装 `luci-app-oxidns` 和可选简体中文语言包，并自动重启 `rpcd`。
+
+可用环境变量：
+
+| 变量 | 作用 |
+| --- | --- |
+| `OXIDNS_OPENWRT_VERSION` | 指定 LuCI 插件 release 标签，默认 `latest` |
+| `OXIDNS_OPENWRT_REPO` | 指定 LuCI 插件仓库，默认 `svenshi/luci-app-oxidns` |
+| `OXIDNS_OPENWRT_I18N=0` | 跳过简体中文语言包 |
+| `OXIDNS_OPENWRT_INSTALL=0` | 在 OpenWrt 上禁用 LuCI 插件分支，强制走普通 Linux archive 安装 |
+
+## 手动安装 LuCI 插件
+
+从 [`luci-app-oxidns` Releases](https://github.com/svenshi/luci-app-oxidns/releases) 下载对应包后安装：
+
+```sh
+opkg install ./luci-app-oxidns_*.ipk
+# 可选：简体中文语言包
+opkg install ./luci-i18n-oxidns-zh-cn_*.ipk
+```
+
+在使用 `apk` 的 OpenWrt 系统上：
+
+```sh
+apk add --allow-untrusted --no-network ./luci-app-oxidns_*.apk
+# 可选：简体中文语言包
+apk add --allow-untrusted --no-network ./luci-i18n-oxidns-zh-cn_*.apk
+```
+
+如果安装后菜单没有出现，重启 `rpcd`：
+
+```sh
+/etc/init.d/rpcd restart
+```
+
+然后打开 LuCI：`Services -> OxiDNS`。
+
+## 安装 OxiDNS 内核
+
+如果从旧的 OpenWrt `oxidns` 包模式迁移，先停止服务并移除旧内核包，避免它继续拥有 `/usr/bin/oxidns` 或 `/etc/init.d/oxidns`：
+
+```sh
+/etc/init.d/oxidns stop
+opkg remove oxidns
+```
+
+使用 `apk` 的系统对应执行：
+
+```sh
+/etc/init.d/oxidns stop
+apk del oxidns
+```
+
+1. 打开 `Services -> OxiDNS -> Settings`，确认 `Core repository` 为 `svenshi/oxidns`，`Core bundle` 为 `full`。
+2. 打开 `Services -> OxiDNS -> Core`，点击 `Install Core`。离线环境可点击 `Upload Core` 上传官方 `.tar.gz` archive 或单个 `oxidns` 二进制。
+3. 安装成功后，到 `Overview` 启动并启用服务。
+
+LuCI 会按当前设备 CPU 架构选择 OxiDNS Linux musl release archive，例如 `oxidns-x86_64-unknown-linux-musl.tar.gz`，并在安装时校验 GitHub release asset 的 SHA256 digest。
+
+## 默认路径
+
+- 二进制：`/usr/bin/oxidns`
+- WebUI：`/usr/share/oxidns/webui`
+- 配置：`/etc/oxidns/config.yaml`
+- 工作目录：`/var/lib/oxidns`
+- 服务脚本：`/etc/init.d/oxidns`
+
+## 升级与删除
+
+升级 OxiDNS 内核时，请使用 OxiDNS 自带的 WebUI / API / CLI 升级能力。LuCI 的 `Core` 页面只负责首次安装、上传安装和修复重装，不作为版本升级入口。
+
+升级 LuCI 插件时，下载新版 `luci-app-oxidns` 包并重新安装即可。LuCI 页面内不提供自升级。
+
+删除 OxiDNS 内核可以在 LuCI 的 `Core` 页面点击 `Remove Core`。该操作会停止并禁用服务，删除 `/usr/bin/oxidns` 和 `/usr/share/oxidns/webui`，但保留 `/etc/oxidns/config.yaml` 和 `/var/lib/oxidns`。
+
+也可以使用卸载脚本移除 LuCI 插件和已安装的 OxiDNS core 文件：
+
+```sh
+curl -fsSL https://oxidns.org/uninstall.sh | sh
+```
+
+默认会卸载 `luci-app-oxidns` / 语言包，删除 `/usr/bin/oxidns` 与 `/usr/share/oxidns/webui`，并保留 OxiDNS 配置、工作目录和 LuCI 设置。
+
+彻底清理配置和工作目录：
+
+```sh
+curl -fsSL https://oxidns.org/uninstall.sh | env OXIDNS_PURGE=1 sh
+```
+
+`OXIDNS_PURGE=1` 会同时删除 OxiDNS 配置、工作目录和 LuCI 设置；执行前请备份 `/etc/oxidns/config.yaml`。
+
+## 受限网络
+
+路由器需要能直接访问 GitHub Releases 和 release archive。私有仓库或受限网络环境可以在 `Settings` 中配置 GitHub token 或下载代理；也可以在 `Core` 页面手动上传 release archive 或二进制进行离线安装。

--- a/docs/docs/quickstart.mdx
+++ b/docs/docs/quickstart.mdx
@@ -12,6 +12,7 @@ import Admonition from '@theme/Admonition';
 <Admonition type="tip" title="选哪种安装方式？">
 
 * **Linux 服务器**：优先使用一条命令安装脚本、release 压缩包或 `.deb`
+* **OpenWrt 路由器**：优先使用 [`luci-app-oxidns`](openwrt.mdx) LuCI 插件
 * **容器环境**：优先使用 Docker 镜像
 * **需要自行改代码或调试**：使用 Cargo 从源码构建
 * **macOS / Windows**：优先使用一条命令安装脚本或 release 压缩包
@@ -20,7 +21,7 @@ import Admonition from '@theme/Admonition';
 
 ## 1. 一条命令安装
 
-安装脚本会自动识别当前平台，下载匹配的 GitHub Release archive，解压 `oxidns` / `oxidns.exe`、`config.yaml` 和 `webui/`，并默认安装、启动为系统服务。
+安装脚本会自动识别当前平台。Linux / macOS / Windows 会下载匹配的 OxiDNS GitHub Release archive，解压 `oxidns` / `oxidns.exe`、`config.yaml` 和 `webui/`，并默认安装、启动为系统服务；OpenWrt 会下载并安装 `luci-app-oxidns` LuCI 插件。
 
 <Tabs groupId="os">
   <TabItem value="unix" label="Linux / macOS" default>
@@ -37,6 +38,19 @@ irm https://oxidns.org/install.ps1 | iex
 ```
 
   </TabItem>
+  <TabItem value="openwrt" label="OpenWrt">
+
+```sh
+curl -fsSL https://oxidns.org/install.sh | sh
+```
+
+没有 `curl` 时：
+
+```sh
+wget -O- https://oxidns.org/install.sh | sh
+```
+
+  </TabItem>
 </Tabs>
 
 默认安装位置：
@@ -47,8 +61,11 @@ irm https://oxidns.org/install.ps1 | iex
 | Windows 管理员 PowerShell 服务安装 | `%ProgramFiles%\OxiDNS` | 加入 Machine PATH，并安装、启动系统服务 |
 | Linux / macOS 便携安装 | `~/.oxidns` | 设置 `OXIDNS_INSTALL_SERVICE=0` 后，在 `~/.local/bin/oxidns` 创建链接 |
 | Windows 便携安装 | `%LOCALAPPDATA%\OxiDNS` | 设置 `OXIDNS_INSTALL_SERVICE=0` 后，将安装目录加入用户 PATH |
+| OpenWrt / LuCI 插件安装 | 由 `opkg` / `apk` 管理 | 安装 `luci-app-oxidns` 和可选中文语言包；OxiDNS 内核后续在 LuCI 中安装 |
 
-重复运行安装脚本会更新二进制和 `webui/`。如果安装目录中已经有 `config.yaml`，脚本会保留现有配置，并把 release 内置配置写成 `config.yaml.example`。
+在 Linux / macOS / Windows archive 安装模式下，重复运行安装脚本会更新二进制和 `webui/`。如果安装目录中已经有 `config.yaml`，脚本会保留现有配置，并把 release 内置配置写成 `config.yaml.example`。
+
+在 OpenWrt 上，重复运行安装脚本会重新安装当前选择的 `luci-app-oxidns` release 包；OxiDNS 内核版本升级仍使用 LuCI / WebUI / API / CLI 内置升级流程。
 
 ### 安装指定版本
 
@@ -81,6 +98,10 @@ $env:OXIDNS_VERSION = "v1.0.1"; irm https://oxidns.org/install.ps1 | iex
 | `OXIDNS_NO_PATH=1` | 不创建命令链接或不修改 PATH |
 | `OXIDNS_INSTALL_SERVICE=0` | 不安装系统服务，改为便携安装 |
 | `OXIDNS_START_SERVICE=0` | 安装服务但不立即启动 |
+| `OXIDNS_OPENWRT_INSTALL` | OpenWrt 分支开关，默认 `auto`；设置为 `0` 可强制走普通 Linux archive 安装 |
+| `OXIDNS_OPENWRT_REPO` | LuCI 插件仓库，默认 `svenshi/luci-app-oxidns` |
+| `OXIDNS_OPENWRT_VERSION` | LuCI 插件 release 标签，默认 `latest` |
+| `OXIDNS_OPENWRT_I18N` | 是否安装简体中文语言包，默认 `auto`；可设为 `0` 跳过 |
 
 便携安装：
 
@@ -128,13 +149,26 @@ oxidns.exe start -c "$env:LOCALAPPDATA\OxiDNS\config.yaml" -d "$env:LOCALAPPDATA
 
 ### 卸载
 
-卸载脚本会移除二进制、`webui/` 和 PATH 入口，默认保留 `config.yaml`。
+卸载脚本会移除二进制、`webui/` 和 PATH 入口，默认保留 `config.yaml`。在 OpenWrt 上，它会卸载 `luci-app-oxidns` / 语言包，并清理 LuCI 安装过的 `/usr/bin/oxidns` 和 `/usr/share/oxidns/webui`；默认保留 OxiDNS 配置、工作目录和 LuCI 设置。
 
 <Tabs groupId="os">
   <TabItem value="unix" label="Linux / macOS" default>
 
 ```bash
 curl -fsSL https://oxidns.org/uninstall.sh | sudo sh
+```
+
+  </TabItem>
+  <TabItem value="openwrt" label="OpenWrt">
+
+```sh
+curl -fsSL https://oxidns.org/uninstall.sh | sh
+```
+
+没有 `curl` 时：
+
+```sh
+wget -O- https://oxidns.org/uninstall.sh | sh
 ```
 
   </TabItem>
@@ -147,7 +181,7 @@ irm https://oxidns.org/uninstall.ps1 | iex
   </TabItem>
 </Tabs>
 
-如果安装时使用了 `sudo` 或自定义 `OXIDNS_INSTALL_DIR`，卸载时也请保持相同权限和目录变量。
+如果安装时使用了 `sudo` 或自定义 `OXIDNS_INSTALL_DIR`，卸载时也请保持相同权限和目录变量。OpenWrt 卸载需要 root。
 
 彻底清理安装目录和配置：
 
@@ -156,6 +190,19 @@ irm https://oxidns.org/uninstall.ps1 | iex
 
 ```bash
 curl -fsSL https://oxidns.org/uninstall.sh | sudo env OXIDNS_PURGE=1 sh
+```
+
+  </TabItem>
+  <TabItem value="openwrt" label="OpenWrt">
+
+```sh
+curl -fsSL https://oxidns.org/uninstall.sh | env OXIDNS_PURGE=1 sh
+```
+
+没有 `curl` 时：
+
+```sh
+wget -O- https://oxidns.org/uninstall.sh | env OXIDNS_PURGE=1 sh
 ```
 
   </TabItem>
@@ -170,7 +217,7 @@ $env:OXIDNS_PURGE = "1"; irm https://oxidns.org/uninstall.ps1 | iex
 
 <Admonition type="warning" title="彻底清理">
 
-设置 `OXIDNS_PURGE=1` 会删除整个安装目录，包括配置文件本身。请确认 `config.yaml` 已备份后再执行。
+设置 `OXIDNS_PURGE=1` 会删除配置文件本身。普通 archive 安装会删除整个安装目录；OpenWrt 会删除 OxiDNS 配置、工作目录和 LuCI 设置。请确认 `config.yaml` 已备份后再执行。
 
 </Admonition>
 
@@ -182,7 +229,10 @@ $env:OXIDNS_PURGE = "1"; irm https://oxidns.org/uninstall.ps1 | iex
 | `OXIDNS_BIN_DIR` | Linux / macOS 下覆盖命令链接目录 |
 | `OXIDNS_NO_PATH=1` | 不移除命令链接或用户 PATH |
 | `OXIDNS_UNINSTALL_SERVICE=1` | 强制卸载系统服务；默认在 root / 管理员环境中自动尝试 |
-| `OXIDNS_PURGE=1` | 删除整个安装目录，包括配置 |
+| `OXIDNS_PURGE=1` | 普通 archive 安装删除整个安装目录；OpenWrt 删除 OxiDNS 配置、工作目录和 LuCI 设置 |
+| `OXIDNS_OPENWRT_UNINSTALL` | OpenWrt 卸载分支开关，默认 `auto`；设置为 `0` 可强制走普通 Linux archive 卸载 |
+| `OXIDNS_OPENWRT_CONFIG_PATH` | 覆盖 OpenWrt 配置文件路径；未指定时读取 UCI `config_path`，再回退到 `/etc/oxidns/config.yaml` |
+| `OXIDNS_OPENWRT_WORKING_DIR` | 覆盖 OpenWrt 工作目录；未指定时读取 UCI `working_dir`，再回退到 `/var/lib/oxidns` |
 
 ## 2. 从源码构建
 
@@ -263,6 +313,7 @@ Windows 平台使用 `.zip`：
 | Linux ARM64 | `oxidns-aarch64-unknown-linux-musl.tar.gz` | 默认优先选这个，兼容性更稳 |
 | Debian / Ubuntu x86_64 服务安装 | `*_amd64.deb` | 适合 systemd 服务部署 |
 | Debian / Ubuntu ARM64 服务安装 | `*_arm64.deb` | 适合 systemd 服务部署 |
+| OpenWrt / LuCI | [`luci-app-oxidns`](https://github.com/svenshi/luci-app-oxidns) 的 `.ipk` / `.apk` 包 | 先安装 LuCI 插件，再由 LuCI 下载并安装 OxiDNS Linux musl 内核 |
 | Alpine Linux x86_64 | `oxidns-x86_64-unknown-linux-musl.tar.gz` | Alpine 建议优先选 musl |
 | Alpine Linux ARM64 | `oxidns-aarch64-unknown-linux-musl.tar.gz` | 静态链接更省心 |
 | 明确是 glibc Linux 且需要动态链接版本 | `oxidns-x86_64-unknown-linux-gnu.tar.gz` / `oxidns-aarch64-unknown-linux-gnu.tar.gz` | 仅在明确环境匹配时选择 |
@@ -370,7 +421,45 @@ sudo systemctl status oxidns
 sudo systemctl enable --now oxidns
 ```
 
-## 5. 使用 Docker 镜像
+## 5. OpenWrt / LuCI 插件
+
+OpenWrt 用户建议直接使用 OxiDNS 安装脚本安装 [`luci-app-oxidns`](https://github.com/svenshi/luci-app-oxidns)。它会在 LuCI 中增加 `Services -> OxiDNS` 页面，用于安装 OxiDNS 内核、托管 init 服务、编辑配置和查看日志。
+
+```sh
+curl -fsSL https://oxidns.org/install.sh | sh
+```
+
+没有 `curl` 时：
+
+```sh
+wget -O- https://oxidns.org/install.sh | sh
+```
+
+脚本检测到 OpenWrt 后会读取 `luci-app-oxidns` 最新 release，按系统包管理器选择 `.ipk` 或 `.apk`，安装主包和可选简体中文语言包，并自动重启 `rpcd`。
+
+### 手动安装 LuCI 插件
+
+从 `luci-app-oxidns` Release 下载对应 LuCI 包后安装：
+
+```sh
+opkg install ./luci-app-oxidns_*.ipk
+# 可选：简体中文语言包
+opkg install ./luci-i18n-oxidns-zh-cn_*.ipk
+```
+
+在使用 `apk` 的 OpenWrt 系统上：
+
+```sh
+apk add --allow-untrusted --no-network ./luci-app-oxidns_*.apk
+# 可选：简体中文语言包
+apk add --allow-untrusted --no-network ./luci-i18n-oxidns-zh-cn_*.apk
+```
+
+安装后打开 `Services -> OxiDNS -> Core`，点击 `Install Core`。LuCI 会按当前设备 CPU 架构下载并校验 OxiDNS 官方 Linux musl release archive；离线环境也可以上传官方 `.tar.gz` archive 或单个 `oxidns` 二进制。
+
+完整说明见 [OpenWrt LuCI 插件](openwrt.mdx)。
+
+## 6. 使用 Docker 镜像
 
 仓库提供 Docker 镜像发布流程，镜像仓库地址为：
 
@@ -449,14 +538,15 @@ docker compose up -d
 docker compose logs -f oxidns
 ```
 
-## 6. 选择建议
+## 7. 选择建议
 
 - 想最快验证功能：使用一条命令安装最新 release，或手动下载对应 release 压缩包
 - 想以系统服务长期运行：优先使用 Debian 包
+- 想在 OpenWrt / LuCI 管理：使用 `luci-app-oxidns`
 - 想在容器平台部署：使用 GHCR Docker 或 Docker Hub 镜像
 - 想参与开发或自行裁剪：从源码构建
 
-## 7. 启动后下一步
+## 8. 启动后下一步
 
 启动完成后，建议继续阅读：
 

--- a/docs/docs/roadmap.md
+++ b/docs/docs/roadmap.md
@@ -7,31 +7,31 @@ import RoadmapTimeline, { RoadmapItem } from '@site/src/components/RoadmapTimeli
 
 # 路线图
 
-以下是 OxiDNS 自 v0.1.0 发布以来的完整开发路线图。最新计划在最上方，历史版本按时间倒序排列。
+以下是 OxiDNS 自 v0.1.0 发布以来的完整开发路线图。最新计划在最上方，已完成里程碑和历史版本按时间倒序排列。
 
 <RoadmapTimeline>
 
-<RoadmapItem type="future" label="敬请期待" title="简单模式 WebUI" desc="基于模板配置，打造类 AdGuard Home 的开箱即用体验" num={4}>
+<RoadmapItem type="future" label="敬请期待" title="简单模式 WebUI" desc="基于模板配置，打造类 AdGuard Home 的开箱即用体验" num={3}>
 
 面向不想编写 YAML 的普通用户，提供一套预置场景模板（去广告、防污染、家庭过滤、分流加速等），通过表单与开关完成主要配置；保留切回完整模式继续手写规则的入口。目标体验对标 AdGuard Home 的简单管理界面，让 OxiDNS 的安装门槛接近"开箱即用"。
 
 </RoadmapItem>
 
-<RoadmapItem type="future" label="敬请期待" title="插件 API 扩展与 WebUI 接入" desc="为已有插件补齐管理 API，WebUI 接入新增端点与详情面板" num={3}>
+<RoadmapItem type="future" label="敬请期待" title="插件 API 扩展与 WebUI 接入" desc="为已有插件补齐管理 API，WebUI 接入新增端点与详情面板" num={2}>
 
 按"个体枚举 / 状态查询 / 动作触发"归 API、"计数器 / 直方图 / 低基数 gauge"归 metrics 的划分原则，为 `forward`、`cron`、`download`、`script`、`ip_selector`、`cache`、`rate_limiter` 等已有插件补齐运行时管理 API（上游探测、任务暂停 / 立即执行、规则枚举、热点客户端、缓存 top-N 等），并在 WebUI 的插件详情面板里接入对应端点；同时按上述边界补全 Prometheus 指标，提升整体可观测性与运维效率。
-
-</RoadmapItem>
-
-<RoadmapItem type="future" label="敬请期待" title="OpenWrt 支持" desc="通过 opkg 一键安装，服务自动托管，随系统更新" num={2}>
-
-为 OpenWrt 用户提供与 Debian 包同等级别的原生安装体验：通过 opkg 一键安装、服务自动托管、随系统更新，无需手动部署二进制文件。
 
 </RoadmapItem>
 
 <RoadmapItem type="future" label="敬请期待" title="MikroTik 深度集成" desc="与 RouterOS 双向同步 IP 集，DNS 策略联动路由策略" num={1}>
 
 在现有单向推送基础上，新增从 RouterOS 拉取地址列表作为数据源，以及将本地 IP 集主动推送到 RouterOS，实现 DNS 策略与路由策略的双向数据联动。
+
+</RoadmapItem>
+
+<RoadmapItem type="done" label="2026-07-02" title="OpenWrt LuCI 插件" desc="通过 luci-app-oxidns 在 LuCI 中安装内核、托管服务、编辑配置并查看日志">
+
+新增 [`luci-app-oxidns`](https://github.com/svenshi/luci-app-oxidns)：OpenWrt 用户可以在 LuCI 的 `Services -> OxiDNS` 中安装 OxiDNS core、管理 init 服务、编辑配置并查看日志。LuCI 插件不内置 OxiDNS 内核，首次安装时会从官方 GitHub Releases 下载并校验 Linux musl release archive；后续内核升级继续使用 OxiDNS 自带升级能力。
 
 </RoadmapItem>
 

--- a/docs/i18n/en/docusaurus-plugin-content-docs/current/openwrt.mdx
+++ b/docs/i18n/en/docusaurus-plugin-content-docs/current/openwrt.mdx
@@ -1,0 +1,124 @@
+---
+title: OpenWrt LuCI App
+---
+
+import Admonition from '@theme/Admonition';
+
+OxiDNS supports OpenWrt / LuCI deployment through [`luci-app-oxidns`](https://github.com/svenshi/luci-app-oxidns).
+
+After installation, LuCI adds `Services -> OxiDNS` pages for installing the OxiDNS core binary, managing the OpenWrt init service, editing configuration, and viewing logs.
+
+<Admonition type="info" title="App boundary">
+
+`luci-app-oxidns` does not embed the OxiDNS core binary and no longer manages a separate OpenWrt `oxidns` package. LuCI downloads the official OxiDNS GitHub Release archive, verifies the SHA256 digest, and installs the binary as an OpenWrt service. Future OxiDNS core upgrades should use the upgrade feature built into the OxiDNS WebUI / API / CLI.
+
+</Admonition>
+
+## One-Command LuCI App Install
+
+Run as root on OpenWrt:
+
+```sh
+curl -fsSL https://oxidns.org/install.sh | sh
+```
+
+If `curl` is not installed:
+
+```sh
+wget -O- https://oxidns.org/install.sh | sh
+```
+
+When the script detects OpenWrt, it reads the latest package from [`luci-app-oxidns` Releases](https://github.com/svenshi/luci-app-oxidns/releases), selects `.ipk` or `.apk` for the system package manager, installs `luci-app-oxidns` and the optional Simplified Chinese translation package, and restarts `rpcd`.
+
+Supported environment variables:
+
+| Variable | Purpose |
+| --- | --- |
+| `OXIDNS_OPENWRT_VERSION` | Select the LuCI app release tag, defaults to `latest` |
+| `OXIDNS_OPENWRT_REPO` | Select the LuCI app repository, defaults to `svenshi/luci-app-oxidns` |
+| `OXIDNS_OPENWRT_I18N=0` | Skip the Simplified Chinese translation package |
+| `OXIDNS_OPENWRT_INSTALL=0` | Disable the LuCI app branch on OpenWrt and force normal Linux archive installation |
+
+## Manual LuCI App Install
+
+Download the matching package from [`luci-app-oxidns` Releases](https://github.com/svenshi/luci-app-oxidns/releases), then install it:
+
+```sh
+opkg install ./luci-app-oxidns_*.ipk
+# Optional Simplified Chinese translation
+opkg install ./luci-i18n-oxidns-zh-cn_*.ipk
+```
+
+On OpenWrt systems using `apk`:
+
+```sh
+apk add --allow-untrusted --no-network ./luci-app-oxidns_*.apk
+# Optional Simplified Chinese translation
+apk add --allow-untrusted --no-network ./luci-i18n-oxidns-zh-cn_*.apk
+```
+
+If the menu does not appear after installation, restart `rpcd`:
+
+```sh
+/etc/init.d/rpcd restart
+```
+
+Then open LuCI: `Services -> OxiDNS`.
+
+## Install OxiDNS Core
+
+If you are migrating from the old OpenWrt `oxidns` package model, stop the service and remove the old runtime package first so it no longer owns `/usr/bin/oxidns` or `/etc/init.d/oxidns`:
+
+```sh
+/etc/init.d/oxidns stop
+opkg remove oxidns
+```
+
+On systems using `apk`, run:
+
+```sh
+/etc/init.d/oxidns stop
+apk del oxidns
+```
+
+1. Open `Services -> OxiDNS -> Settings` and confirm `Core repository` is `svenshi/oxidns` and `Core bundle` is `full`.
+2. Open `Services -> OxiDNS -> Core` and click `Install Core`. For offline installs, click `Upload Core` to upload an official `.tar.gz` archive or a single `oxidns` binary.
+3. After installation succeeds, use `Overview` to start and enable the service.
+
+LuCI selects the OxiDNS Linux musl release archive for the current CPU architecture, such as `oxidns-x86_64-unknown-linux-musl.tar.gz`, and verifies the GitHub release asset SHA256 digest before installation.
+
+## Default Paths
+
+- Binary: `/usr/bin/oxidns`
+- WebUI: `/usr/share/oxidns/webui`
+- Config: `/etc/oxidns/config.yaml`
+- Working directory: `/var/lib/oxidns`
+- Init script: `/etc/init.d/oxidns`
+
+## Upgrade And Remove
+
+To upgrade the OxiDNS core, use the upgrade feature built into the OxiDNS WebUI / API / CLI. The LuCI `Core` page handles first install, upload install, and repair reinstall only; it is not a version-upgrade entry point.
+
+To upgrade the LuCI app, download and install the newer `luci-app-oxidns` package. The LuCI UI does not provide self-upgrade.
+
+To remove the OxiDNS core, click `Remove Core` on the LuCI `Core` page. This stops and disables the service, removes `/usr/bin/oxidns` and `/usr/share/oxidns/webui`, and preserves `/etc/oxidns/config.yaml` and `/var/lib/oxidns`.
+
+You can also use the uninstall script to remove the LuCI app and installed OxiDNS core files:
+
+```sh
+curl -fsSL https://oxidns.org/uninstall.sh | sh
+```
+
+By default this removes `luci-app-oxidns` / the translation package, deletes `/usr/bin/oxidns` and `/usr/share/oxidns/webui`, and keeps OxiDNS config, the working directory, and LuCI settings.
+
+To purge config and the working directory too:
+
+```sh
+curl -fsSL https://oxidns.org/uninstall.sh | env OXIDNS_PURGE=1 sh
+```
+
+`OXIDNS_PURGE=1` also deletes OxiDNS config, the working directory, and LuCI settings. Back up `/etc/oxidns/config.yaml` first.
+
+## Restricted Networks
+
+The router must be able to reach GitHub Releases and release archives directly. For private repositories or restricted networks, configure a GitHub token or download proxy in `Settings`; you can also use `Upload Core` on the `Core` page to install an archive or binary offline.

--- a/docs/i18n/en/docusaurus-plugin-content-docs/current/quickstart.mdx
+++ b/docs/i18n/en/docusaurus-plugin-content-docs/current/quickstart.mdx
@@ -12,6 +12,7 @@ This page describes the OxiDNS installation paths and the shortest path from dow
 <Admonition type="tip" title="Which install path should I choose?">
 
 * **Linux servers**: the one-command installer, release archives, or `.deb` packages
+* **OpenWrt routers**: the [`luci-app-oxidns`](openwrt.mdx) LuCI app
 * **Containerized environments**: the Docker image
 * **Local development or debugging**: build from source with Cargo
 * **macOS / Windows**: the one-command installer or release archives
@@ -20,7 +21,7 @@ This page describes the OxiDNS installation paths and the shortest path from dow
 
 ## 1. One-Command Install
 
-The installer detects the current platform, downloads the matching GitHub Release archive, extracts `oxidns` / `oxidns.exe`, `config.yaml`, and `webui/`, then installs and starts OxiDNS as a system service by default.
+The installer detects the current platform. On Linux / macOS / Windows, it downloads the matching OxiDNS GitHub Release archive, extracts `oxidns` / `oxidns.exe`, `config.yaml`, and `webui/`, then installs and starts OxiDNS as a system service by default. On OpenWrt, it downloads and installs the `luci-app-oxidns` LuCI app.
 
 <Tabs groupId="os">
   <TabItem value="unix" label="Linux / macOS" default>
@@ -37,6 +38,19 @@ irm https://oxidns.org/install.ps1 | iex
 ```
 
   </TabItem>
+  <TabItem value="openwrt" label="OpenWrt">
+
+```sh
+curl -fsSL https://oxidns.org/install.sh | sh
+```
+
+If `curl` is not installed:
+
+```sh
+wget -O- https://oxidns.org/install.sh | sh
+```
+
+  </TabItem>
 </Tabs>
 
 Default install locations:
@@ -47,8 +61,11 @@ Default install locations:
 | Windows service install from elevated PowerShell | `%ProgramFiles%\OxiDNS` | Adds the install directory to the Machine PATH, then installs and starts the service |
 | Linux / macOS portable install | `~/.oxidns` | Set `OXIDNS_INSTALL_SERVICE=0`; creates `~/.local/bin/oxidns` |
 | Windows portable install | `%LOCALAPPDATA%\OxiDNS` | Set `OXIDNS_INSTALL_SERVICE=0`; adds the install directory to the user PATH |
+| OpenWrt / LuCI app install | Managed by `opkg` / `apk` | Installs `luci-app-oxidns` and the optional Chinese translation package; install the OxiDNS core from LuCI afterward |
 
-Running the installer again updates the binary and `webui/`. If `config.yaml` already exists in the install directory, the installer keeps it and writes the release default config as `config.yaml.example`.
+In Linux / macOS / Windows archive install mode, running the installer again updates the binary and `webui/`. If `config.yaml` already exists in the install directory, the installer keeps it and writes the release default config as `config.yaml.example`.
+
+On OpenWrt, running the installer again reinstalls the selected `luci-app-oxidns` release package. OxiDNS core version upgrades still use the built-in LuCI / WebUI / API / CLI upgrade flow.
 
 ### Install A Specific Version
 
@@ -81,6 +98,10 @@ Common environment variables:
 | `OXIDNS_NO_PATH=1` | Do not create a command link or update PATH |
 | `OXIDNS_INSTALL_SERVICE=0` | Skip system service installation and use portable install mode |
 | `OXIDNS_START_SERVICE=0` | Install the service but do not start it immediately |
+| `OXIDNS_OPENWRT_INSTALL` | OpenWrt branch switch, defaults to `auto`; set `0` to force normal Linux archive installation |
+| `OXIDNS_OPENWRT_REPO` | LuCI app repository, defaults to `svenshi/luci-app-oxidns` |
+| `OXIDNS_OPENWRT_VERSION` | LuCI app release tag, defaults to `latest` |
+| `OXIDNS_OPENWRT_I18N` | Whether to install the Simplified Chinese translation package, defaults to `auto`; set `0` to skip it |
 
 Portable install:
 
@@ -128,13 +149,26 @@ The default config includes a `:53` listener. On Linux / macOS, portable install
 
 ### Uninstall
 
-The uninstall script removes the binary, `webui/`, and PATH entry while keeping `config.yaml` by default.
+The uninstall script removes the binary, `webui/`, and PATH entry while keeping `config.yaml` by default. On OpenWrt, it removes `luci-app-oxidns` / the translation package and cleans the LuCI-installed `/usr/bin/oxidns` and `/usr/share/oxidns/webui`; OxiDNS config, the working directory, and LuCI settings are kept by default.
 
 <Tabs groupId="os">
   <TabItem value="unix" label="Linux / macOS" default>
 
 ```bash
 curl -fsSL https://oxidns.org/uninstall.sh | sudo sh
+```
+
+  </TabItem>
+  <TabItem value="openwrt" label="OpenWrt">
+
+```sh
+curl -fsSL https://oxidns.org/uninstall.sh | sh
+```
+
+If `curl` is not installed:
+
+```sh
+wget -O- https://oxidns.org/uninstall.sh | sh
 ```
 
   </TabItem>
@@ -147,7 +181,7 @@ irm https://oxidns.org/uninstall.ps1 | iex
   </TabItem>
 </Tabs>
 
-If you installed with `sudo` or a custom `OXIDNS_INSTALL_DIR`, use the same privilege level and directory variable when uninstalling.
+If you installed with `sudo` or a custom `OXIDNS_INSTALL_DIR`, use the same privilege level and directory variable when uninstalling. OpenWrt uninstall requires root.
 
 Remove the install directory and config too:
 
@@ -156,6 +190,19 @@ Remove the install directory and config too:
 
 ```bash
 curl -fsSL https://oxidns.org/uninstall.sh | sudo env OXIDNS_PURGE=1 sh
+```
+
+  </TabItem>
+  <TabItem value="openwrt" label="OpenWrt">
+
+```sh
+curl -fsSL https://oxidns.org/uninstall.sh | env OXIDNS_PURGE=1 sh
+```
+
+If `curl` is not installed:
+
+```sh
+wget -O- https://oxidns.org/uninstall.sh | env OXIDNS_PURGE=1 sh
 ```
 
   </TabItem>
@@ -170,7 +217,7 @@ $env:OXIDNS_PURGE = "1"; irm https://oxidns.org/uninstall.ps1 | iex
 
 <Admonition type="warning" title="Purge removes configuration">
 
-Setting `OXIDNS_PURGE=1` deletes the entire install directory, including the configuration file. Back up `config.yaml` before running it.
+Setting `OXIDNS_PURGE=1` deletes the configuration file. For archive installs it removes the full install directory; on OpenWrt it removes OxiDNS config, the working directory, and LuCI settings. Back up `config.yaml` before running it.
 
 </Admonition>
 
@@ -182,7 +229,10 @@ Common uninstall variables:
 | `OXIDNS_BIN_DIR` | Override the command-link directory on Linux / macOS |
 | `OXIDNS_NO_PATH=1` | Do not remove the command link or user PATH entry |
 | `OXIDNS_UNINSTALL_SERVICE=1` | Force operating-system service uninstall; by default this is attempted automatically as root / administrator |
-| `OXIDNS_PURGE=1` | Remove the full install directory, including config |
+| `OXIDNS_PURGE=1` | For archive installs, remove the full install directory; on OpenWrt, remove OxiDNS config, the working directory, and LuCI settings |
+| `OXIDNS_OPENWRT_UNINSTALL` | OpenWrt uninstall branch switch, defaults to `auto`; set `0` to force normal Linux archive uninstall |
+| `OXIDNS_OPENWRT_CONFIG_PATH` | Override the OpenWrt config path; when omitted, reads UCI `config_path`, then falls back to `/etc/oxidns/config.yaml` |
+| `OXIDNS_OPENWRT_WORKING_DIR` | Override the OpenWrt working directory; when omitted, reads UCI `working_dir`, then falls back to `/var/lib/oxidns` |
 
 ## 2. Build From Source
 
@@ -263,6 +313,7 @@ When the correct asset is unclear, use this mapping:
 | Linux ARM64 | `oxidns-aarch64-unknown-linux-musl.tar.gz` | Safer default for broad compatibility |
 | Debian / Ubuntu x86_64 service install | `*_amd64.deb` | Best fit for systemd-based deployment |
 | Debian / Ubuntu ARM64 service install | `*_arm64.deb` | Best fit for systemd-based deployment |
+| OpenWrt / LuCI | `.ipk` / `.apk` packages from [`luci-app-oxidns`](https://github.com/svenshi/luci-app-oxidns) | Install the LuCI app first; LuCI then downloads and installs the OxiDNS Linux musl core |
 | Alpine Linux x86_64 | `oxidns-x86_64-unknown-linux-musl.tar.gz` | Prefer musl on Alpine |
 | Alpine Linux ARM64 | `oxidns-aarch64-unknown-linux-musl.tar.gz` | Static-friendly build |
 | Confirmed glibc Linux requiring a dynamic build | `oxidns-x86_64-unknown-linux-gnu.tar.gz` / `oxidns-aarch64-unknown-linux-gnu.tar.gz` | Only choose this when the target environment is clearly compatible |
@@ -370,7 +421,45 @@ If the service is not running yet:
 sudo systemctl enable --now oxidns
 ```
 
-## 5. Run With Docker
+## 5. OpenWrt / LuCI App
+
+OpenWrt users should use the OxiDNS installer script to install [`luci-app-oxidns`](https://github.com/svenshi/luci-app-oxidns). It adds `Services -> OxiDNS` pages to LuCI for installing the OxiDNS core, managing the init service, editing configuration, and viewing logs.
+
+```sh
+curl -fsSL https://oxidns.org/install.sh | sh
+```
+
+If `curl` is not installed:
+
+```sh
+wget -O- https://oxidns.org/install.sh | sh
+```
+
+When the script detects OpenWrt, it reads the latest `luci-app-oxidns` release, selects `.ipk` or `.apk` for the system package manager, installs the main package and optional Simplified Chinese translation package, and restarts `rpcd`.
+
+### Manual LuCI App Install
+
+Download the matching LuCI package from the `luci-app-oxidns` Release, then install it:
+
+```sh
+opkg install ./luci-app-oxidns_*.ipk
+# Optional Simplified Chinese translation
+opkg install ./luci-i18n-oxidns-zh-cn_*.ipk
+```
+
+On OpenWrt systems using `apk`:
+
+```sh
+apk add --allow-untrusted --no-network ./luci-app-oxidns_*.apk
+# Optional Simplified Chinese translation
+apk add --allow-untrusted --no-network ./luci-i18n-oxidns-zh-cn_*.apk
+```
+
+After installation, open `Services -> OxiDNS -> Core` and click `Install Core`. LuCI downloads and verifies the official OxiDNS Linux musl release archive for the current CPU architecture; offline environments can upload an official `.tar.gz` archive or a single `oxidns` binary.
+
+See [OpenWrt LuCI App](openwrt.mdx) for the full flow.
+
+## 6. Run With Docker
 
 The repository publishes a Docker image at:
 
@@ -449,14 +538,15 @@ Follow logs with:
 docker compose logs -f oxidns
 ```
 
-## 6. Selection Guide
+## 7. Selection Guide
 
 - Fastest evaluation path: use the one-command installer for the latest release, or download a release archive manually
 - Long-running Linux service: prefer the Debian package
+- OpenWrt / LuCI management: use `luci-app-oxidns`
 - Container platforms: use the GHCR Docker or Docker Hub image
 - Development or custom builds: compile from source
 
-## 7. Next Reading
+## 8. Next Reading
 
 After the first successful start, continue with:
 

--- a/docs/i18n/en/docusaurus-plugin-content-docs/current/roadmap.md
+++ b/docs/i18n/en/docusaurus-plugin-content-docs/current/roadmap.md
@@ -7,31 +7,31 @@ import RoadmapTimeline, { RoadmapItem } from '@site/src/components/RoadmapTimeli
 
 # Roadmap
 
-OxiDNS's complete development roadmap since v0.1.0. Upcoming work appears at the top; past versions follow in reverse chronological order.
+OxiDNS's complete development roadmap since v0.1.0. Upcoming work appears at the top; completed milestones and past versions follow in reverse chronological order.
 
 <RoadmapTimeline>
 
-<RoadmapItem type="future" label="Soon" title="Simple-mode WebUI" desc="Template-driven config delivering an AdGuard Home-style turnkey experience" num={4}>
+<RoadmapItem type="future" label="Soon" title="Simple-mode WebUI" desc="Template-driven config delivering an AdGuard Home-style turnkey experience" num={3}>
 
 For users who don't want to touch YAML: a set of preset scenario templates (ad blocking, anti-poisoning, family filtering, split-tunnel acceleration) configured entirely through forms and toggles, with an escape hatch back to the full editor for advanced rules. The target experience matches AdGuard Home's simple admin UI, bringing OxiDNS's setup bar close to out-of-the-box.
 
 </RoadmapItem>
 
-<RoadmapItem type="future" label="Soon" title="Plugin API Expansion & WebUI Wiring" desc="Fill in management APIs for existing plugins; wire them into the WebUI" num={3}>
+<RoadmapItem type="future" label="Soon" title="Plugin API Expansion & WebUI Wiring" desc="Fill in management APIs for existing plugins; wire them into the WebUI" num={2}>
 
 Apply the rule "per-entity / status / action → API; counters / histograms / low-cardinality gauges → metrics" and fill in runtime management APIs (upstream probe, job pause / run-now, rule enumeration, hot-client buckets, cache top-N, …) for existing plugins such as `forward`, `cron`, `download`, `script`, `ip_selector`, `cache`, and `rate_limiter`. Wire each endpoint into a corresponding WebUI detail panel and round out Prometheus metrics along the same boundary to improve observability and day-2 operations.
-
-</RoadmapItem>
-
-<RoadmapItem type="future" label="Soon" title="OpenWrt Support" desc="One-command install via opkg, automatic service management, system-integrated updates" num={2}>
-
-Native install experience for OpenWrt users on par with the Debian package: opkg one-command install, automatic service management, system-integrated updates — no manual binary deployment.
 
 </RoadmapItem>
 
 <RoadmapItem type="future" label="Soon" title="MikroTik Deep Integration" desc="Bidirectional IP set sync between OxiDNS and RouterOS" num={1}>
 
 On top of the existing one-way push, add pulling RouterOS address lists as an OxiDNS data source and actively pushing local IP sets to RouterOS — bidirectional DNS-policy and routing-policy integration.
+
+</RoadmapItem>
+
+<RoadmapItem type="done" label="2026-07-02" title="OpenWrt LuCI App" desc="Use luci-app-oxidns to install the core, manage the service, edit config, and view logs from LuCI">
+
+Added [`luci-app-oxidns`](https://github.com/svenshi/luci-app-oxidns): OpenWrt users can install the OxiDNS core, manage the init service, edit configuration, and view logs from LuCI under `Services -> OxiDNS`. The LuCI app does not embed the OxiDNS core; on first install it downloads and verifies the official Linux musl release archive from GitHub Releases. Future core upgrades continue to use OxiDNS's built-in upgrade capability.
 
 </RoadmapItem>
 

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -5,7 +5,7 @@ const sidebars = {
       type: 'category',
       label: '入门',
       collapsed: false,
-      items: ['quickstart', 'scenarios', 'migrate-from-mosdns'],
+      items: ['quickstart', 'openwrt', 'scenarios', 'migrate-from-mosdns'],
     },
     {
       type: 'category',

--- a/docs/src/components/Hero.tsx
+++ b/docs/src/components/Hero.tsx
@@ -49,6 +49,7 @@ const TELEGRAM_QR = '/img/telegram-qr.png';
 const INSTALL_TABS: InstallTab[] = [
   { label: 'Linux / macOS', prompt: '$', code: 'curl -fsSL https://oxidns.org/install.sh | sudo sh' },
   { label: 'Windows', prompt: 'PS>', code: 'irm https://oxidns.org/install.ps1 | iex' },
+  { label: 'OpenWrt', prompt: '#', code: 'curl -fsSL https://oxidns.org/install.sh | sh' },
   { label: 'Docker', prompt: '$', code: 'docker run -d \\\n' +
           '  --name oxidns \\\n' +
           '  --restart unless-stopped \\\n' +

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-# Install OxiDNS release archives on Linux and macOS.
+# Install OxiDNS release archives on Linux and macOS, or luci-app-oxidns on OpenWrt.
 #
 # Common overrides:
 #   OXIDNS_VERSION=v1.0.1
@@ -9,6 +9,10 @@
 #   OXIDNS_BUNDLE=standard
 #   OXIDNS_INSTALL_SERVICE=0
 #   OXIDNS_START_SERVICE=0
+#   OXIDNS_OPENWRT_INSTALL=auto
+#   OXIDNS_OPENWRT_REPO=svenshi/luci-app-oxidns
+#   OXIDNS_OPENWRT_VERSION=latest
+#   OXIDNS_OPENWRT_I18N=auto
 
 set -eu
 
@@ -21,6 +25,10 @@ BIN_DIR="${OXIDNS_BIN_DIR:-}"
 NO_PATH="${OXIDNS_NO_PATH:-0}"
 INSTALL_SERVICE="${OXIDNS_INSTALL_SERVICE:-1}"
 START_SERVICE="${OXIDNS_START_SERVICE:-1}"
+OPENWRT_INSTALL="${OXIDNS_OPENWRT_INSTALL:-auto}"
+OPENWRT_REPO="${OXIDNS_OPENWRT_REPO:-svenshi/luci-app-oxidns}"
+OPENWRT_VERSION="${OXIDNS_OPENWRT_VERSION:-latest}"
+OPENWRT_I18N="${OXIDNS_OPENWRT_I18N:-auto}"
 
 log() {
     printf '%s\n' "$*"
@@ -42,6 +50,13 @@ need_cmd() {
 is_truthy() {
     case "$1" in
         1|true|TRUE|yes|YES|on|ON) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+is_falsey() {
+    case "$1" in
+        0|false|FALSE|no|NO|off|OFF) return 0 ;;
         *) return 1 ;;
     esac
 }
@@ -95,6 +110,136 @@ download() {
     fi
 }
 
+is_openwrt() {
+    [ -f /etc/openwrt_release ] && return 0
+    if [ -r /etc/os-release ] && grep -qi 'openwrt' /etc/os-release 2>/dev/null; then
+        return 0
+    fi
+    return 1
+}
+
+should_install_openwrt() {
+    case "$OPENWRT_INSTALL" in
+        auto|"")
+            is_openwrt
+            ;;
+        *)
+            is_truthy "$OPENWRT_INSTALL"
+            ;;
+    esac
+}
+
+openwrt_release_api_url() {
+    if [ "$OPENWRT_VERSION" = "latest" ]; then
+        printf 'https://api.github.com/repos/%s/releases/latest' "$OPENWRT_REPO"
+    else
+        printf 'https://api.github.com/repos/%s/releases/tags/%s' "$OPENWRT_REPO" "$OPENWRT_VERSION"
+    fi
+}
+
+openwrt_asset_url() {
+    release_json="$1"
+    package_name="$2"
+    package_ext="$3"
+
+    sed -n 's#.*"browser_download_url"[[:space:]]*:[[:space:]]*"\([^"]*/'"$package_name"'_[^"]*_all\.'"$package_ext"'\)".*#\1#p' "$release_json" | head -n 1
+}
+
+openwrt_install_package() {
+    package_manager="$1"
+    package_path="$2"
+
+    case "$package_manager" in
+        opkg)
+            opkg install "$package_path"
+            ;;
+        apk)
+            apk add --allow-untrusted --no-network "$package_path"
+            ;;
+        *)
+            err "unsupported OpenWrt package manager: $package_manager"
+            ;;
+    esac
+}
+
+install_openwrt_luci() {
+    is_root || err "OpenWrt LuCI installation requires root; rerun as root"
+    need_cmd sed
+    need_cmd head
+    need_cmd mktemp
+
+    if command -v opkg >/dev/null 2>&1; then
+        openwrt_package_manager="opkg"
+        openwrt_package_ext="ipk"
+    elif command -v apk >/dev/null 2>&1; then
+        openwrt_package_manager="apk"
+        openwrt_package_ext="apk"
+    else
+        err "OpenWrt package manager not found: expected opkg or apk"
+    fi
+
+    openwrt_tmp_dir="$(mktemp -d "${TMPDIR:-/tmp}/oxidns-openwrt-install.XXXXXX")"
+    cleanup_openwrt() {
+        rm -rf "$openwrt_tmp_dir"
+    }
+    trap cleanup_openwrt EXIT HUP INT TERM
+
+    openwrt_release_json="$openwrt_tmp_dir/release.json"
+    openwrt_api_url="$(openwrt_release_api_url)"
+
+    log "Downloading luci-app-oxidns release metadata from $OPENWRT_REPO ($OPENWRT_VERSION)..."
+    download "$openwrt_api_url" "$openwrt_release_json"
+
+    openwrt_app_url="$(openwrt_asset_url "$openwrt_release_json" "luci-app-oxidns" "$openwrt_package_ext")"
+    [ -n "$openwrt_app_url" ] || err "could not find luci-app-oxidns .$openwrt_package_ext asset in $OPENWRT_REPO release $OPENWRT_VERSION"
+
+    openwrt_app_pkg="$openwrt_tmp_dir/${openwrt_app_url##*/}"
+    log "Downloading ${openwrt_app_url##*/}..."
+    download "$openwrt_app_url" "$openwrt_app_pkg"
+
+    log "Installing ${openwrt_app_url##*/} with $openwrt_package_manager..."
+    openwrt_install_package "$openwrt_package_manager" "$openwrt_app_pkg"
+
+    openwrt_i18n_url="$(openwrt_asset_url "$openwrt_release_json" "luci-i18n-oxidns-zh-cn" "$openwrt_package_ext")"
+    openwrt_install_i18n=0
+    case "$OPENWRT_I18N" in
+        auto|"")
+            [ -n "$openwrt_i18n_url" ] && openwrt_install_i18n=1
+            ;;
+        *)
+            if is_truthy "$OPENWRT_I18N"; then
+                [ -n "$openwrt_i18n_url" ] || err "OXIDNS_OPENWRT_I18N=1 but luci-i18n-oxidns-zh-cn .$openwrt_package_ext asset was not found"
+                openwrt_install_i18n=1
+            elif is_falsey "$OPENWRT_I18N"; then
+                openwrt_install_i18n=0
+            else
+                err "unsupported OXIDNS_OPENWRT_I18N=$OPENWRT_I18N; expected auto, 1, or 0"
+            fi
+            ;;
+    esac
+
+    if [ "$openwrt_install_i18n" = "1" ]; then
+        openwrt_i18n_pkg="$openwrt_tmp_dir/${openwrt_i18n_url##*/}"
+        log "Downloading ${openwrt_i18n_url##*/}..."
+        download "$openwrt_i18n_url" "$openwrt_i18n_pkg"
+
+        log "Installing ${openwrt_i18n_url##*/} with $openwrt_package_manager..."
+        openwrt_install_package "$openwrt_package_manager" "$openwrt_i18n_pkg"
+    fi
+
+    if [ -x /etc/init.d/rpcd ]; then
+        if /etc/init.d/rpcd restart >/dev/null 2>&1; then
+            log "Restarted rpcd"
+        else
+            warn "failed to restart rpcd; run /etc/init.d/rpcd restart if the LuCI menu does not appear"
+        fi
+    fi
+
+    log "luci-app-oxidns installed"
+    log "Open LuCI: Services -> OxiDNS"
+    log "Then use Core -> Install Core to download and install the OxiDNS core binary."
+}
+
 contains_path() {
     dir="$1"
     case ":${PATH:-}:" in
@@ -124,6 +269,11 @@ install_link() {
     cp "$INSTALL_DIR/oxidns" "$link_path"
     chmod 755 "$link_path"
 }
+
+if should_install_openwrt; then
+    install_openwrt_luci
+    exit 0
+fi
 
 if [ -z "$TARGET" ]; then
     TARGET="$(detect_target)"

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -1,11 +1,13 @@
 #!/bin/sh
-# Uninstall OxiDNS files installed by scripts/install.sh on Linux and macOS.
+# Uninstall OxiDNS files installed by scripts/install.sh on Linux and macOS,
+# or luci-app-oxidns plus OxiDNS core files on OpenWrt.
 #
 # Common overrides:
 #   OXIDNS_INSTALL_DIR=/opt/oxidns
 #   OXIDNS_BIN_DIR=/usr/local/bin
 #   OXIDNS_UNINSTALL_SERVICE=1
 #   OXIDNS_PURGE=1
+#   OXIDNS_OPENWRT_UNINSTALL=auto
 
 set -eu
 
@@ -15,6 +17,14 @@ NO_PATH="${OXIDNS_NO_PATH:-0}"
 UNINSTALL_SERVICE="${OXIDNS_UNINSTALL_SERVICE:-auto}"
 PURGE="${OXIDNS_PURGE:-0}"
 HOME_DIR="${HOME:-}"
+OPENWRT_UNINSTALL="${OXIDNS_OPENWRT_UNINSTALL:-auto}"
+OPENWRT_CONFIG_PATH="${OXIDNS_OPENWRT_CONFIG_PATH:-}"
+OPENWRT_WORKING_DIR="${OXIDNS_OPENWRT_WORKING_DIR:-}"
+OPENWRT_BIN="/usr/bin/oxidns"
+OPENWRT_WEBUI_DIR="/usr/share/oxidns/webui"
+OPENWRT_UCI_CONFIG="/etc/config/oxidns"
+OPENWRT_DEFAULT_CONFIG_PATH="/etc/oxidns/config.yaml"
+OPENWRT_DEFAULT_WORKING_DIR="/var/lib/oxidns"
 
 log() {
     printf '%s\n' "$*"
@@ -40,6 +50,25 @@ is_root() {
     [ "$(id -u 2>/dev/null || printf '1')" = "0" ]
 }
 
+is_openwrt() {
+    [ -f /etc/openwrt_release ] && return 0
+    if [ -r /etc/os-release ] && grep -qi 'openwrt' /etc/os-release 2>/dev/null; then
+        return 0
+    fi
+    return 1
+}
+
+should_uninstall_openwrt() {
+    case "$OPENWRT_UNINSTALL" in
+        auto|"")
+            is_openwrt
+            ;;
+        *)
+            is_truthy "$OPENWRT_UNINSTALL"
+            ;;
+    esac
+}
+
 should_uninstall_service() {
     case "$UNINSTALL_SERVICE" in
         auto|"")
@@ -49,6 +78,215 @@ should_uninstall_service() {
             is_truthy "$UNINSTALL_SERVICE"
             ;;
     esac
+}
+
+uci_get_oxidns() {
+    option="$1"
+    fallback="$2"
+
+    if command -v uci >/dev/null 2>&1; then
+        value="$(uci -q get "oxidns.main.$option" 2>/dev/null || true)"
+        if [ -n "$value" ]; then
+            printf '%s' "$value"
+            return 0
+        fi
+    fi
+
+    printf '%s' "$fallback"
+}
+
+oxidns_named_path() {
+    path_value="$1"
+    base_name="$(basename "$path_value" 2>/dev/null || printf '')"
+    dir_name="$(dirname "$path_value" 2>/dev/null || printf '')"
+    dir_base="$(basename "$dir_name" 2>/dev/null || printf '')"
+
+    case "$base_name:$dir_base" in
+        *oxidns*|*:oxidns*) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+path_has_parent_ref() {
+    case "$1" in
+        ..|../*|*/..|*/../*) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+safe_remove_openwrt_config_path() {
+    path_value="$1"
+
+    [ -n "$path_value" ] || return 1
+    path_has_parent_ref "$path_value" && return 1
+    case "$path_value" in
+        /*) ;;
+        *) return 1 ;;
+    esac
+    [ -d "$path_value" ] && return 1
+    oxidns_named_path "$path_value"
+}
+
+safe_remove_openwrt_working_dir() {
+    path_value="$1"
+
+    [ -n "$path_value" ] || return 1
+    path_has_parent_ref "$path_value" && return 1
+    case "$path_value" in
+        /*) ;;
+        *) return 1 ;;
+    esac
+    case "$path_value" in
+        /|/bin|/dev|/etc|/lib|/mnt|/overlay|/proc|/rom|/root|/sbin|/sys|/tmp|/usr|/var|/www)
+            return 1
+            ;;
+    esac
+    oxidns_named_path "$path_value"
+}
+
+openwrt_package_manager() {
+    if command -v opkg >/dev/null 2>&1; then
+        printf 'opkg'
+    elif command -v apk >/dev/null 2>&1; then
+        printf 'apk'
+    else
+        err "OpenWrt package manager not found: expected opkg or apk"
+    fi
+}
+
+openwrt_package_installed() {
+    package_manager="$1"
+    package_name="$2"
+
+    case "$package_manager" in
+        opkg)
+            opkg status "$package_name" 2>/dev/null | grep -q '^Status: .* installed'
+            ;;
+        apk)
+            apk info -e "$package_name" >/dev/null 2>&1
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
+
+openwrt_remove_package() {
+    package_manager="$1"
+    package_name="$2"
+
+    if ! openwrt_package_installed "$package_manager" "$package_name"; then
+        log "OpenWrt package not installed: $package_name"
+        return 0
+    fi
+
+    log "Removing OpenWrt package: $package_name"
+    case "$package_manager" in
+        opkg)
+            opkg remove "$package_name"
+            ;;
+        apk)
+            apk del "$package_name"
+            ;;
+        *)
+            err "unsupported OpenWrt package manager: $package_manager"
+            ;;
+    esac
+}
+
+openwrt_stop_service() {
+    init="/etc/init.d/oxidns"
+
+    if [ ! -x "$init" ]; then
+        return 0
+    fi
+
+    "$init" stop >/dev/null 2>&1 || true
+    "$init" disable >/dev/null 2>&1 || true
+    log "Stopped and disabled OpenWrt service: oxidns"
+}
+
+restore_openwrt_uci_config() {
+    backup_file="$1"
+
+    [ -n "$backup_file" ] || return 0
+    [ -f "$backup_file" ] || return 0
+    [ ! -e "$OPENWRT_UCI_CONFIG" ] || return 0
+
+    mkdir -p "$(dirname "$OPENWRT_UCI_CONFIG")"
+    cp "$backup_file" "$OPENWRT_UCI_CONFIG"
+    log "Restored LuCI settings: $OPENWRT_UCI_CONFIG"
+}
+
+install_openwrt_uninstall_trap() {
+    tmp_dir="$1"
+    trap 'rm -rf "$tmp_dir"' EXIT HUP INT TERM
+}
+
+uninstall_openwrt() {
+    is_root || err "OpenWrt uninstall requires root; rerun as root"
+
+    package_manager="$(openwrt_package_manager)"
+    config_path="${OPENWRT_CONFIG_PATH:-$(uci_get_oxidns config_path "$OPENWRT_DEFAULT_CONFIG_PATH")}"
+    working_dir="${OPENWRT_WORKING_DIR:-$(uci_get_oxidns working_dir "$OPENWRT_DEFAULT_WORKING_DIR")}"
+    tmp_dir="$(mktemp -d "${TMPDIR:-/tmp}/oxidns-openwrt-uninstall.XXXXXX")"
+    uci_backup=""
+
+    install_openwrt_uninstall_trap "$tmp_dir"
+
+    if ! is_truthy "$PURGE" && [ -f "$OPENWRT_UCI_CONFIG" ]; then
+        uci_backup="$tmp_dir/uci-oxidns"
+        cp "$OPENWRT_UCI_CONFIG" "$uci_backup"
+    fi
+
+    if should_uninstall_service; then
+        openwrt_stop_service
+    fi
+
+    openwrt_remove_package "$package_manager" "luci-i18n-oxidns-zh-cn"
+    openwrt_remove_package "$package_manager" "luci-app-oxidns"
+    restore_openwrt_uci_config "$uci_backup"
+
+    rm -f "$OPENWRT_BIN"
+    rm -rf "$OPENWRT_WEBUI_DIR"
+    rmdir "$(dirname "$OPENWRT_WEBUI_DIR")" 2>/dev/null || true
+    log "Removed OxiDNS core binary: $OPENWRT_BIN"
+    log "Removed OxiDNS WebUI: $OPENWRT_WEBUI_DIR"
+
+    if is_truthy "$PURGE"; then
+        if [ -e "$config_path" ]; then
+            safe_remove_openwrt_config_path "$config_path" || err "refusing to delete unsafe OpenWrt config path: $config_path"
+            rm -f "$config_path"
+            rmdir "$(dirname "$config_path")" 2>/dev/null || true
+            log "Removed config: $config_path"
+        fi
+
+        if [ -e "$working_dir" ]; then
+            safe_remove_openwrt_working_dir "$working_dir" || err "refusing to delete unsafe OpenWrt working directory: $working_dir"
+            rm -rf "$working_dir"
+            log "Removed working directory: $working_dir"
+        fi
+
+        if [ -e "$OPENWRT_UCI_CONFIG" ]; then
+            safe_remove_openwrt_config_path "$OPENWRT_UCI_CONFIG" || err "refusing to delete unsafe OpenWrt LuCI settings path: $OPENWRT_UCI_CONFIG"
+            rm -f "$OPENWRT_UCI_CONFIG"
+            log "Removed LuCI settings: $OPENWRT_UCI_CONFIG"
+        fi
+    else
+        if [ -f "$config_path" ]; then
+            log "Kept config: $config_path"
+        fi
+        if [ -d "$working_dir" ]; then
+            log "Kept working directory: $working_dir"
+        fi
+        log "Use OXIDNS_PURGE=1 to remove OpenWrt config and working directory."
+    fi
+
+    if [ -x /etc/init.d/rpcd ]; then
+        /etc/init.d/rpcd restart >/dev/null 2>&1 || warn "failed to restart rpcd"
+    fi
+
+    log "OxiDNS OpenWrt uninstall complete"
 }
 
 same_file() {
@@ -134,6 +372,11 @@ uninstall_service() {
         warn "service uninstall failed or service was not installed"
     fi
 }
+
+if should_uninstall_openwrt; then
+    uninstall_openwrt
+    exit 0
+fi
 
 if [ -z "$INSTALL_DIR" ]; then
     if is_root; then


### PR DESCRIPTION
- Detect OpenWrt in the installer and install luci-app-oxidns via opkg/apk from GitHub Releases.
- Add OpenWrt uninstall handling that removes LuCI packages and core files while preserving config by default.
- Support purge semantics for OpenWrt config, working directory, and LuCI settings.
- Document OpenWrt install, uninstall, and roadmap status in both locales.