### PR TITLE
fix(dns): avoid CNAME-only hits for address queries

### DIFF
--- a/crates/proto/src/rdata/service.rs
+++ b/crates/proto/src/rdata/service.rs
@@ -252,7 +252,7 @@ impl SvcParamValue {
                     return Self::Unknown;
                 }
                 let mut mandatory = Vec::with_capacity(value.len() / 2);
-                for chunk in value.chunks_exact(2) {
+                for chunk in value.as_chunks::<2>().0 {
                     mandatory.push(u16::from_be_bytes([chunk[0], chunk[1]]));
                 }
                 Self::Mandatory(mandatory)
@@ -290,7 +290,9 @@ impl SvcParamValue {
                     return Self::Unknown;
                 }
                 let hints = value
-                    .chunks_exact(4)
+                    .as_chunks::<4>()
+                    .0
+                    .iter()
                     .map(|c| Ipv4Addr::new(c[0], c[1], c[2], c[3]))
                     .collect();
                 Self::Ipv4Hint(hints)
@@ -301,7 +303,9 @@ impl SvcParamValue {
                     return Self::Unknown;
                 }
                 let hints = value
-                    .chunks_exact(16)
+                    .as_chunks::<16>()
+                    .0
+                    .iter()
                     .map(|c| {
                         let mut octets = [0u8; 16];
                         octets.copy_from_slice(c);

--- a/src/infra/network/upstream/config.rs
+++ b/src/infra/network/upstream/config.rs
@@ -576,40 +576,29 @@ fn detect_connection_type(
     let url =
         Url::parse(addr).map_err(|e| DnsError::plugin(format!("invalid upstream URL: {}", e)))?;
     let mut helper_flags = HelperFlags::default();
-    let connection_type;
 
     let host = url
         .host_str()
         .map(|host| host.to_owned())
         .ok_or_else(|| DnsError::plugin("invalid upstream URL: no host specified"))?;
 
-    match url.scheme() {
-        "udp" => {
-            connection_type = ConnectionType::UDP;
-        }
-        "tcp" => {
-            connection_type = ConnectionType::TCP;
-        }
+    let connection_type = match url.scheme() {
+        "udp" => ConnectionType::UDP,
+        "tcp" => ConnectionType::TCP,
         "tcp+pipeline" => {
             helper_flags.force_pipeline = true;
-            connection_type = ConnectionType::TCP;
+            ConnectionType::TCP
         }
-        "tls" => {
-            connection_type = ConnectionType::DoT;
-        }
+        "tls" => ConnectionType::DoT,
         "tls+pipeline" => {
             helper_flags.force_pipeline = true;
-            connection_type = ConnectionType::DoT;
+            ConnectionType::DoT
         }
-        "quic" | "doq" => {
-            connection_type = ConnectionType::DoQ;
-        }
-        "https" | "doh" => {
-            connection_type = ConnectionType::DoH;
-        }
+        "quic" | "doq" => ConnectionType::DoQ,
+        "https" | "doh" => ConnectionType::DoH,
         "h3" => {
             helper_flags.force_http3 = true;
-            connection_type = ConnectionType::DoH;
+            ConnectionType::DoH
         }
         other => {
             return Err(DnsError::plugin(format!(

--- a/src/plugin/executor/cache/mod.rs
+++ b/src/plugin/executor/cache/mod.rs
@@ -815,7 +815,25 @@ impl Cache {
 
         match cache_map.get_retained_cloned_status(&key, now, touch_interval_ms) {
             Some(TtlCacheLookup::Hit(item)) => {
-                if now < item.value.fresh_until_ms {
+                if !is_cache_entry_response_valid(&item.value.resp, key.record_type) {
+                    if cache_map.remove_if(&key, |existing| {
+                        existing.cache_time_ms == item.cache_time_ms
+                            && existing.expire_at_ms == item.expire_at_ms
+                            && Arc::ptr_eq(&existing.value, &item.value)
+                    }) {
+                        self.updated_keys.fetch_add(1, Ordering::Relaxed);
+                        self.metrics.record_skip(CacheSkipReason::NoTtl);
+                        debug!(
+                            "evicted invalid cache entry: domain={}, type={:?}, class={:?}, do={}, cd={}, ecs={}",
+                            key.domain,
+                            key.record_type,
+                            key.dns_class,
+                            key.do_bit,
+                            key.cd_bit,
+                            key.ecs_scope.is_some()
+                        );
+                    }
+                } else if now < item.value.fresh_until_ms {
                     self.metrics.fresh_hit_total.fetch_add(1, Ordering::Relaxed);
                     let remaining_ttl = item
                         .value
@@ -1418,6 +1436,15 @@ fn is_complete_positive_response(response: &Message, record_type: RecordType) ->
     response.rcode() == Rcode::NoError
         && !response.answers().is_empty()
         && (record_type == RecordType::ANY || response.has_answer_type(record_type))
+}
+
+fn is_cache_entry_response_valid(response: &Message, record_type: RecordType) -> bool {
+    match response.rcode() {
+        Rcode::NoError if response.answers().is_empty() => true,
+        Rcode::NoError => is_complete_positive_response(response, record_type),
+        Rcode::NXDomain => true,
+        _ => false,
+    }
 }
 
 fn parse_cache_config(args: Option<Value>) -> Result<CacheConfig> {
@@ -2409,6 +2436,44 @@ mod tests {
 
         assert_eq!(cache.cache_map.get().unwrap().len(), 0);
         assert_eq!(cache.metrics.insert_total.load(AtomicOrdering::Relaxed), 0);
+        assert_eq!(
+            cache
+                .metrics
+                .skip_no_ttl_total
+                .load(AtomicOrdering::Relaxed),
+            1
+        );
+    }
+
+    #[tokio::test]
+    async fn restored_cname_only_address_entry_is_evicted_before_cache_hit() {
+        AppClock::start();
+        let mut cache = test_cache(default_test_config());
+        let _ = cache.init_for_test().await;
+
+        let mut context = make_context(make_request_with_query("example.com.", false, false));
+        let key = Cache::build_cache_key(&mut context, false).unwrap();
+        let now = AppClock::elapsed_millis();
+        cache.cache_map.get().unwrap().insert_or_update_with_meta(
+            key,
+            Arc::new(CacheItem::new(
+                cname_only_response_for_domain("example.com.", 60),
+                60,
+                now.saturating_add(60_000),
+            )),
+            now,
+            now.saturating_add(60_000),
+            now,
+        );
+
+        let lookup = cache
+            .try_cache_hit(&mut context, cache.cache_map.get().unwrap())
+            .expect("cache lookup should exist");
+
+        assert_eq!(lookup.hit_kind, None);
+        assert!(context.response().is_none());
+        assert_eq!(cache.cache_map.get().unwrap().len(), 0);
+        assert_eq!(cache.metrics.miss_total.load(AtomicOrdering::Relaxed), 1);
         assert_eq!(
             cache
                 .metrics

--- a/src/plugin/executor/cache/mod.rs
+++ b/src/plugin/executor/cache/mod.rs
@@ -861,9 +861,7 @@ impl Cache {
                         hit_kind: Some(CacheHitKind::Fresh),
                         refresh_entry: None,
                     });
-                }
-
-                if self.config.lazy_cache_ttl.is_some() && now < item.expire_at_ms {
+                } else if self.config.lazy_cache_ttl.is_some() && now < item.expire_at_ms {
                     let refresh_entry = CacheEntryIdentity {
                         value: item.value.clone(),
                         cache_time_ms: item.cache_time_ms,
@@ -2474,6 +2472,50 @@ mod tests {
         assert!(context.response().is_none());
         assert_eq!(cache.cache_map.get().unwrap().len(), 0);
         assert_eq!(cache.metrics.miss_total.load(AtomicOrdering::Relaxed), 1);
+        assert_eq!(
+            cache
+                .metrics
+                .skip_no_ttl_total
+                .load(AtomicOrdering::Relaxed),
+            1
+        );
+    }
+
+    #[tokio::test]
+    async fn restored_cname_only_address_entry_is_not_served_as_lazy_stale_hit() {
+        AppClock::start();
+        let mut cfg = default_test_config();
+        cfg.lazy_cache_ttl = Some(30);
+        let mut cache = test_cache(cfg);
+        let _ = cache.init_for_test().await;
+
+        let mut context = make_context(make_request_with_query("example.com.", false, false));
+        let key = Cache::build_cache_key(&mut context, false).unwrap();
+        let now = AppClock::elapsed_millis();
+        cache.cache_map.get().unwrap().insert_or_update_with_meta(
+            key,
+            Arc::new(CacheItem::new(
+                cname_only_response_for_domain("example.com.", 60),
+                60,
+                now.saturating_sub(1_000),
+            )),
+            now.saturating_sub(61_000),
+            now.saturating_add(30_000),
+            now,
+        );
+
+        let lookup = cache
+            .try_cache_hit(&mut context, cache.cache_map.get().unwrap())
+            .expect("cache lookup should exist");
+
+        assert_eq!(lookup.hit_kind, None);
+        assert!(context.response().is_none());
+        assert_eq!(cache.cache_map.get().unwrap().len(), 0);
+        assert_eq!(cache.metrics.miss_total.load(AtomicOrdering::Relaxed), 1);
+        assert_eq!(
+            cache.metrics.stale_hit_total.load(AtomicOrdering::Relaxed),
+            0
+        );
         assert_eq!(
             cache
                 .metrics

--- a/src/plugin/executor/cache/mod.rs
+++ b/src/plugin/executor/cache/mod.rs
@@ -32,7 +32,7 @@ use crate::infra::observability::metrics::{
 use crate::infra::task as task_center;
 use crate::plugin::executor::{ExecStep, Executor, ExecutorNext};
 use crate::plugin::{Plugin, PluginFactory, UninitializedPlugin};
-use crate::proto::{Message, Rcode};
+use crate::proto::{Message, Rcode, RecordType};
 use crate::{continue_next, plugin_factory};
 
 #[cfg(feature = "api")]
@@ -783,12 +783,10 @@ impl Cache {
     }
 
     #[inline]
-    fn can_lazy_cache_response(&self, response: &Message) -> bool {
+    fn can_lazy_cache_response(&self, response: &Message, record_type: RecordType) -> bool {
         self.config.lazy_cache_ttl.is_some()
-            && response.rcode() == Rcode::NoError
-            && !response.answers().is_empty()
             && matches!(
-                self.compute_positive_ttl(response),
+                self.compute_positive_ttl(response, record_type),
                 CacheTtlDecision::Cache(_)
             )
     }
@@ -942,8 +940,12 @@ impl Cache {
     }
 
     #[inline]
-    fn compute_positive_ttl(&self, response: &Message) -> CacheTtlDecision {
-        if response.rcode() != Rcode::NoError {
+    fn compute_positive_ttl(
+        &self,
+        response: &Message,
+        record_type: RecordType,
+    ) -> CacheTtlDecision {
+        if !is_complete_positive_response(response, record_type) {
             return CacheTtlDecision::Skip(CacheSkipReason::NoTtl);
         }
 
@@ -995,8 +997,8 @@ impl Cache {
     }
 
     #[inline]
-    fn compute_cache_ttl(&self, response: &Message) -> CacheTtlDecision {
-        match self.compute_positive_ttl(response) {
+    fn compute_cache_ttl(&self, response: &Message, record_type: RecordType) -> CacheTtlDecision {
+        match self.compute_positive_ttl(response, record_type) {
             CacheTtlDecision::Cache(ttl) => CacheTtlDecision::Cache(ttl),
             CacheTtlDecision::Skip(CacheSkipReason::LowPositiveTtl) => {
                 CacheTtlDecision::Skip(CacheSkipReason::LowPositiveTtl)
@@ -1016,8 +1018,8 @@ impl Cache {
     fn update_cache_entry(&self, cache_map: &CacheMap, key: CacheKey, response: Message, ttl: u32) {
         let now = AppClock::elapsed_millis();
         let fresh_until_ms = Self::compute_fresh_until_ms(now, ttl);
-        let expire_time =
-            self.compute_expire_time(now, ttl, self.can_lazy_cache_response(&response));
+        let enable_lazy = self.can_lazy_cache_response(&response, key.record_type);
+        let expire_time = self.compute_expire_time(now, ttl, enable_lazy);
         let item = CacheItem::new(response, ttl, fresh_until_ms);
         debug!(
             "cached: domain={}, type={:?}, class={:?}, ttl={}",
@@ -1080,6 +1082,7 @@ impl Cache {
                 Ok(Ok(Some(response))) if !response.truncated() => {
                     let ttl = compute_cache_ttl_with_policy(
                         &response,
+                        key.record_type,
                         max_positive_ttl,
                         min_positive_ttl,
                         cache_negative,
@@ -1090,11 +1093,10 @@ impl Cache {
                         let now = AppClock::elapsed_millis();
                         let fresh_until_ms = Cache::compute_fresh_until_ms(now, ttl);
                         let enable_lazy = lazy_cache_ttl.is_some()
-                            && response.rcode() == Rcode::NoError
-                            && !response.answers().is_empty()
                             && matches!(
                                 compute_positive_ttl_with_policy(
                                     &response,
+                                    key.record_type,
                                     max_positive_ttl,
                                     min_positive_ttl
                                 ),
@@ -1312,7 +1314,7 @@ impl Executor for Cache {
                 return Ok(next_step);
             }
 
-            match self.compute_cache_ttl(response) {
+            match self.compute_cache_ttl(response, key.record_type) {
                 CacheTtlDecision::Cache(ttl) => {
                     self.update_cache_entry(cache_map, key, response.clone(), ttl);
                 }
@@ -1327,10 +1329,11 @@ impl Executor for Cache {
 
 fn compute_positive_ttl_with_policy(
     response: &Message,
+    record_type: RecordType,
     max_positive_ttl: Option<u32>,
     min_positive_ttl: Option<u32>,
 ) -> CacheTtlDecision {
-    if response.rcode() != Rcode::NoError {
+    if !is_complete_positive_response(response, record_type) {
         return CacheTtlDecision::Skip(CacheSkipReason::NoTtl);
     }
 
@@ -1378,13 +1381,19 @@ fn compute_negative_ttl_with_policy(
 
 fn compute_cache_ttl_with_policy(
     response: &Message,
+    record_type: RecordType,
     max_positive_ttl: Option<u32>,
     min_positive_ttl: Option<u32>,
     cache_negative: bool,
     max_negative_ttl: u32,
     negative_ttl_without_soa: u32,
 ) -> CacheTtlDecision {
-    match compute_positive_ttl_with_policy(response, max_positive_ttl, min_positive_ttl) {
+    match compute_positive_ttl_with_policy(
+        response,
+        record_type,
+        max_positive_ttl,
+        min_positive_ttl,
+    ) {
         CacheTtlDecision::Cache(ttl) => CacheTtlDecision::Cache(ttl),
         CacheTtlDecision::Skip(CacheSkipReason::LowPositiveTtl) => {
             CacheTtlDecision::Skip(CacheSkipReason::LowPositiveTtl)
@@ -1402,6 +1411,13 @@ fn compute_cache_ttl_with_policy(
             }
         }
     }
+}
+
+#[inline]
+fn is_complete_positive_response(response: &Message, record_type: RecordType) -> bool {
+    response.rcode() == Rcode::NoError
+        && !response.answers().is_empty()
+        && (record_type == RecordType::ANY || response.has_answer_type(record_type))
 }
 
 fn parse_cache_config(args: Option<Value>) -> Result<CacheConfig> {
@@ -1604,7 +1620,7 @@ mod tests {
     use super::*;
     use crate::plugin::executor::Executor;
     use crate::plugin::executor::sequence::chain::ChainProgram;
-    use crate::proto::rdata::SOA;
+    use crate::proto::rdata::{CNAME, SOA};
     use crate::proto::{
         DNSClass, Edns, EdnsOption, Message, Name, Question, RData, Record, RecordType,
     };
@@ -1754,10 +1770,19 @@ mod tests {
     }
 
     fn make_request_with_query(name: &str, do_bit: bool, cd_bit: bool) -> Message {
+        make_request_with_qtype(name, RecordType::A, do_bit, cd_bit)
+    }
+
+    fn make_request_with_qtype(
+        name: &str,
+        qtype: RecordType,
+        do_bit: bool,
+        cd_bit: bool,
+    ) -> Message {
         let mut request = Message::new();
         request.add_question(Question::new(
             Name::from_ascii(name).unwrap(),
-            RecordType::A,
+            qtype,
             DNSClass::IN,
         ));
         request.set_checking_disabled(cd_bit);
@@ -1801,6 +1826,32 @@ mod tests {
         response.add_answer(Record::from_rdata(
             Name::from_ascii(domain).unwrap(),
             ttl,
+            RData::A(crate::proto::rdata::A(Ipv4Addr::new(1, 1, 1, 1))),
+        ));
+        response
+    }
+
+    fn cname_only_response_for_domain(domain: &str, ttl: u32) -> Message {
+        let mut response = Message::new();
+        response.set_rcode(Rcode::NoError);
+        response.add_question(Question::new(
+            Name::from_ascii(domain).unwrap(),
+            RecordType::A,
+            DNSClass::IN,
+        ));
+        response.add_answer(Record::from_rdata(
+            Name::from_ascii(domain).unwrap(),
+            ttl,
+            RData::CNAME(CNAME(Name::from_ascii("target.example.com.").unwrap())),
+        ));
+        response
+    }
+
+    fn cname_with_a_response_for_domain(domain: &str, cname_ttl: u32, a_ttl: u32) -> Message {
+        let mut response = cname_only_response_for_domain(domain, cname_ttl);
+        response.add_answer(Record::from_rdata(
+            Name::from_ascii("target.example.com.").unwrap(),
+            a_ttl,
             RData::A(crate::proto::rdata::A(Ipv4Addr::new(1, 1, 1, 1))),
         ));
         response
@@ -1972,6 +2023,24 @@ mod tests {
                 RData::A(crate::proto::rdata::A(Ipv4Addr::new(9, 9, 9, 9))),
             ));
             context.set_response(response);
+            Ok(ExecStep::Next)
+        }
+    }
+
+    #[derive(Debug)]
+    struct CnameOnlyRefreshExecutor;
+
+    #[async_trait]
+    impl Plugin for CnameOnlyRefreshExecutor {
+        fn tag(&self) -> &str {
+            "cname_only_refresh_executor"
+        }
+    }
+
+    #[async_trait]
+    impl Executor for CnameOnlyRefreshExecutor {
+        async fn execute(&self, context: &mut DnsContext) -> Result<ExecStep> {
+            context.set_response(cname_only_response_for_domain("example.com.", 60));
             Ok(ExecStep::Next)
         }
     }
@@ -2190,7 +2259,7 @@ mod tests {
         response.set_rcode(Rcode::ServFail);
 
         assert_eq!(
-            cache.compute_cache_ttl(&response),
+            cache.compute_cache_ttl(&response, RecordType::A),
             CacheTtlDecision::Skip(CacheSkipReason::NoTtl)
         );
     }
@@ -2210,7 +2279,7 @@ mod tests {
         ));
 
         assert_eq!(
-            cache.compute_cache_ttl(&response),
+            cache.compute_cache_ttl(&response, RecordType::A),
             CacheTtlDecision::Skip(CacheSkipReason::LowPositiveTtl)
         );
     }
@@ -2230,7 +2299,7 @@ mod tests {
         ));
 
         assert_eq!(
-            cache.compute_cache_ttl(&response),
+            cache.compute_cache_ttl(&response, RecordType::A),
             CacheTtlDecision::Cache(4)
         );
     }
@@ -2251,9 +2320,54 @@ mod tests {
         ));
 
         assert_eq!(
-            cache.compute_cache_ttl(&response),
+            cache.compute_cache_ttl(&response, RecordType::A),
             CacheTtlDecision::Skip(CacheSkipReason::LowPositiveTtl)
         );
+    }
+
+    #[test]
+    fn cname_only_response_is_not_positive_cacheable_for_address_key() {
+        let cache = test_cache(default_test_config());
+        let response = cname_only_response_for_domain("example.com.", 60);
+
+        assert_eq!(
+            cache.compute_cache_ttl(&response, RecordType::A),
+            CacheTtlDecision::Skip(CacheSkipReason::NoTtl)
+        );
+        assert_eq!(cache.compute_negative_ttl(&response), None);
+    }
+
+    #[test]
+    fn cname_chain_with_requested_answer_is_positive_cacheable() {
+        let cache = test_cache(default_test_config());
+        let response = cname_with_a_response_for_domain("example.com.", 30, 120);
+
+        assert_eq!(
+            cache.compute_cache_ttl(&response, RecordType::A),
+            CacheTtlDecision::Cache(30)
+        );
+    }
+
+    #[test]
+    fn any_query_allows_non_empty_cname_answer() {
+        let cache = test_cache(default_test_config());
+        let response = cname_only_response_for_domain("example.com.", 60);
+
+        assert_eq!(
+            cache.compute_cache_ttl(&response, RecordType::ANY),
+            CacheTtlDecision::Cache(60)
+        );
+    }
+
+    #[test]
+    fn empty_noerror_remains_nodata_but_cname_only_does_not() {
+        let cache = test_cache(default_test_config());
+        let mut nodata = Message::new();
+        nodata.set_rcode(Rcode::NoError);
+        let cname_only = cname_only_response_for_domain("example.com.", 60);
+
+        assert_eq!(cache.compute_negative_ttl(&nodata), Some(60));
+        assert_eq!(cache.compute_negative_ttl(&cname_only), None);
     }
 
     #[tokio::test]
@@ -2279,6 +2393,56 @@ mod tests {
                 .skip_truncated_total
                 .load(AtomicOrdering::Relaxed),
             1
+        );
+    }
+
+    #[tokio::test]
+    async fn cname_only_response_is_not_cached_under_address_key() {
+        AppClock::start();
+        let mut cache = test_cache(default_test_config());
+        let _ = cache.init_for_test().await;
+
+        let mut context = make_context(make_request_with_query("example.com.", false, false));
+        context.set_response(cname_only_response_for_domain("example.com.", 60));
+
+        cache.execute_with_next(&mut context, None).await.unwrap();
+
+        assert_eq!(cache.cache_map.get().unwrap().len(), 0);
+        assert_eq!(cache.metrics.insert_total.load(AtomicOrdering::Relaxed), 0);
+        assert_eq!(
+            cache
+                .metrics
+                .skip_no_ttl_total
+                .load(AtomicOrdering::Relaxed),
+            1
+        );
+    }
+
+    #[tokio::test]
+    async fn any_query_caches_non_empty_cname_answer() {
+        AppClock::start();
+        let mut cache = test_cache(default_test_config());
+        let _ = cache.init_for_test().await;
+
+        let mut context = make_context(make_request_with_qtype(
+            "example.com.",
+            RecordType::ANY,
+            false,
+            false,
+        ));
+        let key = Cache::build_cache_key(&mut context, false).unwrap();
+        context.set_response(cname_only_response_for_domain("example.com.", 60));
+
+        cache.execute_with_next(&mut context, None).await.unwrap();
+
+        assert_eq!(cache.metrics.insert_total.load(AtomicOrdering::Relaxed), 1);
+        assert!(
+            cache
+                .cache_map
+                .get()
+                .unwrap()
+                .get_retained_cloned(&key, AppClock::elapsed_millis(), 0)
+                .is_some()
         );
     }
 
@@ -2614,6 +2778,66 @@ mod tests {
                 .value
                 .resp
                 .has_answer_ip(|ip| ip == std::net::IpAddr::V4(Ipv4Addr::new(9, 9, 9, 9)))
+        );
+    }
+
+    #[tokio::test]
+    async fn lazy_refresh_does_not_update_address_key_with_cname_only_response() {
+        AppClock::start();
+        let mut cfg = default_test_config();
+        cfg.lazy_cache_ttl = Some(30);
+        cfg.short_circuit = Some(true);
+        let mut cache = test_cache(cfg);
+        let _ = cache.init_for_test().await;
+
+        let program =
+            ChainProgram::single_with_next_executor_for_test(Arc::new(CnameOnlyRefreshExecutor));
+        let next = ExecutorNext::from_program_for_test(program, 0);
+
+        let mut context = make_context(make_request_with_query("example.com.", false, false));
+        let key = Cache::build_cache_key(&mut context, false).unwrap();
+        let old_response = cacheable_response_for_domain("example.com.", 120);
+        let now = AppClock::elapsed_millis();
+        cache.cache_map.get().unwrap().insert_or_update_with_meta(
+            key.clone(),
+            Arc::new(CacheItem::new(old_response, 120, now.saturating_sub(1_000))),
+            now.saturating_sub(121_000),
+            now.saturating_add(10_000),
+            now.saturating_sub(100),
+        );
+
+        let _ = cache
+            .execute_with_next(&mut context, Some(next))
+            .await
+            .unwrap();
+        wait_until("lazy refresh CNAME-only skip should be recorded", || {
+            cache
+                .metrics
+                .lazy_refresh_failed_total
+                .load(AtomicOrdering::Relaxed)
+                == 1
+        })
+        .await;
+
+        assert_eq!(cache.metrics.insert_total.load(AtomicOrdering::Relaxed), 0);
+        assert_eq!(
+            cache
+                .metrics
+                .skip_no_ttl_total
+                .load(AtomicOrdering::Relaxed),
+            1
+        );
+        let stored = cache
+            .cache_map
+            .get()
+            .unwrap()
+            .get_retained_cloned(&key, AppClock::elapsed_millis(), 0)
+            .expect("old stale entry should remain present");
+        assert!(
+            stored
+                .value
+                .resp
+                .has_answer_ip(|ip| ip == std::net::IpAddr::V4(Ipv4Addr::new(1, 1, 1, 1)))
         );
     }
 

--- a/src/plugin/executor/cache/persistence.rs
+++ b/src/plugin/executor/cache/persistence.rs
@@ -12,7 +12,7 @@ use tracing::{info, warn};
 use wincode::{SchemaRead, SchemaWrite};
 
 use super::key::{CacheKey, EcsScopeDigest, normalize_domain_key};
-use super::{CacheItem, CacheMap};
+use super::{CacheItem, CacheMap, is_cache_entry_response_valid};
 use crate::infra::cache::ttl::TtlCacheEntry;
 use crate::infra::clock::AppClock;
 use crate::infra::error::Result;
@@ -67,6 +67,10 @@ pub(super) fn dump_cache_to_bytes(cache_map: &CacheMap) -> Result<Vec<u8>> {
 
         let remaining_ttl_ms = expire_at_ms.saturating_sub(now);
         if remaining_ttl_ms == 0 {
+            continue;
+        }
+
+        if !is_cache_entry_response_valid(&value.resp, key.record_type) {
             continue;
         }
 
@@ -225,6 +229,10 @@ pub(super) fn load_cache_from_bytes(
             }
         };
 
+        if !is_cache_entry_response_valid(&resp, key.record_type) {
+            continue;
+        }
+
         let expire_time = now.saturating_add(entry.remaining_ttl_ms);
         let cache_time = now.saturating_sub(entry.cache_age_ms);
         let fresh_until_ms = cache_time.saturating_add(u64::from(entry.ttl) * 1000);
@@ -246,6 +254,8 @@ pub(super) fn load_cache_from_bytes(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::proto::rdata::CNAME;
+    use crate::proto::{Name, Question, RData, Record};
 
     fn make_entry() -> PersistedCacheEntry {
         PersistedCacheEntry {
@@ -264,6 +274,22 @@ mod tests {
             ttl: 60,
             remaining_ttl_ms: 30_000,
         }
+    }
+
+    fn cname_only_response_bytes() -> Vec<u8> {
+        let mut response = Message::new();
+        response.set_rcode(crate::proto::Rcode::NoError);
+        response.add_question(Question::new(
+            Name::from_ascii("example.com.").unwrap(),
+            RecordType::A,
+            DNSClass::IN,
+        ));
+        response.add_answer(Record::from_rdata(
+            Name::from_ascii("example.com.").unwrap(),
+            60,
+            RData::CNAME(CNAME(Name::from_ascii("target.example.com.").unwrap())),
+        ));
+        response.to_bytes().expect("response should encode")
     }
 
     #[test]
@@ -319,5 +345,25 @@ mod tests {
         let cache_key = to_cache_key(&entry, false).expect("cache key should be built");
 
         assert_eq!(cache_key.ecs_scope, None);
+    }
+
+    #[test]
+    fn test_load_cache_skips_cname_only_address_entry() {
+        AppClock::start();
+        let cache_map = CacheMap::with_capacity(1);
+        let mut entry = make_entry();
+        entry.record_type = u16::from(RecordType::A);
+        entry.ecs_family = None;
+        entry.ecs_source_prefix = None;
+        entry.ecs_scope_prefix = None;
+        entry.ecs_network = None;
+        entry.resp_bytes = cname_only_response_bytes();
+
+        let data = wincode::serialize(&vec![entry]).expect("entry should serialize");
+        let loaded =
+            load_cache_from_bytes(&cache_map, &data, false, false).expect("load should succeed");
+
+        assert_eq!(loaded, 0);
+        assert_eq!(cache_map.len(), 0);
     }
 }

--- a/src/plugin/executor/forward/concurrent.rs
+++ b/src/plugin/executor/forward/concurrent.rs
@@ -95,6 +95,7 @@ impl ConcurrentForwarder {
             return (None, Some("no upstream configured".to_string()), false);
         }
 
+        let requested_qtype = request.first_qtype();
         let mut join_set = JoinSet::new();
         let start_idx = rand::rng().random_range(0..total_upstreams);
 
@@ -126,6 +127,7 @@ impl ConcurrentForwarder {
         select_response(
             &mut join_set,
             self.active_concurrent,
+            requested_qtype,
             self.response_selection,
         )
         .await

--- a/src/plugin/executor/forward/selection.rs
+++ b/src/plugin/executor/forward/selection.rs
@@ -291,7 +291,8 @@ fn classify_response(response: &Message, requested_qtype: Option<RecordType>) ->
         Rcode::NoError if is_complete_positive_response(response, requested_qtype) => {
             ResponseClass::Positive
         }
-        Rcode::NoError | Rcode::NXDomain => ResponseClass::Negative,
+        Rcode::NoError if response.answers().is_empty() => ResponseClass::Negative,
+        Rcode::NXDomain => ResponseClass::Negative,
         _ => ResponseClass::Other,
     }
 }

--- a/src/plugin/executor/forward/selection.rs
+++ b/src/plugin/executor/forward/selection.rs
@@ -329,9 +329,20 @@ fn should_replace_best(
 }
 
 fn response_rank(response: &Message, requested_qtype: Option<RecordType>) -> u8 {
+    if is_incomplete_noerror_answer(response, requested_qtype) {
+        return 3;
+    }
+
     match classify_response(response, requested_qtype) {
-        ResponseClass::Positive => 3,
+        ResponseClass::Positive => 4,
         ResponseClass::Negative => 2,
         ResponseClass::Other => 1,
     }
+}
+
+#[inline]
+fn is_incomplete_noerror_answer(response: &Message, requested_qtype: Option<RecordType>) -> bool {
+    response.rcode() == Rcode::NoError
+        && !response.answers().is_empty()
+        && !is_complete_positive_response(response, requested_qtype)
 }

--- a/src/plugin/executor/forward/selection.rs
+++ b/src/plugin/executor/forward/selection.rs
@@ -9,7 +9,7 @@ use tracing::warn;
 
 use super::is_timeout_error;
 use crate::infra::error::{DnsError, Result};
-use crate::proto::{Message, Rcode};
+use crate::proto::{Message, Rcode, RecordType};
 
 const BALANCED_NEGATIVE_GRACE: Duration = Duration::from_millis(100);
 const CONSENSUS_NEGATIVE_VOTES: usize = 2;
@@ -51,6 +51,7 @@ struct NegativeVote {
 
 #[derive(Debug)]
 struct SelectionState {
+    requested_qtype: Option<RecordType>,
     completed: usize,
     last_error: Option<String>,
     last_timeout: bool,
@@ -60,8 +61,9 @@ struct SelectionState {
 }
 
 impl SelectionState {
-    fn new() -> Self {
+    fn new(requested_qtype: Option<RecordType>) -> Self {
         Self {
+            requested_qtype,
             completed: 0,
             last_error: None,
             last_timeout: false,
@@ -72,14 +74,14 @@ impl SelectionState {
     }
 
     fn record_response(&mut self, response: Message) -> ResponseClass {
-        let class = classify_response(&response);
+        let class = classify_response(&response, self.requested_qtype);
         if class == ResponseClass::Negative {
             self.negative_votes += 1;
             if let Some(key) = negative_response_key(&response) {
                 self.record_negative_vote(key);
             }
         }
-        if should_replace_best(self.best_response.as_ref(), &response) {
+        if should_replace_best(self.best_response.as_ref(), &response, self.requested_qtype) {
             self.best_response = Some(response);
         }
         class
@@ -122,22 +124,27 @@ impl SelectionState {
 pub(super) async fn select_response(
     join_set: &mut JoinSet<Result<Message>>,
     active_concurrent: usize,
+    requested_qtype: Option<RecordType>,
     mode: ResponseSelectionMode,
 ) -> (Option<Message>, Option<String>, bool) {
     match mode {
         ResponseSelectionMode::Fastest => select_fastest(join_set).await,
-        ResponseSelectionMode::Balanced => select_balanced(join_set, active_concurrent).await,
-        ResponseSelectionMode::PreferPositive => {
-            select_prefer_positive(join_set, active_concurrent).await
+        ResponseSelectionMode::Balanced => {
+            select_balanced(join_set, active_concurrent, requested_qtype).await
         }
-        ResponseSelectionMode::Consensus => select_consensus(join_set, active_concurrent).await,
+        ResponseSelectionMode::PreferPositive => {
+            select_prefer_positive(join_set, active_concurrent, requested_qtype).await
+        }
+        ResponseSelectionMode::Consensus => {
+            select_consensus(join_set, active_concurrent, requested_qtype).await
+        }
     }
 }
 
 async fn select_fastest(
     join_set: &mut JoinSet<Result<Message>>,
 ) -> (Option<Message>, Option<String>, bool) {
-    let mut state = SelectionState::new();
+    let mut state = SelectionState::new(None);
     while let Some(joined) = join_set.join_next().await {
         match joined {
             Ok(Ok(response)) => {
@@ -154,8 +161,9 @@ async fn select_fastest(
 async fn select_prefer_positive(
     join_set: &mut JoinSet<Result<Message>>,
     active_concurrent: usize,
+    requested_qtype: Option<RecordType>,
 ) -> (Option<Message>, Option<String>, bool) {
-    let mut state = SelectionState::new();
+    let mut state = SelectionState::new(requested_qtype);
     while let Some(class) = next_response_class(join_set, &mut state).await {
         if class == ResponseClass::Positive {
             join_set.abort_all();
@@ -171,8 +179,9 @@ async fn select_prefer_positive(
 async fn select_balanced(
     join_set: &mut JoinSet<Result<Message>>,
     active_concurrent: usize,
+    requested_qtype: Option<RecordType>,
 ) -> (Option<Message>, Option<String>, bool) {
-    let mut state = SelectionState::new();
+    let mut state = SelectionState::new(requested_qtype);
     let mut negative_grace =
         std::pin::Pin::from(Box::new(tokio::time::sleep(BALANCED_NEGATIVE_GRACE)));
 
@@ -219,12 +228,13 @@ async fn select_balanced(
 async fn select_consensus(
     join_set: &mut JoinSet<Result<Message>>,
     active_concurrent: usize,
+    requested_qtype: Option<RecordType>,
 ) -> (Option<Message>, Option<String>, bool) {
     if active_concurrent < CONSENSUS_NEGATIVE_VOTES {
-        return select_prefer_positive(join_set, active_concurrent).await;
+        return select_prefer_positive(join_set, active_concurrent, requested_qtype).await;
     }
 
-    let mut state = SelectionState::new();
+    let mut state = SelectionState::new(requested_qtype);
     while let Some(class) = next_response_class(join_set, &mut state).await {
         match class {
             ResponseClass::Positive => {
@@ -276,11 +286,25 @@ fn handle_joined_response(
 }
 
 #[inline]
-fn classify_response(response: &Message) -> ResponseClass {
+fn classify_response(response: &Message, requested_qtype: Option<RecordType>) -> ResponseClass {
     match response.rcode() {
-        Rcode::NoError if !response.answers().is_empty() => ResponseClass::Positive,
+        Rcode::NoError if is_complete_positive_response(response, requested_qtype) => {
+            ResponseClass::Positive
+        }
         Rcode::NoError | Rcode::NXDomain => ResponseClass::Negative,
         _ => ResponseClass::Other,
+    }
+}
+
+#[inline]
+fn is_complete_positive_response(response: &Message, requested_qtype: Option<RecordType>) -> bool {
+    if response.answers().is_empty() {
+        return false;
+    }
+
+    match requested_qtype {
+        Some(RecordType::ANY) | None => true,
+        Some(qtype) => response.has_answer_type(qtype),
     }
 }
 
@@ -292,15 +316,19 @@ fn negative_response_key(response: &Message) -> Option<NegativeResponseKey> {
     }
 }
 
-fn should_replace_best(current: Option<&Message>, candidate: &Message) -> bool {
+fn should_replace_best(
+    current: Option<&Message>,
+    candidate: &Message,
+    requested_qtype: Option<RecordType>,
+) -> bool {
     let Some(current) = current else {
         return true;
     };
-    response_rank(candidate) >= response_rank(current)
+    response_rank(candidate, requested_qtype) >= response_rank(current, requested_qtype)
 }
 
-fn response_rank(response: &Message) -> u8 {
-    match classify_response(response) {
+fn response_rank(response: &Message, requested_qtype: Option<RecordType>) -> u8 {
+    match classify_response(response, requested_qtype) {
         ResponseClass::Positive => 3,
         ResponseClass::Negative => 2,
         ResponseClass::Other => 1,

--- a/src/plugin/executor/forward/tests.rs
+++ b/src/plugin/executor/forward/tests.rs
@@ -25,7 +25,7 @@ use crate::plugin::executor::{ExecStep, Executor};
 use crate::plugin::{PluginFactory, UninitializedPlugin};
 use crate::proto::{A, Message, Name, Question, RData, Rcode, Record, RecordType};
 
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 enum MockAnswer {
     None,
     A,
@@ -483,7 +483,7 @@ async fn balanced_selection_waits_for_complete_answer_after_cname_only() {
         active_concurrent: 2,
         upstreams: vec![
             Arc::new(MockUpstream::ok_with_cname_answer(Duration::ZERO)),
-            Arc::new(MockUpstream::ok_with_answer(Duration::from_millis(20))),
+            Arc::new(MockUpstream::ok_with_answer(Duration::from_millis(200))),
         ],
         short_circuit: false,
         response_selection: ResponseSelectionMode::Balanced,

--- a/src/plugin/executor/forward/tests.rs
+++ b/src/plugin/executor/forward/tests.rs
@@ -499,6 +499,32 @@ async fn balanced_selection_waits_for_complete_answer_after_cname_only() {
 }
 
 #[tokio::test(start_paused = true)]
+async fn balanced_selection_keeps_cname_only_above_negative_fallback() {
+    let forwarder = ConcurrentForwarder {
+        tag: "forward-test".to_string(),
+        active_concurrent: 2,
+        upstreams: vec![
+            Arc::new(MockUpstream::ok_with_cname_answer(Duration::ZERO)),
+            Arc::new(MockUpstream::response(
+                Rcode::NXDomain,
+                Duration::from_millis(20),
+            )),
+        ],
+        short_circuit: false,
+        response_selection: ResponseSelectionMode::Balanced,
+        metrics: test_metrics(),
+    };
+
+    let mut context = make_context();
+    let step = forwarder.execute(&mut context).await.unwrap();
+    let response = context.response().expect("response must exist");
+    assert!(matches!(step, ExecStep::Next));
+    assert_eq!(response.rcode(), Rcode::NoError);
+    assert!(response.has_answer_type(RecordType::CNAME));
+    assert!(!response.has_answer_type(RecordType::A));
+}
+
+#[tokio::test(start_paused = true)]
 async fn prefer_positive_waits_for_late_positive() {
     let forwarder = ConcurrentForwarder {
         tag: "forward-test".to_string(),
@@ -540,6 +566,32 @@ async fn prefer_positive_waits_for_complete_answer_after_cname_only() {
     assert!(matches!(step, ExecStep::Next));
     assert_eq!(response.rcode(), Rcode::NoError);
     assert!(response.has_answer_type(RecordType::A));
+}
+
+#[tokio::test(start_paused = true)]
+async fn prefer_positive_keeps_cname_only_above_negative_fallback() {
+    let forwarder = ConcurrentForwarder {
+        tag: "forward-test".to_string(),
+        active_concurrent: 2,
+        upstreams: vec![
+            Arc::new(MockUpstream::ok_with_cname_answer(Duration::ZERO)),
+            Arc::new(MockUpstream::response(
+                Rcode::NXDomain,
+                Duration::from_millis(20),
+            )),
+        ],
+        short_circuit: false,
+        response_selection: ResponseSelectionMode::PreferPositive,
+        metrics: test_metrics(),
+    };
+
+    let mut context = make_context();
+    let step = forwarder.execute(&mut context).await.unwrap();
+    let response = context.response().expect("response must exist");
+    assert!(matches!(step, ExecStep::Next));
+    assert_eq!(response.rcode(), Rcode::NoError);
+    assert!(response.has_answer_type(RecordType::CNAME));
+    assert!(!response.has_answer_type(RecordType::A));
 }
 
 #[tokio::test(start_paused = true)]
@@ -628,4 +680,30 @@ async fn consensus_selection_does_not_count_cname_only_as_negative_vote() {
     assert!(matches!(step, ExecStep::Next));
     assert_eq!(response.rcode(), Rcode::NoError);
     assert!(response.has_answer_type(RecordType::A));
+}
+
+#[tokio::test(start_paused = true)]
+async fn consensus_selection_keeps_cname_only_above_negative_fallback() {
+    let forwarder = ConcurrentForwarder {
+        tag: "forward-test".to_string(),
+        active_concurrent: 2,
+        upstreams: vec![
+            Arc::new(MockUpstream::ok_with_cname_answer(Duration::ZERO)),
+            Arc::new(MockUpstream::response(
+                Rcode::NXDomain,
+                Duration::from_millis(20),
+            )),
+        ],
+        short_circuit: false,
+        response_selection: ResponseSelectionMode::Consensus,
+        metrics: test_metrics(),
+    };
+
+    let mut context = make_context();
+    let step = forwarder.execute(&mut context).await.unwrap();
+    let response = context.response().expect("response must exist");
+    assert!(matches!(step, ExecStep::Next));
+    assert_eq!(response.rcode(), Rcode::NoError);
+    assert!(response.has_answer_type(RecordType::CNAME));
+    assert!(!response.has_answer_type(RecordType::A));
 }

--- a/src/plugin/executor/forward/tests.rs
+++ b/src/plugin/executor/forward/tests.rs
@@ -26,10 +26,17 @@ use crate::plugin::{PluginFactory, UninitializedPlugin};
 use crate::proto::{A, Message, Name, Question, RData, Rcode, Record, RecordType};
 
 #[derive(Debug)]
+enum MockAnswer {
+    None,
+    A,
+    Cname,
+}
+
+#[derive(Debug)]
 struct MockUpstream {
     connection_info: ConnectionInfo,
     response_code: Option<Rcode>,
-    answer: bool,
+    answer: MockAnswer,
     fail_message: Option<String>,
     delay: Duration,
 }
@@ -41,7 +48,13 @@ impl MockUpstream {
 
     fn ok_with_answer(delay: Duration) -> Self {
         let mut upstream = Self::response(Rcode::NoError, delay);
-        upstream.answer = true;
+        upstream.answer = MockAnswer::A;
+        upstream
+    }
+
+    fn ok_with_cname_answer(delay: Duration) -> Self {
+        let mut upstream = Self::response(Rcode::NoError, delay);
+        upstream.answer = MockAnswer::Cname;
         upstream
     }
 
@@ -50,7 +63,7 @@ impl MockUpstream {
             connection_info: ConnectionInfo::with_addr("1.1.1.1")
                 .expect("mock upstream addr must be valid"),
             response_code: Some(response_code),
-            answer: false,
+            answer: MockAnswer::None,
             fail_message: None,
             delay,
         }
@@ -61,7 +74,7 @@ impl MockUpstream {
             connection_info: ConnectionInfo::with_addr("1.1.1.1")
                 .expect("mock upstream addr must be valid"),
             response_code: None,
-            answer: false,
+            answer: MockAnswer::None,
             fail_message: Some(msg.to_string()),
             delay,
         }
@@ -79,12 +92,24 @@ impl Upstream for MockUpstream {
         }
         let response_code = self.response_code.unwrap_or(Rcode::NoError);
         let mut response = request.response(response_code);
-        if self.answer {
-            response.add_answer(Record::from_rdata(
-                Name::from_ascii("example.com.").unwrap(),
-                60,
-                RData::A(A("192.0.2.1".parse().unwrap())),
-            ));
+        match self.answer {
+            MockAnswer::None => {}
+            MockAnswer::A => {
+                response.add_answer(Record::from_rdata(
+                    Name::from_ascii("example.com.").unwrap(),
+                    60,
+                    RData::A(A("192.0.2.1".parse().unwrap())),
+                ));
+            }
+            MockAnswer::Cname => {
+                response.add_answer(Record::from_rdata(
+                    Name::from_ascii("example.com.").unwrap(),
+                    60,
+                    RData::CNAME(crate::proto::CNAME(
+                        Name::from_ascii("target.example.com.").unwrap(),
+                    )),
+                ));
+            }
         }
         Ok(response)
     }
@@ -452,6 +477,28 @@ async fn balanced_selection_waits_briefly_for_positive_after_negative() {
 }
 
 #[tokio::test(start_paused = true)]
+async fn balanced_selection_waits_for_complete_answer_after_cname_only() {
+    let forwarder = ConcurrentForwarder {
+        tag: "forward-test".to_string(),
+        active_concurrent: 2,
+        upstreams: vec![
+            Arc::new(MockUpstream::ok_with_cname_answer(Duration::ZERO)),
+            Arc::new(MockUpstream::ok_with_answer(Duration::from_millis(20))),
+        ],
+        short_circuit: false,
+        response_selection: ResponseSelectionMode::Balanced,
+        metrics: test_metrics(),
+    };
+
+    let mut context = make_context();
+    let step = forwarder.execute(&mut context).await.unwrap();
+    let response = context.response().expect("response must exist");
+    assert!(matches!(step, ExecStep::Next));
+    assert_eq!(response.rcode(), Rcode::NoError);
+    assert!(response.has_answer_type(RecordType::A));
+}
+
+#[tokio::test(start_paused = true)]
 async fn prefer_positive_waits_for_late_positive() {
     let forwarder = ConcurrentForwarder {
         tag: "forward-test".to_string(),
@@ -471,6 +518,28 @@ async fn prefer_positive_waits_for_late_positive() {
     assert!(matches!(step, ExecStep::Next));
     assert_eq!(response.rcode(), Rcode::NoError);
     assert_eq!(response.answers().len(), 1);
+}
+
+#[tokio::test(start_paused = true)]
+async fn prefer_positive_waits_for_complete_answer_after_cname_only() {
+    let forwarder = ConcurrentForwarder {
+        tag: "forward-test".to_string(),
+        active_concurrent: 2,
+        upstreams: vec![
+            Arc::new(MockUpstream::ok_with_cname_answer(Duration::ZERO)),
+            Arc::new(MockUpstream::ok_with_answer(Duration::from_millis(200))),
+        ],
+        short_circuit: false,
+        response_selection: ResponseSelectionMode::PreferPositive,
+        metrics: test_metrics(),
+    };
+
+    let mut context = make_context();
+    let step = forwarder.execute(&mut context).await.unwrap();
+    let response = context.response().expect("response must exist");
+    assert!(matches!(step, ExecStep::Next));
+    assert_eq!(response.rcode(), Rcode::NoError);
+    assert!(response.has_answer_type(RecordType::A));
 }
 
 #[tokio::test(start_paused = true)]
@@ -530,4 +599,33 @@ async fn consensus_selection_waits_when_negative_votes_disagree() {
     assert!(matches!(step, ExecStep::Next));
     assert_eq!(response.rcode(), Rcode::NoError);
     assert_eq!(response.answers().len(), 1);
+}
+
+#[tokio::test(start_paused = true)]
+async fn consensus_selection_does_not_count_cname_only_as_negative_vote() {
+    let forwarder = ConcurrentForwarder {
+        tag: "forward-test".to_string(),
+        active_concurrent: 3,
+        upstreams: vec![
+            Arc::new(MockUpstream::ok_with_cname_answer(Duration::ZERO)),
+            Arc::new(MockUpstream::response(
+                Rcode::NXDomain,
+                Duration::from_millis(20),
+            )),
+            Arc::new(MockUpstream::ok_with_answer(Duration::from_millis(200))),
+        ],
+        short_circuit: false,
+        response_selection: ResponseSelectionMode::Consensus,
+        metrics: Arc::new(ForwardMetrics::new(
+            "forward-test".to_string(),
+            vec!["u0".to_string(), "u1".to_string(), "u2".to_string()],
+        )),
+    };
+
+    let mut context = make_context();
+    let step = forwarder.execute(&mut context).await.unwrap();
+    let response = context.response().expect("response must exist");
+    assert!(matches!(step, ExecStep::Next));
+    assert_eq!(response.rcode(), Rcode::NoError);
+    assert!(response.has_answer_type(RecordType::A));
 }


### PR DESCRIPTION
- Treat NOERROR CNAME-only responses as incomplete for A/AAAA forwarding, so they do not win positive selection or count as negative consensus.
- Gate cache admission and lazy refresh by the original cache key qtype, while preserving ANY-query behavior.
- Add forward and cache regression coverage for CNAME-only, CNAME+A, ANY, and lazy refresh paths.

Fixed #261 